### PR TITLE
Enforce bi-directional RoadPoint connections on path updates

### DIFF
--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -28,6 +28,8 @@ export(NodePath) var debug_next
 var segid_map = {}
 
 export(bool) var generate_ai_lanes := false setget _set_gen_ai_lanes
+export(String) var ai_lane_group := "road_lanes" setget _set_ai_lane_group
+
 export(bool) var debug := false
 export(bool) var draw_lanes_editor := false setget _set_draw_lanes_editor, _get_draw_lanes_editor
 export(bool) var draw_lanes_game := false setget _set_draw_lanes_game, _get_draw_lanes_game
@@ -67,11 +69,18 @@ func _ui_refresh_set(value):
 	auto_refresh = value
 
 
-func _set_gen_ai_lanes(value):
+func _set_gen_ai_lanes(value: bool):
 	if auto_refresh and not _dirty:
 		_dirty = true
 		call_deferred("_dirty_rebuild_deferred")
 	generate_ai_lanes = value
+
+
+func _set_ai_lane_group(value: String):
+	if auto_refresh and not _dirty:
+		_dirty = true
+		call_deferred("_dirty_rebuild_deferred")
+	ai_lane_group = value
 
 
 func _set_density(value):
@@ -196,7 +205,7 @@ func remove_segment(seg:RoadSegment) -> void:
 	var id := seg.get_id()
 	seg.queue_free()
 	segid_map.erase(id)
-	
+
 	# If this function is triggered by during an onpoint update (such as
 	# setting next_pt_init to ""), then this would be a repeat signal call.
 	#emit_signal("on_road_updated", [])

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -186,6 +186,22 @@ func rebuild_segments(clear_existing=false):
 	emit_signal("on_road_updated", signal_rebuilt)
 
 
+## Removes a single RoadSegment, ensuring no leftovers and signal is emitted.
+func remove_segment(seg:RoadSegment) -> void:
+	if not seg or not is_instance_valid(seg):
+		print("What is seg now?, ", seg)
+		push_warning("RoadSegment is invalid, cannot remove")
+		print("Did NOT signal for the removal here", seg)
+		return
+	var id := seg.get_id()
+	seg.queue_free()
+	segid_map.erase(id)
+	
+	# If this function is triggered by during an onpoint update (such as
+	# setting next_pt_init to ""), then this would be a repeat signal call.
+	#emit_signal("on_road_updated", [])
+
+
 ## Create a new road segment based on input prior and next RoadPoints.
 ## Returns Array[was_updated: bool, RoadSegment]
 func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
@@ -333,6 +349,8 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 			segs_updated.append(res[1])  # Track an updated RoadSegment
 
 	if len(segs_updated) > 0:
+		if self.debug:
+			print_debug("Road segs rebuilt: ", len(segs_updated))
 		emit_signal("on_road_updated", segs_updated)
 
 

--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -536,8 +536,11 @@ func _is_junction_valid(point: RoadPoint)->bool:
 ## that the user is manually connecting these two points, and we should finish
 ## the reference by making the reference bidirectional.
 ##
