### PR TITLE
Update export vars so shoulders and lane width are floats.

### DIFF
--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -56,9 +56,9 @@ export(bool) var auto_lanes := true setget _set_auto_lanes, _get_auto_lanes
 # the top of the screen in a top down orientation.
 export(Array, LaneType) var lanes:Array setget _set_lanes, _get_lanes
 
-export var lane_width := 4.0 setget _set_lane_width, _get_lane_width
-export var shoulder_width_l := 2 setget _set_shoulder_width_l, _get_shoulder_width_l
-export var shoulder_width_r := 2 setget _set_shoulder_width_r, _get_shoulder_width_r
+export(float) var lane_width := 4.0 setget _set_lane_width, _get_lane_width
+export(float) var shoulder_width_l := 2.0 setget _set_shoulder_width_l, _get_shoulder_width_l
+export(float) var shoulder_width_r := 2.0 setget _set_shoulder_width_r, _get_shoulder_width_r
 # Profile: x: how far out the gutter goes, y: how far down to clip.
 export(Vector2) var gutter_profile := Vector2(0.5, -0.5) setget _set_profile, _get_profile
 export(NodePath) var prior_pt_init setget _set_prior_pt, _get_prior_pt


### PR DESCRIPTION
Before now, road lane widths as well as shoulder widths had to be integer values, when they should have been floats.

All GUT tests pass:
`4 passed 0 failed.  Tests finished in 0.0s`
