### PR TITLE
Identify container edges

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -29,12 +29,12 @@ export(bool) var debug := false
 export(bool) var draw_lanes_editor := false setget _set_draw_lanes_editor, _get_draw_lanes_editor
 export(bool) var draw_lanes_game := false setget _set_draw_lanes_game, _get_draw_lanes_game
 
-## Auto generated exposed variables dused to conneect this RoadContainer to
+## Auto generated exposed variables used to connect this RoadContainer to
 ## another RoadContainer.
 ## These should *never* be manually adjusted, they are only export vars to
 ## facilitate the connection of RoadContainers needing to connect to points in
 ## different scenes, where said connection needs to be established in the editor
-export(Array, NodePath) var edge_containers # Paths to other containers, relative to this contianer
+export(Array, NodePath) var edge_containers # Paths to other containers, relative to this container
 export(Array, NodePath) var edge_rp_targets  # Node paths within other containers, relative to the *target* container (not self here)
 export(Array, String) var edge_rp_target_dirs  # Bools, true = next_init
 export(Array, NodePath) var edge_rp_locals  # Node paths within this container, relative to this container
@@ -258,7 +258,7 @@ func update_edges():
 		#var dir := 0  # -1 is for prior init, 1 is for next init
 
 		for this_dir in [-1, 1]:
-			var is_edge = false
+			var is_edge := false
 			var dir_pt_init
 			if this_dir == -1:
 				dir_pt_init = pt.prior_pt_init
@@ -266,16 +266,15 @@ func update_edges():
 				dir_pt_init = pt.next_pt_init
 
 			if dir_pt_init == "":
-				# Set this rp to indicate it's next point is the container,
+				# Set this rp to indicate its next point is the container,
 				# making it aware it is an "edge".
-				print("%s edge by one %s" % [pt.name, this_dir])
 				is_edge = true
 			elif dir_pt_init == pt.get_path_to(self):
-				print("%s edge by linkedto container %s" % [pt.name, this_dir])
 				# Already self identified as an edge as connected to this container
 				is_edge = true
 			else:
-				print("%s not edge dir %s" % [pt.name, this_dir])
+				# Must be 'interior' as it is connected but not to container
+				is_edge = false
 
 			if is_edge == false:
 				continue
@@ -292,7 +291,6 @@ func update_edges():
 					continue
 				idx = _find_idx
 				break
-			print("Foudn pre-existing match", idx)
 
 			if idx >= 0:
 				_tmp_containers.append(edge_containers[idx])

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -31,10 +31,9 @@ export(bool) var draw_lanes_game := false setget _set_draw_lanes_game, _get_draw
 
 ## Auto generated exposed variables dused to conneect this RoadContainer to
 ## another RoadContainer.
-# connection_nodepaths = list of Nodepaths to pther RoadContainers, to indicate
-#   which should be connected to this indicie's roadpoint.
-# edge_indicies = list of indicies, to indicate which index of the *target's*
-#   children list of RoadPoint to use
+## These should *never* be manually adjusted, they are only export vars to
+## facilitate the connection of RoadContainers needing to connect to points in
+## different scenes, where said connection needs to be established in the editor
 export(Array, NodePath) var edge_containers # Paths to other containers, relative to this contianer
 export(Array, NodePath) var edge_rp_targets  # Node paths within other containers, relative to the *target* container (not self here)
 export(Array, String) var edge_rp_target_dirs  # Bools, true = next_init

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -22,27 +22,27 @@ export(bool) var create_geo := true setget _set_create_geo
 # If create_geo is true, then whether to reduce geo mid transform.
 export(bool) var use_lowpoly_preview:bool = false
 
-## Auto generated exposed variables dused to conneect this RoadContainer to
-## another RoadContainer.
-# connection_nodepaths = list of Nodepaths to pther RoadContainers, to indicate
-#   which should be connected to this indicie's roadpoint.
-# edge_indicies = list of indicies, to indicate which index of the *target's*
-#   children list of RoadPoint to use
-export(Array, NodePath) var edge_containers # Paths to other containers
-export(Array, String) var edge_rp_targets  # Node names within other containers
-export(Array, String) var edge_rp_target_dirs  # Bools, true = next_init
-export(Array, String) var edge_rp_locals  # Node names within this container
-export(Array, String) var edge_rp_local_dirs  # Bools, true = next_init
-
-# Mapping maintained of individual segments and their corresponding resources.
-var segid_map = {}
-
 export(bool) var generate_ai_lanes := false setget _set_gen_ai_lanes
 export(String) var ai_lane_group := "road_lanes" setget _set_ai_lane_group
 
 export(bool) var debug := false
 export(bool) var draw_lanes_editor := false setget _set_draw_lanes_editor, _get_draw_lanes_editor
 export(bool) var draw_lanes_game := false setget _set_draw_lanes_game, _get_draw_lanes_game
