### PR TITLE
Generate signals on road updated

### DIFF
--- a/addons/road-generator/road_lane.gd
+++ b/addons/road-generator/road_lane.gd
@@ -16,7 +16,10 @@ export var lane_left:NodePath # Used to indicate allowed lane changes
 export var lane_right:NodePath # Used to indicate allowed lane changes
 export var lane_next:NodePath # RoadLane or intersection
 export var lane_prior:NodePath # RoadLane or intersection
-export var draw_in_game = false # Can override to draw if outside the editor
+
+# Can override to draw if outside the editor
+export var draw_in_game = false setget _set_draw_in_game, _get_draw_in_game
+export var draw_in_editor = false setget _set_draw_in_editor, _get_draw_in_editor
 
 
 # Tags are used help populate the lane_next and lane_prior NodePaths above.
@@ -43,6 +46,8 @@ var refresh_geom = true
 var geom # For tool usage, drawing lane directions and end points
 
 var _vehicles_in_lane = [] # Registration
+var _draw_in_game: bool = false
+var _draw_in_editor: bool = false
 var _display_fins: bool = false
 
 
@@ -51,6 +56,7 @@ func _ready():
 	set_notify_local_transform(true)
 	connect("curve_changed", self, "curve_changed")
 	rebuild_geom()
+	#_instantiate_geom()
 
 
 func _set_direction(value):
@@ -105,7 +111,13 @@ func get_vehicles() -> Array:
 
 
 func _instantiate_geom() -> void:
-	if not _display_fins and (Engine.is_editor_hint() or draw_in_game):
+
+	if Engine.is_editor_hint():
+		_display_fins = _draw_in_editor
+	else:
+		_display_fins = _draw_in_game
+
+	if not _display_fins:
 		if geom:
 			geom.clear()
 		return
@@ -167,7 +179,24 @@ func curve_changed() -> void:
 	rebuild_geom()
 
 
+func _set_draw_in_game(value: bool) -> void:
+	refresh_geom = true
+	_draw_in_game = value
+	rebuild_geom()
+
+func _get_draw_in_game() -> bool:
+	return _draw_in_game
+
+func _set_draw_in_editor(value: bool) -> void:
+	refresh_geom = true
+	_draw_in_editor = value
+	rebuild_geom()
+
+func _get_draw_in_editor() -> bool:
+	return _draw_in_editor
+
+
 func show_fins(value: bool) -> void:
-	_display_fins = value
+	_draw_in_editor = false
 	rebuild_geom()
 

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -29,6 +29,11 @@ var segid_map = {}
 
 export(bool) var generate_ai_lanes := false setget _set_gen_ai_lanes
 export(bool) var debug := false
+export(bool) var draw_lanes_editor := false setget _set_draw_lanes_editor, _get_draw_lanes_editor
+export(bool) var draw_lanes_game := false setget _set_draw_lanes_game, _get_draw_lanes_game
+
+var _draw_lanes_editor:bool = false
+var _draw_lanes_game:bool = false
 
 
 func _ready():
@@ -75,6 +80,23 @@ func _set_segments(value):
 	segments = value
 	if auto_refresh:
 		call_deferred("rebuild_segments", true)
+
+
+func _set_draw_lanes_editor(value: bool):
+	_draw_lanes_editor = value
+	call_deferred("rebuild_segments", true)
+
+func _get_draw_lanes_editor() -> bool:
+	return _draw_lanes_editor
+
+func _set_draw_lanes_game(value: bool):
+	_draw_lanes_game = value
+	call_deferred("rebuild_segments", true)
+
+func _get_draw_lanes_game() -> bool:
+	return _draw_lanes_game
+
+
 
 
 func rebuild_segments(clear_existing=false):
@@ -159,8 +181,7 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 		new_seg.check_rebuild()
 
 		if generate_ai_lanes:
-			print("Doing road lanes")
-			new_seg.generate_lane_segments(debug)
+			new_seg.generate_lane_segments()
 
 		return [true, new_seg]
 
@@ -256,7 +277,7 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 		point.prior_seg.is_dirty = true
 		point.prior_seg.call_deferred("check_rebuild")
 		if not use_lowpoly:
-			point.prior_seg.generate_lane_segments(debug)
+			point.prior_seg.generate_lane_segments()
 		else:
 			point.prior_seg.clear_lane_segments()
 		segs_updated.append(point.prior_seg)  # Track an updated RoadSegment
@@ -272,7 +293,7 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 		point.next_seg.is_dirty = true
 		point.next_seg.call_deferred("check_rebuild")
 		if not use_lowpoly:
-			point.next_seg.generate_lane_segments(debug)
+			point.next_seg.generate_lane_segments()
 		else:
 			if point.next_seg:
 				point.next_seg.clear_lane_segments()

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -112,21 +112,23 @@ func _set_draw_lanes_editor(value: bool):
 	_draw_lanes_editor = value
 	call_deferred("rebuild_segments", true)
 
+
 func _get_draw_lanes_editor() -> bool:
 	return _draw_lanes_editor
+
 
 func _set_draw_lanes_game(value: bool):
 	_draw_lanes_game = value
 	call_deferred("rebuild_segments", true)
 
