### PR TITLE
Auto connect LaneSegment ends to neighbors

### DIFF
--- a/addons/road-generator/lane_point.gd
+++ b/addons/road-generator/lane_point.gd
@@ -1,6 +1,0 @@
-extends Node
-class_name LanePoint
-
-export var width := 4.0
-export var reverse := false
-

--- a/addons/road-generator/lane_segment.gd
+++ b/addons/road-generator/lane_segment.gd
@@ -15,8 +15,28 @@ export var reverse_direction:bool = false setget _set_direction, _get_direction
 export var lane_left:NodePath # Used to indicate allowed lane changes
 export var lane_right:NodePath # Used to indicate allowed lane changes
 export var lane_next:NodePath # LaneSegment or intersection
-export var lane_previous:NodePath # LaneSegment or intersection
+export var lane_prior:NodePath # LaneSegment or intersection
 export var draw_in_game = false # Can override to draw if outside the editor
+
+
+# Tags are used help populate the lane_next and lane_prior NodePaths above.
+#
+# Given two segments (seg_A followed by seg_B), a lane_A of seg_A will be auto
+# matched to lane_B of seg_B if lane_A's lane_next_tag is the same as lane_B's
+# lane_prior_tag (since lane_B follows lane_A in this situation).
+#
+# Any matching name will do, and it will match the first match. Auto-generated
+# lanes have a convention of a prefix F or R (for forward or reverse lane,
+# relative to the road segment) followed by a 0-indexed integer, based on how
+# far from the middle of the road (middle = where the lane direction flips).
+#
+# This way, the inner most lanes are always matched together. A lane F2 being
+# removed on the right (forward) will be recognized as needing to have it's
+# lane_next_tag set to F1, representing cars merging from this removed lane into
+# the next interior lane.
+export var lane_prior_tag:String  # e.g. R0, R1,...R#, F0, F1, ... F#.
+export var lane_next_tag:String  # e.g. R0, R1,...R#, F0, F1, ... F#.
+
 
 var this_road_segment = null # RoadSegment
 var refresh_geom = true
@@ -73,7 +93,7 @@ func unregister_vehicle(vehicle: Node) -> void:
 
 
 ## Return all vehicles registered to this lane, performing cleanup as needed.
-func get_vehicles()  -> Array:
+func get_vehicles() -> Array:
 	for vehicle in _vehicles_in_lane:
 		if not is_instance_valid(vehicle):
 			_vehicles_in_lane.erase(vehicle)
@@ -150,5 +170,4 @@ func curve_changed() -> void:
 func show_fins(value: bool) -> void:
 	_display_fins = value
 	rebuild_geom()
-
 

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -154,8 +154,6 @@ func process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> int:
 # Process over each end of "connecting" Lanes, therefore best to iterate
 # over RoadPoints.
 func update_lane_seg_connections():
-	print_debug("KEYS!", segid_map.keys())
-
 	for obj in get_node(points).get_children():
 		if not obj.visible:
 			continue # Assume local chunk has dealt with the geo visibility.

--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -414,6 +414,7 @@ func increment_name(name: String) -> String:
 		new_name += "001"
 	return new_name
 
+
 ## Adds a RoadPoint to SceneTree and transfers settings from another RoadPoint
 func add_road_point(new_road_point: RoadPoint, pt_init):
 	var points = get_parent()

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -133,7 +133,7 @@ func generate_lane_segments(debug: bool) -> bool:
 	var lanes_added := 0
 	for this_match in mathced_lanes:
 		var ln_type: int = this_match[0]  # Enum RoadPoint.LaneType
-		var ln_dir: int = this_match[0]  # Enum RoadPoint.LaneDir
+		var ln_dir: int = this_match[1]  # Enum RoadPoint.LaneDir
 		var new_ln := LaneSegment.new()
 		add_child(new_ln)
 

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -709,7 +709,7 @@ func _match_lanes() -> Array:
 					start_point.lanes[-i - 1],
 					RoadPoint.LaneDir.REVERSE,
 					"R0",