+
+## Auto generated exposed variables dused to conneect this RoadContainer to
+## another RoadContainer.
+# connection_nodepaths = list of Nodepaths to pther RoadContainers, to indicate
+#   which should be connected to this indicie's roadpoint.
+# edge_indicies = list of indicies, to indicate which index of the *target's*
+#   children list of RoadPoint to use
+export(Array, NodePath) var edge_containers # Paths to other containers, relative to this contianer
+export(Array, NodePath) var edge_rp_targets  # Node paths within other containers, relative to the *target* container (not self here)
+export(Array, String) var edge_rp_target_dirs  # Bools, true = next_init
+export(Array, NodePath) var edge_rp_locals  # Node paths within this container, relative to this container
+export(Array, String) var edge_rp_local_dirs  # Bools, true = next_init
+
+# Mapping maintained of individual segments and their corresponding resources.
+var segid_map = {}
 
 # Non-exposed developer control, which allows showing all nodes (including generated) in the scene
 # tree. Typcially we don't want to do this, so that users don't accidentally start adding nodes
@@ -281,13 +281,13 @@ func update_edges():
 			if is_edge == false:
 				continue
 
-			_tmp_rp_locals.append(pt.name)
+			_tmp_rp_locals.append(self.get_path_to(pt))
 			_tmp_rp_local_dirs.append(this_dir)
 
 			# Lookup pre-existing connections to apply, match of name + dir
 			var idx = -1
 			for _find_idx in len(edge_rp_locals):
-				if edge_rp_locals[_find_idx] != pt.name:
+				if edge_rp_locals[_find_idx] != self.get_path_to(pt):
 					continue
 				if edge_rp_local_dirs[_find_idx] != this_dir:
 					continue

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -418,6 +418,8 @@ func _create_2x2_road_do(t_container: RoadContainer, single_point: bool):
 	else:
 		set_selection(first_road_point)
 
+	t_container.update_edges() # Since we updated a roadpoint name after adding.
+
 
 func _create_2x2_road_undo(selected_node: RoadContainer, single_point: bool) -> void:
 	# Make a likely bad assumption that the last two children are the ones to

--- a/test/unit/test_road_container.gd
+++ b/test/unit/test_road_container.gd
@@ -47,11 +47,11 @@ func validate_edges_equal_size(container):
 
 	# now also validate that all local children name match actual names in editor,
 	# since we depend on node names for making connections.
-	var ch_names = []
+	var ch_paths = []
 	for ch in container.get_children():
-		ch_names.append(ch.name)
-	for rp_name in container.edge_rp_locals:
-		assert_has(ch_names, rp_name, "edge_rp_local name not matching any child")
+		ch_paths.append(container.get_path_to(ch))
+	for rp_path in container.edge_rp_locals:
+		assert_has(ch_paths, rp_path, "edge_rp_local name not matching any child")
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
As a stepping stone to allow for the connection of different RoadContainers to other RoadContainers, this PR establishes the concept of "edge RoadPoints".

Whenever adding a new RoadPoint or updating connections of a RoadPoint, the `RoadContainer.update_edges()` function on the given RoadContainer instance will trigger. The result is the update of 5 parallel export var arrays. While it seems excessive, this seems to be the most stable way to ensure bidirectional fetching of data. Basically, these export vars allow the equivalent of a RoadPoint of one container to set its next_pt_init to a RoadPoint on another, but using their corresponding RoadContainers as middlemen. Relevant snippet from the code for more

```gdscript
## Auto generated exposed variables used to connect this RoadContainer to
## another RoadContainer.
## These should *never* be manually adjusted, they are only export vars to
## facilitate the connection of RoadContainers needing to connect to points in
## different scenes, where said connection needs to be established in the editor
export(Array, NodePath) var edge_containers # Paths to other containers, relative to this container
export(Array, NodePath) var edge_rp_targets  # Node paths within other containers, relative to the *target* container (not self here)
export(Array, String) var edge_rp_target_dirs  # Bools, true = next_init
export(Array, NodePath) var edge_rp_locals  # Node paths within this container, relative to this container
export(Array, String) var edge_rp_local_dirs  # Bools, true = next_init
```

Relates to #122 

All tests pass, including new ones added to ensure auto updating of these export vars.