### PR TITLE
Workaround for godot empty array synced bug

### DIFF
--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -46,9 +46,7 @@ const COLOR_RED = Color(0.7, 0.3, 0.3)
 const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPoint.
 
 # Assign the direction of traffic order. This i
-export(Array, LaneDir) var traffic_dir:Array = [
-	LaneDir.REVERSE, LaneDir.REVERSE, LaneDir.FORWARD, LaneDir.FORWARD
-	] setget _set_dir, _get_dir
+export(Array, LaneDir) var traffic_dir:Array setget _set_dir, _get_dir
 
 # Enables auto assignment of the lanes array below, based on traffic_dir setup.
 export(bool) var auto_lanes := true setget _set_auto_lanes, _get_auto_lanes
@@ -56,9 +54,7 @@ export(bool) var auto_lanes := true setget _set_auto_lanes, _get_auto_lanes
 # Assign the textures to use for each lane.
 # Order is left to right when oriented such that the RoadPoint is facing towards
 # the top of the screen in a top down orientation.
-export(Array, LaneType) var lanes:Array = [
-	LaneType.SLOW, LaneType.FAST, LaneType.FAST, LaneType.SLOW
-	] setget _set_lanes, _get_lanes
+export(Array, LaneType) var lanes:Array setget _set_lanes, _get_lanes
 
 export var lane_width := 4.0 setget _set_lane_width, _get_lane_width
 export var shoulder_width_l := 2 setget _set_shoulder_width_l, _get_shoulder_width_l
@@ -88,10 +84,14 @@ var _last_update_ms # To calculate min updates.
 func _init():
 	# Workaround to avoid linked export arrays between duplicates, see:
 	# https://github.com/TheDuckCow/godot-road-generator/issues/86
-	if len(traffic_dir) == 0:
-		traffic_dir = []
-	if len(lanes) == 0:
-		lanes = []
+	# and
+	# https://github.com/TheDuckCow/godot-road-generator/pull/87
+	traffic_dir = [
+		LaneDir.REVERSE, LaneDir.REVERSE, LaneDir.FORWARD, LaneDir.FORWARD
+	]
+	lanes = [
+		LaneType.SLOW, LaneType.FAST, LaneType.FAST, LaneType.SLOW
+	]
 
 
 func _ready():

--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -85,6 +85,14 @@ var geom:ImmediateGeometry # For tool usage, drawing lane directions and end poi
 
 var _last_update_ms # To calculate min updates.
 
+func _init():
+	# Workaround to avoid linked export arrays between duplicates, see:
+	# https://github.com/TheDuckCow/godot-road-generator/issues/86
+	if len(traffic_dir) == 0:
+		traffic_dir = []
+	if len(lanes) == 0:
+		lanes = []
+
 
 func _ready():
 	# Ensure the transform notificaitons work

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -586,6 +586,8 @@ static func quad(st, uvs:Array, pts:Array) -> void:
 ## Returns: Array[RoadPoint.LaneType, RoadPoint.LaneDir]
 func _match_lanes() -> Array:
 	# Check for invalid lane configuration
+	if len(start_point.traffic_dir) == 0 or len(end_point.traffic_dir) == 0:
+		return []
 	if (
 		(start_point.traffic_dir[0] == RoadPoint.LaneDir.REVERSE
 			and end_point.traffic_dir[0] == RoadPoint.LaneDir.FORWARD)


### PR DESCRIPTION
Appears to be working when copied into the wheel steal project. The match lane issue was happening when they were properly de-synced but then zero array length, hence failing on reference [0].

Closes https://github.com/TheDuckCow/godot-road-generator/issues/86