### PR TITLE
Persistent lane width and improved easing

### DIFF
--- a/addons/road-generator/plugin.cfg
+++ b/addons/road-generator/plugin.cfg
@@ -3,5 +3,5 @@
 name="road-generator"
 description="Plugin for creating 3D highways and streets for car games."
 author="Moo-Ack! Productions (TheDuckCow)"
-version="0.3.2"
+version="0.3.3"
 script="plugin.gd"

--- a/addons/road-generator/road_network.gd
+++ b/addons/road-generator/road_network.gd
@@ -64,7 +64,7 @@ func _ready():
 
 
 func _ui_refresh_set(value):
-	if auto_refresh and not _dirty:
+	if value and not _dirty:
 		_dirty = true
 		call_deferred("_dirty_rebuild_deferred")
 	auto_refresh = value

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -376,11 +376,9 @@ func _normal_for_offset(curve: Curve3D, sample_position: float) -> Vector3:
 	return _normal_for_offset_eased(curve, sample_position)
 	# return _normal_for_offset_legacy(curve, sample_position)
 
-func _normal_for_offset_legacy(curve: Curve3D, sample_position: float) -> Vector3:
 
-	# TOOD: See about ensuring width is strictly always lane width and not
-	# made less or more during curvey parts of road (even if that means
-	# resulting in overlapping meshes).
+## Alternate method which doesn't guarentee consistent lane width.
+func _normal_for_offset_legacy(curve: Curve3D, sample_position: float) -> Vector3:
 	var loop_point: Transform
 	var _smooth_amount := -1.5
 	var interp_amount: float = ease(sample_position, _smooth_amount)
@@ -391,8 +389,9 @@ func _normal_for_offset_legacy(curve: Curve3D, sample_position: float) -> Vector
 	return loop_point.basis.x
 
 
+## Enforce consistent lane width, at the cost of overlapping geometry.
 func _normal_for_offset_eased(curve: Curve3D, sample_position: float) -> Vector3:
-	var offset_amount = 0.002 # maybe base it on lane width..?
+	var offset_amount = 0.002 # TODO: Consider basing this on lane width.
 	var start_offset: float
 	var end_offset: float
 	if sample_position <= 0.0 + offset_amount:
@@ -413,7 +412,6 @@ func _normal_for_offset_eased(curve: Curve3D, sample_position: float) -> Vector3
 		sample_position)
 	var normal = up_vec.cross(tangent)
 	return normal.normalized()
-
 
 
 func _build_geo():

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -388,24 +388,22 @@ func _normal_for_offset_current(curve: Curve3D, sample_position: float) -> Vecto
 
 
 func _normal_for_offset_nonsmoothed(curve: Curve3D, sample_position: float) -> Vector3:
-	var offset_amount = 0.1 # maybe base it on lane width..?
+	var offset_amount = 0.002 # maybe base it on lane width..?
 	var start_offset: float
 	var end_offset: float
-	if sample_position >= 1.0 - offset_amount * 0.5:
-		start_offset = sample_position - offset_amount
-		end_offset = sample_position
-	elif sample_position <= 0.0 + offset_amount:
-		start_offset = sample_position
-		end_offset = sample_position + offset_amount
+	if sample_position <= 0.0 + offset_amount:
+		return start_point.global_transform.basis.x
+	elif sample_position >= 1.0 - offset_amount * 0.5:
+		return end_point.global_transform.basis.x
 	else:
 		start_offset = sample_position - offset_amount * 0.5
 		end_offset = sample_position + offset_amount * 0.5
 
 	var pt1 := curve.interpolate_baked(start_offset * curve.get_baked_length())
 	var pt2 := curve.interpolate_baked(end_offset * curve.get_baked_length())
-	var fwd_vec := pt2 - pt1
-	var tilt = curve.interpolate_baked_up_vector(sample_position)
-	var normal = tilt.cross(fwd_vec)
+	var tangent := pt2 - pt1
+	var up_vec = curve.interpolate_baked_up_vector(sample_position)
+	var normal = up_vec.cross(tangent)
 	return normal.normalized()
 
 

--- a/addons/road-generator/road_segment.gd
+++ b/addons/road-generator/road_segment.gd
@@ -29,7 +29,10 @@ var network # The managing network node for this road segment (grandparent).
 
 var is_dirty := true
 var low_poly := false  # If true, then was (or will be) generated as low poly.
-var smooth_amount := -1.5  # Ease in/out smooth, used with ease built function
+
+# Reference:
+# https://raw.githubusercontent.com/godotengine/godot-docs/3.5/img/ease_cheatsheet.png
+var smooth_amount := -2  # Ease in/out smooth, used with ease built function
 
 
 func _init(_network):
@@ -370,16 +373,17 @@ func _update_curve():
 ## Returns: Normalized Vector3
 func _normal_for_offset(curve: Curve3D, sample_position: float) -> Vector3:
 	# Calculate interpolation amount for curve sample point
-	return _normal_for_offset_nonsmoothed(curve, sample_position)
-	# return _normal_for_offset_current(curve, sample_position)
+	return _normal_for_offset_eased(curve, sample_position)
+	# return _normal_for_offset_legacy(curve, sample_position)
 
-func _normal_for_offset_current(curve: Curve3D, sample_position: float) -> Vector3:
+func _normal_for_offset_legacy(curve: Curve3D, sample_position: float) -> Vector3:
 
 	# TOOD: See about ensuring width is strictly always lane width and not
 	# made less or more during curvey parts of road (even if that means
 	# resulting in overlapping meshes).
 	var loop_point: Transform
-	var interp_amount: float = ease(sample_position, smooth_amount)
+	var _smooth_amount := -1.5
+	var interp_amount: float = ease(sample_position, _smooth_amount)
 
 	# Calculate loop transform
 	loop_point.basis = start_point.global_transform.basis
@@ -387,7 +391,7 @@ func _normal_for_offset_current(curve: Curve3D, sample_position: float) -> Vecto
 	return loop_point.basis.x
 
 
-func _normal_for_offset_nonsmoothed(curve: Curve3D, sample_position: float) -> Vector3:
+func _normal_for_offset_eased(curve: Curve3D, sample_position: float) -> Vector3:
 	var offset_amount = 0.002 # maybe base it on lane width..?
 	var start_offset: float
 	var end_offset: float


### PR DESCRIPTION
All tests pass:

`12 passed 0 failed.  Tests finished in 1.3s`

See the change (going from the old way to the new way). This is essentially taking the best of both worlds (in terms of approaches we've tried so far) by having easing, while also ensuring consistent lane width.

![changed](https://github.com/TheDuckCow/godot-road-generator/assets/2958461/7d03e4f4-66eb-4a17-a6ce-44ae4f041693)

Need to do further checks to ensure the easing is also applied as necessary to the RoadLanes.
