### PR TITLE
Adding dirty flag to fix duplicate rebuilds on scene open.

### DIFF
--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -6,7 +6,7 @@ extends Spatial
 const RoadMaterial = preload("res://addons/road-generator/road_texture.material")
 const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
 
-export(bool) var auto_refresh = true setget _ui_refresh_set, _ui_refresh_get
+export(bool) var auto_refresh = true setget _ui_refresh_set
 export(Material) var material_resource:Material setget _set_material
 
 export(float) var density:float = 0.5  setget _set_density # Mesh density of generated segments.
@@ -27,49 +27,75 @@ export(bool) var generate_ai_lanes := false setget _set_gen_ai_lanes
 export(bool) var debug := false
 
 
+# Flag used to defer calls to setup_road_network via _dirty_rebuild_deferred,
+# important during scene startup whereby class properties are called in
+# succession during scene init and otherwise would lead to duplicate calls.
+var _dirty:bool = false
+
+
 func _ready():
 	# setup_road_network won't work in _ready unless call_deferred is used
 	call_deferred("setup_road_network")
-	call_deferred("rebuild_segments", true)
+
+	# Per below, this is technicaly redundant/not really doing anything.
+	_dirty = true
+	call_deferred("_dirty_rebuild_deferred")
+
+	# If we call this now, it will end up generating roads twice.
+	#rebuild_segments(true)
+	# This is due, evidently, to godot loading the scene in such a way where
+	# it actually sets the value to each property and thus also trigger its
+	# setget, and result in calling _dirty_rebuild_deferred. Class properties
+	# are assigned, thus triggering functions like _set_density, before the
+	# _ready function is ever called. Thus by the time _ready is happening,
+	# the _dirty flag is already set.
 
 
 func _ui_refresh_set(value):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
 	auto_refresh = value
-	if auto_refresh:
-		call_deferred("rebuild_segments", true)
-
-
-func _ui_refresh_get():
-	return auto_refresh
 
 
 func _set_gen_ai_lanes(value):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
 	generate_ai_lanes = value
-	if auto_refresh:
-		call_deferred("rebuild_segments", true)
 
 
 func _set_density(value):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
 	density = value
-	if auto_refresh:
-		call_deferred("rebuild_segments", true)
 
 
 func _set_material(value):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
 	material_resource = value
-	if auto_refresh:
-		call_deferred("rebuild_segments", true)
 
 
 func _set_points(value):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
 	points = value
-	if auto_refresh:
-		call_deferred("rebuild_segments", true)
 
 
 func _set_segments(value):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
 	segments = value
-	if auto_refresh:
+
+
+func _dirty_rebuild_deferred():
+	if _dirty:
+		_dirty = false
 		call_deferred("rebuild_segments", true)
 
 
@@ -144,7 +170,6 @@ func process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> int:
 		new_seg.check_rebuild()
 
 		if generate_ai_lanes:
-			print("Doing road lanes")
 			new_seg.generate_lane_segments(debug)
 
 		return 1


### PR DESCRIPTION
Introduces a _dirty flag in the road network, to manage when to trigger rebuilding of all road segments. This was getting to be problematic, as I noticed roads would be regenerated as many as 5x times in a row during scene open (and possible on save, too). Even though each inspector property setter function was initially doing a deferred called to rebuild, they were each triggering it 1x. It now functions on seeing whether it's still "dirty" so they don't overlap.

All 4 tests pass, and no more repeat generations of roads.

There is a potential consequence that this means we can't depend on roads being there in the first frame after _ready, but there's already evidence to believe that this was not reliable anyways. Another PR is focussing on adding necessary signals for that purpose.

Closes #106 