### PR TITLE
Renamed LaneSegment class and file to RoadLane

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -25,8 +25,7 @@ func _enter_tree():
 	connect("scene_closed", self, "_on_scene_closed")
 	add_custom_type("RoadPoint", "Spatial", preload("road_point.gd"), preload("road_point.png"))
 	add_custom_type("RoadNetwork", "Spatial", preload("road_network.gd"), preload("road_segment.png"))
-	# TODO: Set a different icon for lane segments.
-	add_custom_type("LaneSegment", "Curve3d", preload("lane_segment.gd"), preload("road_segment.png"))
+	#add_custom_type("RoadLane", "Curve3d", preload("lane_segment.gd"), preload("road_segment.png"))
 
 
 func _exit_tree():
@@ -39,10 +38,10 @@ func _exit_tree():
 	remove_inspector_plugin(road_point_editor)
 	remove_custom_type("RoadPoint")
 	remove_custom_type("RoadNetwork")
-	remove_custom_type("LaneSegment")
+	#remove_custom_type("RoadLane")
 
 
-## Render the editor indicators for RoadPoints and LaneSegments if selected.
+## Render the editor indicators for RoadPoints and RoadLanes if selected.
 func _on_selection_changed() -> void:
 	var selected_node = get_selected_node(_eds.get_selected_nodes())
 
@@ -60,7 +59,7 @@ func _on_selection_changed() -> void:
 	if selected_node is RoadPoint:
 		_last_point = selected_node
 		selected_node.on_transform()
-	elif selected_node is LaneSegment:
+	elif selected_node is RoadLane:
 		_last_lane = selected_node
 		_last_lane.show_fins(true)
 

--- a/addons/road-generator/road_lane.gd
+++ b/addons/road-generator/road_lane.gd
@@ -4,7 +4,7 @@
 
 tool # Draw in the editor things like path direction and width
 extends Path
-class_name LaneSegment
+class_name RoadLane
 
 const COLOR_PRIMARY = Color(0.6, 0.3, 0,3)
 const COLOR_START = Color(0.7, 0.7, 0,7)
@@ -14,8 +14,8 @@ signal on_transform
 export var reverse_direction:bool = false setget _set_direction, _get_direction
 export var lane_left:NodePath # Used to indicate allowed lane changes
 export var lane_right:NodePath # Used to indicate allowed lane changes
-export var lane_next:NodePath # LaneSegment or intersection
-export var lane_prior:NodePath # LaneSegment or intersection
+export var lane_next:NodePath # RoadLane or intersection
+export var lane_prior:NodePath # RoadLane or intersection
 export var draw_in_game = false # Can override to draw if outside the editor
 
 

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -144,7 +144,7 @@ func process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> int:
 		new_seg.check_rebuild()
 
 		if generate_ai_lanes:
-			print("Doing lane segments")
+			print("Doing road lanes")
 			new_seg.generate_lane_segments(debug)
 
 		return 1

--- a/addons/road-generator/road_point_gizmo.gd
+++ b/addons/road-generator/road_point_gizmo.gd
@@ -327,7 +327,7 @@ func commit_mag_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: b
 		undo_redo.add_do_method(self, "redraw", gizmo)
 		undo_redo.add_undo_method(self, "redraw", gizmo)
 		# Ensure that on undo/redo, the point update is triggered to force
-		# regeneration/placement of LaneSegments.
+		# regeneration/placement of RoadLanes.
 		undo_redo.add_do_method(point.network, "on_point_update", point, false)
 		undo_redo.add_undo_method(point.network, "on_point_update", point, false)
 

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -105,7 +105,7 @@ func check_rebuild():
 		is_dirty = false
 
 
-## Utility to auto generate all lane segments for this road for use by AI.
+## Utility to auto generate all road lanes for this road for use by AI.
 ##
 ## Returns true if any lanes generated, false if not.
 func generate_lane_segments(debug: bool) -> bool:
