### PR TITLE
100-avoid showing repeats in add menu

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -5,6 +5,8 @@ extends EditorPlugin
 const RoadPointGizmo = preload("res://addons/road-generator/road_point_gizmo.gd")
 const RoadPointEdit = preload("res://addons/road-generator/ui/road_point_edit.gd")
 
+const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
+
 var road_point_gizmo = RoadPointGizmo.new(self)
 var road_point_editor = RoadPointEdit.new(self)
 var _road_toolbar = preload("res://addons/road-generator/ui/road_toolbar.tscn").instance()
@@ -23,10 +25,11 @@ func _enter_tree():
 	_eds.connect("selection_changed", road_point_gizmo, "on_selection_changed")
 	connect("scene_changed", self, "_on_scene_changed")
 	connect("scene_closed", self, "_on_scene_closed")
-	add_custom_type("RoadPoint", "Spatial", preload("road_point.gd"), preload("road_point.png"))
-	add_custom_type("RoadNetwork", "Spatial", preload("road_network.gd"), preload("road_segment.png"))
-	# TODO: Set a different icon for lane segments.
-	add_custom_type("LaneSegment", "Curve3d", preload("lane_segment.gd"), preload("road_segment.png"))
+
+	# Don't add the following, as they would result in repeast in the UI.
+	#add_custom_type("RoadPoint", "Spatial", preload("road_point.gd"), preload("road_point.png"))
+	#add_custom_type("RoadNetwork", "Spatial", preload("road_network.gd"), preload("road_segment.png"))
+	#add_custom_type("LaneSegment", "Curve3d", preload("lane_segment.gd"), preload("road_segment.png"))
 
 
 func _exit_tree():
@@ -37,9 +40,11 @@ func _exit_tree():
 	_road_toolbar.queue_free()
 	remove_spatial_gizmo_plugin(road_point_gizmo)
 	remove_inspector_plugin(road_point_editor)
-	remove_custom_type("RoadPoint")
-	remove_custom_type("RoadNetwork")
-	remove_custom_type("LaneSegment")
+
+	# Don't add the following, as they would result in repeast in the UI.
+	#remove_custom_type("RoadPoint")
+	#remove_custom_type("RoadNetwork")
+	#remove_custom_type("LaneSegment")
 
 
 ## Render the editor indicators for RoadPoints and LaneSegments if selected.

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -3,8 +3,8 @@ tool
 class_name RoadNetwork, "road_segment.png"
 extends Spatial
 
-#const RoadPoint = preload("res://addons/road-generator/road_point.gd")
 const RoadMaterial = preload("res://addons/road-generator/road_texture.material")
+const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
 
 export(bool) var auto_refresh = true setget _ui_refresh_set, _ui_refresh_get
 export(Material) var material_resource:Material setget _set_material

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -3,7 +3,12 @@
 ## Assume lazy evaluation, only adding nodes when explicitly requested, so that
 ## the structure stays light only until needed.
 extends Spatial
-class_name RoadSegment, "road_segment.png"
+
+# Disabled, since we don't want users to manually via the UI to add this class.
+#class_name RoadSegment, "road_segment.png"
+#
+# To be able to reference as if a class, place this in any script:
+# const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
 
 const LOWPOLY_FACTOR = 3.0
 

--- a/project.godot
+++ b/project.godot
@@ -33,19 +33,13 @@ _global_script_classes=[ {
 "class": "RoadPoint",
 "language": "GDScript",
 "path": "res://addons/road-generator/road_point.gd"
-}, {
-"base": "Spatial",
-"class": "RoadSegment",
-"language": "GDScript",
-"path": "res://addons/road-generator/road_segment.gd"
 } ]
 _global_script_class_icons={
 "GutHookScript": "",
 "LanePoint": "",
 "LaneSegment": "",
 "RoadNetwork": "res://addons/road-generator/road_segment.png",
-"RoadPoint": "res://addons/road-generator/road_point.png",
-"RoadSegment": "res://addons/road-generator/road_segment.png"
+"RoadPoint": "res://addons/road-generator/road_point.png"
 }
 
 [application]

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -13,6 +13,8 @@
 
 extends "res://addons/gut/test.gd"
 
+const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
+
 var auto_lane_setup = [
 	[
 		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],


### PR DESCRIPTION
See the description in https://github.com/TheDuckCow/godot-road-generator/issues/100, goal here is to avoid repeats in the add UI. It now looks like this, which is desirable:

<img width="456" alt="Screen Shot 2023-06-23 at 11 54 10 PM" src="https://github.com/TheDuckCow/godot-road-generator/assets/2958461/ef2cc77d-67b3-4269-a68a-6ae6a25477ca">

Closes #100 