-					"R0r"])
+					"R0"])
 			elif i > len(end_point.traffic_dir) - 1:
 				lanes.push_front([
 					RoadPoint.LaneType.TRANSITION_REM,

--- a/project.godot
+++ b/project.godot
@@ -14,11 +14,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/gut/hook_script.gd"
 }, {
-"base": "Node",
-"class": "LanePoint",
-"language": "GDScript",
-"path": "res://addons/road-generator/lane_point.gd"
-}, {
 "base": "Path",
 "class": "LaneSegment",
 "language": "GDScript",
@@ -41,7 +36,6 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "GutHookScript": "",
-"LanePoint": "",
 "LaneSegment": "",
 "RoadNetwork": "res://addons/road-generator/road_segment.png",
 "RoadPoint": "res://addons/road-generator/road_point.png",

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -1,10 +1,11 @@
 ## This script contains test cases for the road_segment._match_lanes function.
 ##
 ## Array format:
-## 0 start point traffic dir
-## 1 end point traffic dir
-## 2 start point lane types
-## 3 expected result lane types
+## 0 start RoadPoint traffic dir
+## 1 end RoadPoint traffic dir
+## 2 Start RoadPoint lane types
+## 3 Expected results, which itself is an array where each (lane) item is:
+##    [LaneType, LaneDir, lane_prior_tag, lane_next_tag]
 ## 4 Test case label, with a structure of:
 ##    Direction start > Direction end > expected outcome, where
 ##    Direction start/end: F=forward lane, R=reverse lane
@@ -18,63 +19,149 @@ var auto_lane_setup = [
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
-		[[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD]],
+		[
+			# reverse lane stays reverse lane.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# forward lane stays forward lane.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"]],
 		"RF > RF >> F|F",
+	],
+	[
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
+		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST, RoadPoint.LaneType.SLOW],
+		[
+			# reverse lane stays reverse lane.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# forward lane stays forward lane.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# outer fowrad lane stays the same.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F1", "F1"]],
+		"RFF > RFF >> F|FS",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
-		[[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD]],
+		[
+			# reverse lane stays the same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# fwd lane in (initially single, then middle) stays the same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# added fwd lane goes from connecting to F0 to F1 next.
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD, "F0a", "F1"]],
 		"RF > RFF >> F|FA",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST, RoadPoint.LaneType.SLOW],
-		[[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Reverse stays the same lane
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Forward stays the same lane
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# The outside fwd lane is removed, so goes from F1-F0
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD, "F1", "F0r"]],
 		"RFF > RF >> F|FR",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST, RoadPoint.LaneType.SLOW],
-		[[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Reverse outer lane stays
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Reverse inner lane stays
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Inner fwd lane stays
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# Outer fwd lane removed.
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD, "F1", "F0r"]],
 		"RRFF > RRF >> SF|FR",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
-		[[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Reverse lane outer (id=1) stays.
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Reverse lane inner (id=0) stays.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Inner forward lane (id=0) stays.
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD], "F0", "F0",
+			# Forward lane added (id 0 becomes 1 for next segment)
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD, "F0a", "F1"]],
 		"RRF > RRFF >> SF|FA",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.SLOW, RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
-		[[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD]],
+		[
+			# The initial reverse lane is removed.
+			# TODO: might have this backwards, which side has the 'R1r'
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE, "R2", "R1r"],
+			# Middle reverse (id = 1) remains
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Inner reverse (id = 0) remains
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Forward lane remains
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"]],
 		"RRRF > RRF >> RSF|F",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
-		[[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Reverse lane added (id 1 -> 2)
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE, "R1a", "R2"],
+			# Middle reverse lane the same
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Inner reverse lane the same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Forward lane remains
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"]],
 		"RRF > RRRF >> ASF|F",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.SLOW, RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST, RoadPoint.LaneType.SLOW, RoadPoint.LaneType.SLOW],
-		[[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Reverse lane was removed
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE, "R2", "R0r"],
+			# Reverse lane was removed
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE, "R1", "R0r"],
+			# Revese lane stayed teh same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Forward lane stayed the same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# Forward inner lane was removed
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD, "F1", "F0r"],
+			# Forward outer lane was removed
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD, "F2", "F0r"]],
 		"RRRFFF > RF >> RRF|FRR",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
-		[[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Outer reverse lane added
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE, "R0a", "R2"],
+			# Middle reverse lane added
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE, "R0a", "R1"],
+			# Inner reverse lane the same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
+			# Inner fast lane the same
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# Middle fast lane added
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD, "F0a", "F1"],
+			# Outer fast lane added
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD, "F0a", "F2"]],
 		"RF > RRRFFF >> AAF|FAA",
 	],
 ]
