### PR TITLE
Add "Refresh roads" and "select network" buttons to Create menu.

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -100,6 +100,10 @@ func _show_road_toolbar() -> void:
 	if not _road_toolbar.get_parent():
 		add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, _road_toolbar)
 		_road_toolbar.create_menu.connect(
+			"regenerate_pressed", self, "_on_regenerate_pressed")
+		_road_toolbar.create_menu.connect(
+			"select_network_pressed", self, "_on_select_network_pressed")
+		_road_toolbar.create_menu.connect(
 			"create_2x2_road", self, "_create_2x2_road_pressed")
 
 
@@ -110,27 +114,41 @@ func _hide_road_toolbar() -> void:
 			"create_2x2_road", self, "_create_2x2_road_pressed")
 
 
-## Adds a 2x2 RoadSegment to the Scene
-func _create_2x2_road_pressed():
-	var undo_redo = get_undo_redo()
+func get_network_from_selection():
 	var selected_node = get_selected_node(_eds.get_selected_nodes())
-
 	var t_network = null
 
 	if not is_instance_valid(selected_node):
 		push_error("Invalid selection to add road segment")
 		return
 	if selected_node is RoadNetwork:
-		t_network = selected_node
+		return selected_node
 	elif selected_node is RoadPoint:
 		if is_instance_valid(selected_node.network):
-			t_network = selected_node.network
+			return selected_node.network
 		else:
 			push_error("Invalid network for roadpoint")
 			return
 	else:
 		push_error("Invalid selection for adding new road segments")
 		return
+
+
+func _on_regenerate_pressed():
+	var t_network = get_network_from_selection()
+	t_network.rebuild_segments(true)
+
+
+func _on_select_network_pressed():
+	var t_network = get_network_from_selection()
+	_edi.get_selection().clear()
+	_edi.get_selection().add_node(t_network)
+
+
+## Adds a 2x2 RoadSegment to the Scene
+func _create_2x2_road_pressed():
+	var undo_redo = get_undo_redo()
+	var t_network = get_network_from_selection()
 
 	if t_network == null:
 		push_error("Could not get RoadNetwork object")

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -111,7 +111,12 @@ func _hide_road_toolbar() -> void:
 	if _road_toolbar.get_parent():
 		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _road_toolbar)
 		_road_toolbar.create_menu.disconnect(
+			"regenerate_pressed", self, "_on_regenerate_pressed")
+		_road_toolbar.create_menu.disconnect(
+			"select_network_pressed", self, "_on_select_network_pressed")
+		_road_toolbar.create_menu.disconnect(
 			"create_2x2_road", self, "_create_2x2_road_pressed")
+
 
 
 func get_network_from_selection():

--- a/addons/road-generator/ui/road_toolbar.tscn
+++ b/addons/road-generator/ui/road_toolbar.tscn
@@ -10,5 +10,5 @@ script = ExtResource( 1 )
 margin_right = 53.0
 margin_bottom = 20.0
 text = "Create"
-items = [ "2x2 road", null, 0, false, false, 0, 0, null, "", false ]
+items = [ "Refresh roads", null, 0, false, false, 0, 0, null, "", false, "Select network", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "2x2 road", null, 0, false, false, 2, 0, null, "", false ]
 script = ExtResource( 2 )

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -1,16 +1,25 @@
 tool
 extends MenuButton
 
+signal regenerate_pressed
+signal select_network_pressed
 signal create_2x2_road
 
-enum CREATE_MENU {
+enum CreateMenu {
+	REGENERATE,
+	SELECT_NETWORK,
 	TWO_X_TWO,
 }
 
 func _enter_tree() -> void:
 	get_popup().clear()
 	get_popup().connect("id_pressed", self, "_create_menu_item_clicked")
-	get_popup().add_item("2x2 road")
+
+	get_popup().add_item("Refresh roads", CreateMenu.REGENERATE)
+	get_popup().add_item("Select network", CreateMenu.SELECT_NETWORK)
+
+	get_popup().add_separator()
+	get_popup().add_item("2x2 road", CreateMenu.TWO_X_TWO)
 
 func _exit_tree() -> void:
 	get_popup().disconnect("id_pressed", self, "_create_menu_item_clicked")
@@ -18,5 +27,9 @@ func _exit_tree() -> void:
 
 func _create_menu_item_clicked(id: int) -> void:
 	match id:
-		CREATE_MENU.TWO_X_TWO:
+		CreateMenu.REGENERATE:
+			emit_signal("regenerate_pressed")
+		CreateMenu.SELECT_NETWORK:
+			emit_signal("select_network_pressed")
+		CreateMenu.TWO_X_TWO:
 			emit_signal("create_2x2_road")


### PR DESCRIPTION
12 passed 0 failed.  Tests finished in 1.4s

This makes it more convenient to work with the plugin, especially if you need to disable automatic updates due to large road networks (and thus have "auto refresh" turned off on the RoadNetwork)