### PR TITLE
Updated auto-texturing for one-way roads

### DIFF
--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -283,6 +283,7 @@ func assign_lanes():
 		# Now complete the final lane.
 		if running_same_dir > 0:
 			if running_same_dir == len(flips):
+				#  Special texture case for the "inside" lane of a way one road
 				if traffic_dir[-1] == LaneDir.FORWARD:
 					lanes.append(LaneType.SLOW)
 					lanes[0] = LaneType.NO_MARKING

--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -241,11 +241,7 @@ func on_transform(low_poly=false):
 func assign_lanes():
 	lanes.clear()
 	if len(traffic_dir) == 1:
-		if traffic_dir[0] == LaneDir.NONE:
-			lanes.append(LaneType.NO_MARKING)
-		else:
-			# Direction doesn't matter, since there is only a single lane here.
-			lanes.append(LaneType.ONE_WAY)
+		lanes.append(LaneType.NO_MARKING)
 		return
 
 	var flips = [] # Track changes in direction between lanes.
@@ -286,7 +282,14 @@ func assign_lanes():
 
 		# Now complete the final lane.
 		if running_same_dir > 0:
-			lanes.append(LaneType.SLOW)
+			if running_same_dir == len(flips):
+				if traffic_dir[-1] == LaneDir.FORWARD:
+					lanes.append(LaneType.SLOW)
+					lanes[0] = LaneType.NO_MARKING
+				else:
+					lanes.append(LaneType.NO_MARKING)
+			else:
+				lanes.append(LaneType.SLOW)
 		else:
 			lanes.append(LaneType.TWO_WAY)
 	else:

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -227,12 +227,18 @@ func _update_curve():
 	curve.set_point_tilt(1, end_point.rotation.z)
 
 
-func _normal_for_offset(curve: Curve3D, offset_s: float, loop: float, loops: float):
+## Calculates the horizontal vector of a Segment geometry loop. Interpolates
+## between the start and end points. Applies "easing" to prevent potentially
+## unwanted rotation on the loops at the ends of the curve.
+## Inputs:
+## curve - The curve this Segment will follow.
+## sample_position - Curve sample position to use for interpolation. Normalized.
+## Returns: Normalized Vector3
+func _normal_for_offset(curve: Curve3D, sample_position: float) -> Vector3:
 	# Calculate interpolation amount for curve sample point
 	var loop_point: Transform
 	var smooth_amount: float = -1.5
-	var percent_of_curve: float = loop / (loops - 1)
-	var interp_amount: float = ease(percent_of_curve, smooth_amount)
+	var interp_amount: float = ease(sample_position, smooth_amount)
 
 	# Calculate loop transform
 	loop_point.basis = start_point.global_transform.basis
@@ -321,9 +327,9 @@ func _insert_geo_loop(
 	var end_loop:Vector3
 	var end_basis:Vector3
 	start_loop = curve.interpolate_baked(offset_s * clength)
-	start_basis = _normal_for_offset(curve, offset_s * clength, loop, loops)
+	start_basis = _normal_for_offset(curve, offset_s)
 	end_loop = curve.interpolate_baked(offset_e * clength)
-	end_basis = _normal_for_offset(curve, offset_e * clength, loop + 1, loops)
+	end_basis = _normal_for_offset(curve, offset_e)
 
 	#print("\tRunning loop %s: %s to %s; Start: %s,%s, end: %s,%s" % [
 	#	loop, offset_s, offset_e, start_loop, start_basis, end_loop, end_basis

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -643,7 +643,7 @@ func _match_lanes() -> Array:
 	):
 		for i in range(range_to_check):
 			if i < len(start_point.traffic_dir) and i < len(end_point.traffic_dir):
-				lanes.append([start_point.lanes[i], RoadPoint.LaneDir.REVERSE])
+				lanes.push_front([start_point.lanes[-i - 1], RoadPoint.LaneDir.REVERSE])
 			elif i > len(end_point.traffic_dir) - 1:
 				lanes.push_front([RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE])
 			elif i > len(start_point.traffic_dir) - 1:

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -133,7 +133,7 @@ var one_way_lane_setup = [
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.SLOW, RoadPoint.LaneType.MIDDLE],
-		[[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE]],
+		[[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE]],
 		"RRR > RR >> RSM|",
 	],
 	[

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -40,8 +40,13 @@ var auto_lane_pairs = [
 	],
 	[
 		[RoadPoint.LaneDir.FORWARD],
-		[RoadPoint.LaneType.ONE_WAY],
-		"One way"
+		[RoadPoint.LaneType.NO_MARKING],
+		"One way forward"
+	],
+	[
+		[RoadPoint.LaneDir.REVERSE],
+		[RoadPoint.LaneType.NO_MARKING],
+		"One way reverse"
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
@@ -50,14 +55,19 @@ var auto_lane_pairs = [
 	],
 	[
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
-		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.MIDDLE, RoadPoint.LaneType.SLOW],
-		"3-lane one way"
+		[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneType.MIDDLE, RoadPoint.LaneType.SLOW],
+		"3-lane one way forward"
+	],
+	[
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
+		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.MIDDLE, RoadPoint.LaneType.NO_MARKING],
+		"3-lane one way reverse"
 	],
 ]
 
 func test_auto_lanes_sequence(params=use_parameters(auto_lane_pairs)):
 	var pt = RoadPoint.new()
-	
+
 	pt.traffic_dir = params[0]
 	var target = params[1]
 	pt.assign_lanes()


### PR DESCRIPTION
This update should take care of auto-texturing one-way roads and eliminate unwanted lane lines. All GUT tests passed.

What changed:

ROAD_POINT.GD
Updated road_point.gd to use NO_MARKING texture instead of ONE_WAY in single-lane one-way situations because ONE_WAY resulted in an unwanted line on one side of the lanes where it was used.

Also, updated the "final lane" logic to insure that the "outside" lane texture is NO_MARKING in various one-way multiple lane setups.

ROAD_SEGMENT.GD
Troubleshot an issue where reverse-only lane setups still showed a dotted line on the left side. Updated road_segment.gd "reverse-only" lane matching element result order.

TESTS
Updated both road point and lane matching unit tests.