+
 func _get_draw_lanes_game() -> bool:
 	return _draw_lanes_game
 
 
-
-
 func rebuild_segments(clear_existing=false):
-	# print("Rebuilding segments")
+	if debug:
+		print("Rebuilding RoadSegments")
 	if not get_node(segments) or not is_instance_valid(get_node(segments)):
 		push_error("Segments node path not found")
 		return # Could be before ready called.

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -90,13 +90,15 @@ func _init_end_get():
 	return end_init
 
 
-func check_rebuild():
+## Check if needing to be rebuilt.
+## Returns true if rebuild was done, else (including if invalid) false.
+func check_rebuild() -> bool:
 	if is_queued_for_deletion():
-		return
+		return false
 	if not is_instance_valid(network):
-		return
+		return false
 	if not is_instance_valid(start_point) or not is_instance_valid(end_point):
-		return
+		return false
 	start_point.next_seg = self # TODO: won't work if next/prior is flipped for next node.
 	end_point.prior_seg = self # TODO: won't work if next/prior is flipped for next node.
 	if not start_point or not is_instance_valid(start_point) or not start_point.visible:
@@ -108,6 +110,8 @@ func check_rebuild():
 	if is_dirty:
 		_rebuild()
 		is_dirty = false
+		return true
+	return false
 
 
 ## Utility to auto generate all road lanes for this road for use by AI.

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -116,8 +116,10 @@ func check_rebuild() -> bool:
 
 ## Utility to auto generate all road lanes for this road for use by AI.
 ##
+## debug: No longer used, kept for backwards compatibility.
+##
 ## Returns true if any lanes generated, false if not.
-func generate_lane_segments(debug: bool) -> bool:
+func generate_lane_segments(_debug: bool = false) -> bool:
 	if not is_instance_valid(network):
 		return false
 	if not is_instance_valid(start_point) or not is_instance_valid(end_point):
@@ -216,11 +218,10 @@ func generate_lane_segments(debug: bool) -> bool:
 			curve.get_point_out(1))
 
 		# Visually display.
-		if debug:
-			#new_ln.draw_in_game = true
-			new_ln.show_fins(true)
-		else:
-			new_ln.show_fins(false)
+		new_ln.draw_in_editor = network.draw_lanes_editor
+		new_ln.draw_in_game = network.draw_lanes_game
+		new_ln.refresh_geom = true
+		new_ln.rebuild_geom()
 
 		# Update lane connectedness for left/right lane connections.
 		if not last_ln == null and last_ln.reverse_direction == new_ln.reverse_direction:

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -274,10 +274,10 @@ var one_way_lane_setup = [
 ]
 
 func test_match_lanes_sequence(params=use_parameters(auto_lane_setup)):
-	var seg = RoadSegment.new(null)
+	var seg = autoqfree(RoadSegment.new(null))
 
-	seg.start_point = RoadPoint.new()
-	seg.end_point = RoadPoint.new()
+	seg.start_point = autoqfree(RoadPoint.new())
+	seg.end_point = autoqfree(RoadPoint.new())
 	seg.start_point.traffic_dir = params[0]
 	seg.end_point.traffic_dir = params[1]
 	seg.start_point.lanes = params[2]
@@ -287,10 +287,10 @@ func test_match_lanes_sequence(params=use_parameters(auto_lane_setup)):
 	assert_eq(result, target, "Match lanes %s" % params[4])
 
 func test_one_way_lanes_sequence(params=use_parameters(one_way_lane_setup)):
-	var seg = RoadSegment.new(null)
+	var seg = autoqfree(RoadSegment.new(null))
 
-	seg.start_point = RoadPoint.new()
-	seg.end_point = RoadPoint.new()
+	seg.start_point = autoqfree(RoadPoint.new())
+	seg.end_point = autoqfree(RoadPoint.new())
 	seg.start_point.traffic_dir = params[0]
 	seg.end_point.traffic_dir = params[1]
 	seg.start_point.lanes = params[2]

--- a/test/unit/test_road_network.gd
+++ b/test/unit/test_road_network.gd
@@ -61,17 +61,34 @@ func test_road_network_create():
 
 func test_on_road_updated_single_segment():
 	var network = add_child_autofree(RoadNetwork.new())
-	watch_signals(network)
+	network.auto_refresh = false
 
 	create_oneseg_network(network)
 
 	# Now trigger the update, to see that a single segment was made
+	watch_signals(network)
 	network.rebuild_segments()
 	var res = get_signal_parameters(network, 'on_road_updated')
-	print_debug(res)
 	var segments_updated = res[0]
 	assert_eq(len(segments_updated), 1, "Single segment created")
 	assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")
+
+
+## Ensure that users can manually assign two points to connect with auto_refresh
+func test_roadnetwork_validations_with_autorefresh():
+	var network = add_child_autofree(RoadNetwork.new())
+	network.auto_refresh = true  # Will kick in validation
+
+	create_oneseg_network(network)
+
+	# Now trigger the update, to see that a single segment was made
+	watch_signals(network)
+	network.rebuild_segments()
+	var res = get_signal_parameters(network, 'on_road_updated')
+	var segments_updated = res[0]
+	assert_eq(len(segments_updated), 1, "Single segment created")
+	assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")
+
 
 func test_on_road_updated_pt_transform():
 	pending('Implement test which asserts on_road_updated called on RoadPoint transform')