-## TODO: Technically need to understand the case whereby someone is trying
-## to *clear* the reference to another roadpoint.
+## Args:
+##   old_point_path: The currently connected RoadPoint (as a NodePath)
+##   new_point_path: The to-be connected RoadPoint (as a NodePath)
+##   for_prior: If true, indicates the new+old are both the prior_pt_init for
+##     self; if false, then presume these are both the next_pt_init.
 ##
 ## Returns true if any updates made, false if nothing changed.
 func _autofix_noncyclic_references(

--- a/addons/road-generator/road_point.gd
+++ b/addons/road-generator/road_point.gd
@@ -178,24 +178,44 @@ func _set_profile(value:Vector2):
 	if not is_instance_valid(network):
 		return  # Might not be initialized yet.
 	on_transform()
+
+
 func _get_profile():
 	return gutter_profile
 
 
-func _set_prior_pt(value):
+func _set_prior_pt(value:NodePath):
+	var _pre_assign = prior_pt_init
 	prior_pt_init = value
 	if not is_instance_valid(network):
 		return  # Might not be initialized yet.
+
+	# Attempt an auto fix to ensure dependencies are updated. This should happen
+	# even if auto_refresh is off, since we want to make sure the network static
+	# data is always in a good state *ready* for the next refresh
+	_autofix_noncyclic_references(_pre_assign, value, true)
+
 	on_transform()
+
+
 func _get_prior_pt():
 	return prior_pt_init
 
 
-func _set_next_pt(value):
+func _set_next_pt(value:NodePath):
+	var _pre_assign = next_pt_init
 	next_pt_init = value
 	if not is_instance_valid(network):
 		return  # Might not be initialized yet.
+
+	# Attempt an auto fix to ensure dependencies are updated. This should happen
+	# even if auto_refresh is off, since we want to make sure the network static
+	# data is always in a good state *ready* for the next refresh
+	_autofix_noncyclic_references(_pre_assign, value, false)
+
 	on_transform()
+
+
 func _get_next_pt():
 	return next_pt_init
 
@@ -488,8 +508,10 @@ func validate_junctions(auto_refresh: bool):
 			next_pt_init = null
 
 
-## Evaluates INPUT RoadPoint's prior/next_pt_inits. Returns true if at least
-## one of them references THIS RoadPoint. Otherwise, returns false.
+## Evaluates INPUT RoadPoint's prior/next_pt_inits.
+##
+## Returns true if at least one of them references THIS RoadPoint, or if both
+## are empty. Otherwise, returns false.
 func _is_junction_valid(point: RoadPoint)->bool:
 	var prior_point: RoadPoint
 	var next_point: RoadPoint
@@ -508,3 +530,72 @@ func _is_junction_valid(point: RoadPoint)->bool:
 		if next_point == self:
 			return true
 	return false
+
+## If one RoadPoint references the other, but not the other way around,
+## but itself has an empty slot in the right "orientation", then we assume
+## that the user is manually connecting these two points, and we should finish
+## the reference by making the reference bidirectional.
+##
+## TODO: Technically need to understand the case whereby someone is trying
+## to *clear* the reference to another roadpoint.
+##
+## Returns true if any updates made, false if nothing changed.
+func _autofix_noncyclic_references(
+		old_point_path: NodePath,
+		new_point_path: NodePath,
+		for_prior: bool) -> void:
+	var init_refresh = network.auto_refresh
+	var point:RoadPoint
+	var is_clearing: bool # clearing value vs setting new path.
+
+	if new_point_path != "":
+		# Use the just recently set value.
+		is_clearing = false
+		point = get_node(new_point_path)
+	else:
+		# we are in clearing mode, so use the value that was just overwritten
+		is_clearing = true
+		point = get_node(old_point_path)
+
+	if not is_instance_valid(point):
+		# Shouldn't get to this branch, we check valid upstream first!
+		push_warning("Instance not valid on point for cyclic check")
+		return
+
+	network.auto_refresh = false
+
+	if is_clearing:
+		# Scenario where the user is attempting to CLEAR the _pt_init
+		# Therefore, we want to clear the new path instead.
+		# Key detail: this new point_path value has *not* yet been assigned,
+		# so we can still read self.next_pt_init
+		var seg  # RoadSegment.
+		if for_prior:
+			point.next_pt_init = ""
+			seg = self.prior_seg
+		else:
+			point.prior_pt_init = ""
+			seg = self.next_seg
+		network.remove_segment(seg)
+
+	elif for_prior and point.next_pt_init == "":
+		# self's prior RP is `point`, so make point's next RP be self if slot was empty
+		point.next_pt_init = point.get_path_to(self)
+		#print_debug(point.get_path_to(self), " -> ", point.next_pt_init)
+	elif not for_prior and point.prior_pt_init == "":
+		# Flipped scenario
+		point.prior_pt_init = point.get_path_to(self)
+		#print_debug(point.get_path_to(self), " -> ", point.prior_pt_init)
+	else:
+		if network and is_instance_valid(network) and network.debug:
+			print_debug("Cannot auto-fix cyclic reference")
+
+	# This would ordinarily actually trigger a full rebuild, which
+	# would not be great, as this sets the dirty flag for rebuilding all.
+	# Hacky solution: by setting to false the dirty flag and unsetting, we skip
+	# the internal call_deferred to rebuild. But not good to depend on this,
+	# sine the implementation could change technically.
+	# TODO: Implement better solution not depending on self-internals.
+	network._dirty = true
+	network.auto_refresh = init_refresh
+	network._dirty = false

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -176,6 +176,7 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		if not is_instance_valid(ln_child) or not ln_child is RoadLane:
 			ln_child = RoadLane.new()
 			add_child(ln_child)
+			ln_child.add_to_group(network.ai_lane_group)
 		var new_ln:RoadLane = ln_child
 
 		# Assign the in and out lane tags, to help with connecting to other

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -52,7 +52,7 @@ func _ready():
 
 
 ## Unique identifier for a segment based on what its connected to.
-func get_id():
+func get_id() -> String:
 	# TODO: consider changing so that the smaller resource id is first,
 	# so that we avoid bidirectional issues.
 	if start_point and end_point:

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -1,0 +1,20 @@
+extends "res://addons/gut/test.gd"
+
+## Utility to create a single segment network (2 points)
+func create_oneseg_network(network):
+	network.setup_road_network()
+	var points = network.get_node(network.points)
+	var segments = network.get_node(network.segments)
+
+	assert_eq(points.get_child_count(), 0, "No initial point children")
+	assert_eq(segments.get_child_count(), 0, "No initial segment children")
+
+	var p1 = autoqfree(RoadPoint.new())
+	var p2 = autoqfree(RoadPoint.new())
+
+	points.add_child(p1)
+	points.add_child(p2)
+	assert_eq(points.get_child_count(), 2, "Both RPs added")
+
+	p1.next_pt_init = p1.get_path_to(p2)
+	p2.prior_pt_init = p2.get_path_to(p1)

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -298,3 +298,4 @@ func test_one_way_lanes_sequence(params=use_parameters(one_way_lane_setup)):
 	var target = params[3]
 	var result = seg._match_lanes()
 	assert_eq(result, target, "Match one-way %s" % params[4])
+

--- a/test/unit/test_road_network.gd
+++ b/test/unit/test_road_network.gd
@@ -1,5 +1,8 @@
 extends "res://addons/gut/test.gd"
 
+const RoadUtils = preload("res://test/unit/road_utils.gd")
+onready var road_util := RoadUtils.new()
+
 
 func before_each():
 	gut.p("ran setup", 2)
@@ -12,6 +15,9 @@ func before_all():
 
 func after_all():
 	gut.p("ran run teardown", 2)
+
+
+# ------------------------------------------------------------------------------
 
 
 ## Utility to create a single segment network (2 points)
@@ -35,6 +41,7 @@ func create_oneseg_network(network):
 
 
 # ------------------------------------------------------------------------------
+
 
 func test_road_network_create():
 	var network = autoqfree(RoadNetwork.new())
@@ -88,9 +95,3 @@ func test_roadnetwork_validations_with_autorefresh():
 	var segments_updated = res[0]
 	assert_eq(len(segments_updated), 1, "Single segment created")
 	assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")
-
-
-func test_on_road_updated_pt_transform():
-	pending('Implement test which asserts on_road_updated called on RoadPoint transform')
-
-

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -15,6 +15,29 @@ func after_all():
 
 # ------------------------------------------------------------------------------
 
+
+## Utility to create a single segment network (2 points)
+func create_unconnected_network(network) -> Array:
+	network.setup_road_network()
+	var points = network.get_node(network.points)
+	var segments = network.get_node(network.segments)
+
+	assert_eq(points.get_child_count(), 0, "No initial point children")
+	assert_eq(segments.get_child_count(), 0, "No initial segment children")
+
+	var p1 = autoqfree(RoadPoint.new())
+	var p2 = autoqfree(RoadPoint.new())
+
+	points.add_child(p1)
+	points.add_child(p2)
+	assert_eq(points.get_child_count(), 2, "Both RPs added")
+
+	return [p1, p2]
+
+
+# ------------------------------------------------------------------------------
+
+
 func test_create_road_point():
 	var _pt = autoqfree(RoadPoint.new())
 	pass_test('nothing tested, passing')
@@ -79,3 +102,94 @@ func test_error_no_traffic_dir():
 	pt.traffic_dir = []
 	pt.assign_lanes()
 	pass_test('nothing tested, passing')
+
+
+func test_autofix_noncyclic_added_next():
+	var network = add_child_autofree(RoadNetwork.new())
+	network.auto_refresh = false
+
+	var points = create_unconnected_network(network)
+	var p1 = points[0]
+	var p2 = points[1]
+
+	network.auto_refresh = true
+	watch_signals(network)
+
+	# The change which should trigger an auto path fix and thus a signal
+	p1.next_pt_init = p1.get_path_to(p2)
+
+	# Validate that the road segment was generated (based on signal emission)
+	var res = get_signal_parameters(network, 'on_road_updated')
+	if res == null:
+		fail_test("No signal emitted at all to fetch")
+	else:
+		var segments_updated = res[0]
+		assert_eq(len(segments_updated), 1, "Single segment created")
+		assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")
+
+	# Validate the other connection is there too now.
+	var expected_p2_prior = p2.get_path_to(p1)
+	assert_eq(p2.prior_pt_init, expected_p2_prior, "Check reverse connection made")
+
+
+func test_junction_validate_init_path_just_removed():
+	var network = add_child_autofree(RoadNetwork.new())
+	network.auto_refresh = false
+
+	var points = create_unconnected_network(network)
+	var p1 = points[0]
+	var p2 = points[1]
+
+	# The change which should trigger an auto path fix and thus a signal
+	p1.next_pt_init = p1.get_path_to(p2)
+	p2.prior_pt_init = p2.get_path_to(p1)
+
+	# Trigger build.
+	network.auto_refresh = true
+	network.rebuild_segments(true)
+
+	# should have a child segment now, TODO assert this.
+	watch_signals(network)
+
+	# The main test line: ie clear it out during auto refresh.
+	# Should trigger _autofix_noncyclic_references.
+	p1.next_pt_init = ""
+
+	# Validate that the road segment was deleted
+	# No args to parse, so only removal
+	assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")
+
+	var ref_path:NodePath = ""
+	assert_eq(p1.next_pt_init, ref_path, "P1's next should have stayed cleared")
+	assert_eq(p2.prior_pt_init, ref_path, "P2's prior point should be cleared")
+
+
+func test_on_road_updated_pt_transform():
+	var network = add_child_autofree(RoadNetwork.new())
+	network.auto_refresh = false
+
+	var points = create_unconnected_network(network)
+	var p1 = points[0]
+	var p2 = points[1]
+
+	# Connect the two together
+	p1.next_pt_init = p1.get_path_to(p2)
+	p2.prior_pt_init = p2.get_path_to(p1)
+
+	network.auto_refresh = true
+	# should have a child segment now, TODO assert this.
+	watch_signals(network)
+
+	# Trigger a transform equivalent to moving the point in the viewport.
+	# Changing global_transform doesn't work since it checks for editor,
+	# so we need to directly call the on_transform function.
+	p1.on_transform()
+
+	# Validate that the road segment was generated (based on signal emission)
+	var res = get_signal_parameters(network, 'on_road_updated')
+	if res == null:
+		fail_test("No signal emitted at all to fetch")
+	else:
+		var segments_updated = res[0]
+		assert_eq(len(segments_updated), 1, "Single segment created")
+		assert_signal_emit_count(network, "on_road_updated", 1, "One signal call")


### PR DESCRIPTION
Right now, if someone tries to manually update the reference paths of one RoadPoint to another (while auto refresh is on), it won't work at all, because it fails validations for proper connections (as only one road point will connect to the other, and not the reverse as it hasn't been updated yet).

What we should do is, in the on prior/next point init function, do the call to see if we can properly auto-connect to the target roadpoint in question if it has an equally missing next "slot". And thereafter, ensure on making roadpoint updates that the changes of prior on one point are reflected as the next on the other, and vice versa, to make them properly bidirectional lists.

Demo video of the net result of this change:

https://github.com/TheDuckCow/godot-road-generator/assets/2958461/9bb9e25d-467b-47cf-b89e-184f3439e373