@@ -114,7 +114,7 @@ func generate_lane_segments(debug: bool) -> bool:
 	if not is_instance_valid(start_point) or not is_instance_valid(end_point):
 		return false
 
-	# First identify all segments that will exist.
+	# First identify all road lanes that will exist.
 	var matched_lanes = self._match_lanes()
 	if len(matched_lanes) == 0:
 		return false
@@ -162,13 +162,13 @@ func generate_lane_segments(debug: bool) -> bool:
 		# TODO: Check for existing lanes and reuse (but also clean up if needed)
 		# var ln_child = self.get_node_or_null(ln_name)
 		var ln_child = null
-		if not is_instance_valid(ln_child) or not ln_child is LaneSegment:
-			ln_child = LaneSegment.new()
+		if not is_instance_valid(ln_child) or not ln_child is RoadLane:
+			ln_child = RoadLane.new()
 			add_child(ln_child)
-		var new_ln:LaneSegment = ln_child
+		var new_ln:RoadLane = ln_child
 
 		# Assign the in and out lane tags, to help with connecting to other
-		# lane segments later (handled by RoadNetwork).
+		# road lanes later (handled by RoadNetwork).
 		new_ln.lane_prior_tag = this_match[2]
 		new_ln.lane_next_tag = this_match[3]
 		new_ln.name = ln_name
@@ -286,23 +286,23 @@ func get_transition_offset(
 	return [start_shift, end_shift]
 
 
-## Returns list of only valid LaneSegments
+## Returns list of only valid RoadLanes
 func get_lanes() -> Array:
 	var lanes = []
 	for ch in self.get_children():
 		if not is_instance_valid(ch):
 			continue
-		elif not ch is LaneSegment:
-			# push_warning("Child of road segment is not a lane segment: %s" % ln.name)
+		elif not ch is RoadLane:
+			# push_warning("Child of RoadSegment is not a RoadLane: %s" % ln.name)
 			continue
 		lanes.append(ch)
 	return lanes
 
 
-## Remove all LaneSegments attached to this RoadSegment
+## Remove all RoadLanes attached to this RoadSegment
 func clear_lane_segments():
 	for ch in get_children():
-		if ch is LaneSegment:
+		if ch is RoadLane:
 			ch.queue_free()
 
 
@@ -710,8 +710,8 @@ static func quad(st, uvs:Array, pts:Array) -> void:
 ## Returns: Array[
 ##   RoadPoint.LaneType, # To indicate texture, and whether an add/remove.
 ##   RoadPoint.LaneDir, # To indicate which direction the traffic goes.
-##   lane_prior_tag, # Appropriate str for later connecting LaneSegments
-##   lane_next_tag # Appropriate str for later connecting LaneSegments
+##   lane_prior_tag, # Appropriate str for later connecting RoadLanes
+##   lane_next_tag # Appropriate str for later connecting RoadLanes
 ## ]
 func _match_lanes() -> Array:
 	# Check for invalid lane configuration

--- a/project.godot
+++ b/project.godot
@@ -15,9 +15,9 @@ _global_script_classes=[ {
 "path": "res://addons/gut/hook_script.gd"
 }, {
 "base": "Path",
-"class": "LaneSegment",
+"class": "RoadLane",
 "language": "GDScript",
-"path": "res://addons/road-generator/lane_segment.gd"
+"path": "res://addons/road-generator/road_lane.gd"
 }, {
 "base": "Spatial",
 "class": "RoadNetwork",
@@ -36,7 +36,7 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "GutHookScript": "",
-"LaneSegment": "",
+"RoadLane": "",
 "RoadNetwork": "res://addons/road-generator/road_segment.png",
 "RoadPoint": "res://addons/road-generator/road_point.png",
 "RoadSegment": "res://addons/road-generator/road_segment.png"


### PR DESCRIPTION
For easier discoverability and searchability, renamed LaneSegments to RoadLanes. Now, whenever you search for "road" in the add menu, all relevant nodes to this plugin will appear.

All tests pass:
`4 passed 0 failed.  Tests finished in 0.0s`