--- a/test/unit/test_road_network.gd
+++ b/test/unit/test_road_network.gd
@@ -1,0 +1,79 @@
+extends "res://addons/gut/test.gd"
+
+
+func before_each():
+	gut.p("ran setup", 2)
+
+func after_each():
+	gut.p("ran teardown", 2)
+
+func before_all():
+	gut.p("ran run setup", 2)
+
+func after_all():
+	gut.p("ran run teardown", 2)
+
+
+## Utility to create a single segment network (2 points)
+func create_oneseg_network(network):
+	network.setup_road_network()
+	var points = network.get_node(network.points)
+	var segments = network.get_node(network.segments)
+
+	assert_eq(points.get_child_count(), 0, "No initial point children")
+	assert_eq(segments.get_child_count(), 0, "No initial segment children")
+
+	var p1 = autoqfree(RoadPoint.new())
+	var p2 = autoqfree(RoadPoint.new())
+
+	points.add_child(p1)
+	points.add_child(p2)
+	assert_eq(points.get_child_count(), 2, "Both RPs added")
+
+	p1.next_pt_init = p1.get_path_to(p2)
+	p2.prior_pt_init = p2.get_path_to(p1)
+
+
+# ------------------------------------------------------------------------------
+
+func test_road_network_create():
+	var network = autoqfree(RoadNetwork.new())
+	# Check the children are set up.
+
+	watch_signals(network)
+	assert_signal_emit_count(network, "on_road_updated", 0, "Don't signal create")
+
+	# Trigger the auto setup which happens deferred in _ready
+	network.setup_road_network()
+
+	# Ensure the automatic nodes got set up.
+	var points = network.get_node(network.points)
+	var segments = network.get_node(network.segments)
+	assert_true(is_instance_valid(points))
+	assert_true(is_instance_valid(segments))
+
+	# Since only setup, still should not have triggered on update.
+	assert_signal_emit_count(network, "on_road_updated", 0, "Don't signal setup")
+	network.rebuild_segments()
+	# Now it's updated
+	assert_signal_emit_count(network, "on_road_updated", 1, "Signal after rebuild")
+
+
+func test_on_road_updated_single_segment():
+	var network = add_child_autofree(RoadNetwork.new())
+	watch_signals(network)
+
+	create_oneseg_network(network)
+
+	# Now trigger the update, to see that a single segment was made
+	network.rebuild_segments()
+	var res = get_signal_parameters(network, 'on_road_updated')
+	print_debug(res)
+	var segments_updated = res[0]
+	assert_eq(len(segments_updated), 1, "Single segment created")
+	assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")
+
+func test_on_road_updated_pt_transform():
+	pending('Implement test which asserts on_road_updated called on RoadPoint transform')
+
+

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -16,14 +16,14 @@ func after_all():
 # ------------------------------------------------------------------------------
 
 func test_create_road_point():
-	var pt = RoadPoint.new()
-	pt.queue_free()
+	var _pt = autoqfree(RoadPoint.new())
+	pass_test('nothing tested, passing')
 
 
 var count_params = [1, 2, 3, 4, 5, 6]
 
 func test_auto_lanes_count(params=use_parameters(count_params)):
-	var pt = RoadPoint.new()
+	var pt = autoqfree(RoadPoint.new())
 	pt.traffic_dir = []
 	for _i in range(params):
 		pt.traffic_dir.append(pt.LaneDir.NONE)
@@ -66,7 +66,7 @@ var auto_lane_pairs = [
 ]
 
 func test_auto_lanes_sequence(params=use_parameters(auto_lane_pairs)):
-	var pt = RoadPoint.new()
+	var pt = autoqfree(RoadPoint.new())
 
 	pt.traffic_dir = params[0]
 	var target = params[1]
@@ -75,6 +75,7 @@ func test_auto_lanes_sequence(params=use_parameters(auto_lane_pairs)):
 
 
 func test_error_no_traffic_dir():
-	var pt = RoadPoint.new()
+	var pt = autoqfree(RoadPoint.new())
 	pt.traffic_dir = []
 	pt.assign_lanes()
+	pass_test('nothing tested, passing')


### PR DESCRIPTION
Purpose of this change is to reliably generate a signal when any road segments have been updated, so that downstream listeners can react to the roads (and thus, lanes etc) being updated. It attempts to batch them as much as possible, so one overall rebuilding of all RoadSegments will yield in one signal call referencing all of those roads. 

Not all tests pass right now, due to one recently added test that I thought was initially working but now is not (to with checking rebuild on certain conditions).

Will edit before merging to dev.

```
Totals
Scripts:          3
Passing tests     7
Failing tests     1 # test_on_road_updated_single_segment
Risky tests       0
Pending:          1 # func test_on_road_updated_pt_transform():
Asserts:          49 of 50 passed
```