### PR TITLE
12 initial gizmo handle jumps on cursor press 1

### DIFF
--- a/addons/road-generator/road_point_gizmo.gd
+++ b/addons/road-generator/road_point_gizmo.gd
@@ -57,7 +57,7 @@ func get_handle_value(gizmo: EditorSpatialGizmo, index: int) -> float:
 # Function called when user drags the roadpoint in/out magnitude handle.
 func set_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, point: Vector2) -> void:
 	# Calculate intersection between screen point clicked and a plane aligned to
-    # the handle's vector. Then, calculate new handle magnitude.
+    	# the handle's vector. Then, calculate new handle magnitude.
 	var roadpoint = gizmo.get_spatial_node() as RoadPoint
 	var src = camera.project_ray_origin(point) # Camera initial position.
 	var nrm = camera.project_ray_normal(point) # Normal camera is facing


### PR DESCRIPTION
Re-configured handle logic to work as follows:

    -Use the handle's magnitude as a local Z-value and create a new vector.
    -Use the road point to convert the vector to global space.
    -Combine the result with the camera basis to create a plane.
    -Calculate the intersection between the plane and a camera ray.
    -Use the road point to convert the intersection point to local space.
    -And, finally, use the point's local Z-value as the handle's new magnitude.

Some of these steps were already being done. The missing element was probably the conversion of the magnitude to a point in global space.

Logic seems to tell us that the handle is aligned to the road point. Therefore, we can use the road point as our reference for creating the plane. But, in actuality, we have to use the handle's location. (This was a challenging realization.)

The clue was the fact that the handle jumped only a little bit, which meant that we were looking for something that was only slightly off. The handle and the road point were only offset by a little bit and the jumping increased as the handle moved further away from the center of the road point.

Ran GUT and all tests passed.