### PR TITLE
addressed issue#10 bezier gizmo doesn't respect lowpoly

### DIFF
--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -163,7 +163,7 @@ func _get_next_pt():
 func _set_prior_mag(value):
 	prior_mag = value
 	rebuild_geom()
-	on_transform()
+	_notification(Spatial.NOTIFICATION_TRANSFORM_CHANGED)
 func _get_prior_mag():
 	return prior_mag
 
@@ -171,7 +171,7 @@ func _get_prior_mag():
 func _set_next_mag(value):
 	next_mag = value
 	rebuild_geom()
-	on_transform()
+	_notification(Spatial.NOTIFICATION_TRANSFORM_CHANGED)
 func _get_next_mag():
 	return next_mag
 

--- a/addons/road-generator/road_point_gizmo.gd
+++ b/addons/road-generator/road_point_gizmo.gd
@@ -104,4 +104,5 @@ func commit_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: bool 
 		undo_redo.add_undo_method(self, "redraw", gizmo)
 		
 		undo_redo.commit_action()
+		point._notification(Spatial.NOTIFICATION_TRANSFORM_CHANGED)
 		init_handle = null


### PR DESCRIPTION
ISSUE #10 states that: Changing the curve bezier size via gizmo doesn't respect lowpoly. This request addresses that issue. Read on for further explanation.

Geometry redraw using high or low poly is determined, in part, by the road_point.on_transform routine. This routine is called from numerous locations when geometry needs to be updated. It, in turn, triggers road_network.on_point_update, which treads further down the path of redraw. But, a key determinent is the boolean "low_poly" value supplied to road_point.on_transform.

Its default value of "false" means that high poly drawing will be performed unless someone supplies an alternate value. The default is used by most of the on_transform calls. Hence, a change to the default impacts a large number of calling statements. An alternative approach is to focus on the places where the road_point_gizmo detects Bezier handles being clicked and released since that is our main area of concern. For starters, we want to see low poly when a Bezier handle is clicked.

Clicking a Bezier handle causes road_point_gizmo.set_handle.roadpoint.prior_mag or next_mag to be set. The road_point setter routines for those values call the road_point.on_transform routine using the default value of "false", which results in high poly drawing. (We want low poly.)

When a Bezier handle is released, road_point_gizmo.commit_handle is called. It does not trigger any further calls to road_point.on_transform. Hence, we need to add a call, there, to do a high poly geometry update after transforms are completed. If we don't do an update and low poly drawing was previously used, then the geometry will remain low poly after the commit.

Having said all that, RoadPoint rotation widgets trigger the road_point._notification routine when transformed. It, in turn, employs a check to see if the left mouse button (LMB) is pressed and the program is running in the Editor before running the road_point.on_transform routine. Hence, road_point._notification seems like the most appropriate location to send updates when Bezier handles are clicked/moved/released.

LMB should only be pressed during a transform. So, when road_point._notification is fired: If LMB is pressed, then a low poly draw is performed. If LMB is not pressed, then a high poly draw is performed. Using the _notification routine will help maintain consistency between rotation widget and Bezier widget behavior.

(It's worth noting that there is a "Use Low Poly Preview" checkbox in the UI and it also factors into the decision making chain whenever road_point.on_transform is used. It will continue to work as before.)

So, road_point._notification needs to be called in 3 places:
1 road_point._set_prior_mag
2 road_point._set_next_mag
3 road_point_gizmo.commit_handle

This request performs the above changes.