@@ -84,56 +171,88 @@ var one_way_lane_setup = [
 		[RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.NO_MARKING],
-		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD]],
+		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD, "F0", "F0"]],
 		"F > F >> |M",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneType.NO_MARKING],
-		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.REVERSE]],
+		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.REVERSE, "R0", "R0"]],
 		"R > R >> M|",
 	],
 	[
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneType.SLOW],
-		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Inner fast lane, since middle si to left of fast
+			[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD, "F0"],
+			# Outer fast lane
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD, "F1"]],
 		"FF > FF >> |MS",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.MIDDLE],
-		[[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE]],
+		[
+			# Outer reverse lane the same.
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Inner reverse lane, since the "divider" is to the rigth
+			[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE, "R0", "R0"]],
 		"RR > RR >> SM|",
 	],
 	[
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneType.SLOW],
-		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Inner fast lane the same
+			[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# Middle forward lane the same
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD, "F1", "F1"],
+			# Outer forward lane added
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD, "F1a", "F2"]],
 		"FF > FFF >> |MSA",
 	],
 	[
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD],
 		[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneType.SLOW, RoadPoint.LaneType.SLOW],
-		[[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD],[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD]],
+		[
+			# Inner fast lane the same
+			[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
+			# Middle fast lane the same
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD, "F1", "F1"],
+			# Outer lane removed
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.FORWARD, "F2", "F1r"]],
 		"FFF > FF >> |MSR",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.MIDDLE],
-		[[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE]],
+		[
+			# Reverse lane added
+			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.REVERSE, "R1a", "R2"],
+			# Middle lane the same
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Inner lane the same
+			[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE, "R0", "R0"]],
 		"RR > RRR >> ASM|",
 	],
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
 		[RoadPoint.LaneType.SLOW, RoadPoint.LaneType.SLOW, RoadPoint.LaneType.MIDDLE],
-		[[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE],[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE]],
+		[
+			# Reverse lane removed
+			[RoadPoint.LaneType.TRANSITION_REM, RoadPoint.LaneDir.REVERSE, "R2", "R1r"],
+			# Middle lane the same
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.REVERSE, "R1", "R1"],
+			# Inner lane the same
+			[RoadPoint.LaneType.MIDDLE, RoadPoint.LaneDir.REVERSE, "R0", "R0"]],
 		"RRR > RR >> RSM|",
 	],
 	[

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -36,7 +36,7 @@ var auto_lane_setup = [
 			# forward lane stays forward lane.
 			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
 			# outer fowrad lane stays the same.
-			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F1", "F1"]],
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD, "F1", "F1"]],
 		"RFF > RFF >> F|FS",
 	],
 	[
@@ -90,7 +90,7 @@ var auto_lane_setup = [
 			# Reverse lane inner (id=0) stays.
 			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.REVERSE, "R0", "R0"],
 			# Inner forward lane (id=0) stays.
-			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD], "F0", "F0",
+			[RoadPoint.LaneType.FAST, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
 			# Forward lane added (id 0 becomes 1 for next segment)
 			[RoadPoint.LaneType.TRANSITION_ADD, RoadPoint.LaneDir.FORWARD, "F0a", "F1"]],
 		"RRF > RRFF >> SF|FA",
@@ -187,9 +187,9 @@ var one_way_lane_setup = [
 		[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneType.SLOW],
 		[
 			# Inner fast lane, since middle si to left of fast
-			[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD, "F0"],
+			[RoadPoint.LaneType.NO_MARKING, RoadPoint.LaneDir.FORWARD, "F0", "F0"],
 			# Outer fast lane
-			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD, "F1"]],
+			[RoadPoint.LaneType.SLOW, RoadPoint.LaneDir.FORWARD, "F1", "F1"]],
 		"FF > FF >> |MS",
 	],
 	[


### PR DESCRIPTION
In order for AI to function well, we need to have each LaneSegment (which represents a sort of dotted line which AI can follow, including through intersections and lane transitions) connect to its according left-right neighbors, but also a way for the RoadNetwork to do a pass connecting existing LaneSegments to their according same-lane next/prior's.

Closes #47 