### PR TITLE
Updated bezier handle behavior

### DIFF
--- a/addons/road-generator/road_point_gizmo.gd
+++ b/addons/road-generator/road_point_gizmo.gd
@@ -57,7 +57,7 @@ func get_handle_value(gizmo: EditorSpatialGizmo, index: int) -> float:
 # Function called when user drags the roadpoint in/out magnitude handle.
 func set_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, point: Vector2) -> void:
 	# Calculate intersection between screen point clicked and a plane aligned to
-    	# the handle's vector. Then, calculate new handle magnitude.
+	# the handle's vector. Then, calculate new handle magnitude.
 	var roadpoint = gizmo.get_spatial_node() as RoadPoint
 	var src = camera.project_ray_origin(point) # Camera initial position.
 	var nrm = camera.project_ray_normal(point) # Normal camera is facing
@@ -74,11 +74,16 @@ func set_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, point: Ve
 	var intersect = plane.intersects_ray(src, nrm)
 	
 	# Then isolate to just the magnitude of the z component.
-	var new_mag = abs(roadpoint.to_local(intersect).z)	
+	var new_mag = roadpoint.to_local(intersect).z
+	
+	#Stop the handle at 0 if the cursor crosses over the road point
+	if (new_mag < 0 and index > 0) or (new_mag > 0 and index == 0):
+		new_mag = 0
+		
 	if init_handle == null:
 		init_handle = new_mag
 	if index == 0:
-		roadpoint.prior_mag = new_mag
+		roadpoint.prior_mag = -new_mag
 	else:
 		roadpoint.next_mag = new_mag
 	redraw(gizmo)


### PR DESCRIPTION
Bezier handles used to bounce/pingpong when dragged across the road point. Now, they stop at the road point.