### PR TITLE
Establish edit modes

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -208,6 +208,8 @@ func get_manager(): # -> Optional[RoadManager]
 	var _this_manager = null
 	var _last_par = get_parent()
 	while true:
+		if _last_par == null:
+			break
 		if _last_par.get_path() == "/root":
 			break
 		if _last_par.has_method("is_road_manager"):

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -393,9 +393,7 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 	# but doing this for simplicity now.
 
 	var sid = "%s-%s" % [pt1.get_instance_id(), pt2.get_instance_id()]
-	if sid in segid_map:
-		if not is_instance_valid(segid_map[sid]):
-			push_error("Instance was not valid on sid: %s" % sid)
+	if sid in segid_map and is_instance_valid(segid_map[sid]):
 		var was_rebuilt = segid_map[sid].check_rebuild()
 		return [was_rebuilt, segid_map[sid]]
 	else:

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -61,6 +61,8 @@ export(float) var shoulder_width_l := 2.0 setget _set_shoulder_width_l, _get_sho
 export(float) var shoulder_width_r := 2.0 setget _set_shoulder_width_r, _get_shoulder_width_r
 # Profile: x: how far out the gutter goes, y: how far down to clip.
 export(Vector2) var gutter_profile := Vector2(0.5, -0.5) setget _set_profile, _get_profile
+
+# Path to next/prior RoadPoint, relative to this RoadPoint itself.
 export(NodePath) var prior_pt_init setget _set_prior_pt, _get_prior_pt
 export(NodePath) var next_pt_init setget _set_next_pt, _get_next_pt
 # Handle magniture
@@ -493,12 +495,7 @@ func add_road_point(new_road_point: RoadPoint, pt_init):
 	var basis_z = new_road_point.transform.basis.z
 
 	new_road_point.name = increment_name(name)
-
-	# If container is scene root, assign directly.
-	if get_tree().get_edited_scene_root() == container:
-		new_road_point.set_owner(container)
-	else:
-		new_road_point.set_owner(container.owner)
+	new_road_point.set_owner(get_tree().get_edited_scene_root())
 
 	var refresh = container._auto_refresh
 	container._auto_refresh = false

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -633,7 +633,10 @@ func _autofix_noncyclic_references(
 	else:
 		# we are in clearing mode, so use the value that was just overwritten
 		is_clearing = true
-		point = get_node(old_point_path)
+		var connection = get_node(old_point_path)
+		if connection.has_method("is_road_container"):
+			return # Nothing further to update now.
+		point = connection
 
 	if not is_instance_valid(point):
 		# Shouldn't get to this branch, we check valid upstream first!

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -17,6 +17,9 @@ var _edi = get_editor_interface()
 var _eds = get_editor_interface().get_selection()
 var _last_point: Node
 var _last_lane: Node
+
+var _press_init_pos: Vector2
+
 var new_selection: RoadPoint # Reference for passing selected node
 
 
@@ -74,21 +77,100 @@ func forward_spatial_draw_over_viewport(overlay):
 
 ## Handle or pass on event in the 3D editor
 ## If return true, consumes the event, otherwise forwards event
-func forward_spatial_gui_input(camera: Camera, event: InputEvent)->bool:
-	if event is InputEventMouseButton:
-		# Event triggers on both press and release. Ignore press and only act on
-		# release. Also, ignore right-click and middle-click.
-		if event.button_index == BUTTON_LEFT and not event.pressed:
-			# Shoot a ray and see if it hits anything
-			var point = get_nearest_road_point(camera, event.position)
-			if point:
-				new_selection = point
-	return false # Return false to not consume th event
+func forward_spatial_gui_input(camera: Camera, event: InputEvent) -> bool:
+	var ret := false
+
+	var selected = get_selected_node()
+	var relevant = is_road_node(selected)
+
+	if not relevant or tool_mode == _road_toolbar.InputMode.SELECT:
+		ret = _handle_gui_select_mode(camera, event)
+	elif tool_mode == _road_toolbar.InputMode.ADD:
+		ret = _handle_gui_add_mode(camera, event)
+	elif tool_mode == _road_toolbar.InputMode.DELETE:
+		ret = _handle_gui_delete_mode(camera, event)
+
+	return ret
 
 
 # ------------------------------------------------------------------------------
 # Utilities
 # ------------------------------------------------------------------------------
+
+
+func is_road_node(node: Node) -> bool:
+	return (node is RoadPoint
+		or node is RoadContainer
+		or node is RoadManager
+		or node is RoadIntersection
+		or node is RoadLane)
+
+
+func _handle_gui_select_mode(camera: Camera, event: InputEvent) -> bool:
+	# Event triggers on both press and release. Ignore press and only act on
+	# release. Also, ignore right-click and middle-click.
+	if not event is InputEventMouseButton:
+		return false
+	if event.button_index == BUTTON_LEFT:
+
+		if event.pressed:
+			# Nothing done until click up, but detect initial position
+			# to differentiate between drags and direct clicks.
+			_press_init_pos = event.position
+			return false
+		elif _press_init_pos != event.position:
+			# TODO: possibly add min distance before treated as a drag
+			# (does built in godot have a tolerance before counted as a drag?)
+			return false  # Is a drag event
+
+		# Shoot a ray and see if it hits anything
+		var point = get_nearest_road_point(camera, event.position)
+		if point and not event.pressed:
+			set_selection(point)
+			_on_selection_changed()
+			return true
+	return false
+
+
+func _handle_gui_add_mode(camera: Camera, event: InputEvent) -> bool:
+	# if new click and isn't on top of or exaclty near another RP,
+	# then add a new one into the scene (with undo/redo support)
+	if event is InputEventMouseMotion:
+		# TODO: if pressed state, then use this to update the in/out mag handles
+		return true
+	if not event is InputEventMouseButton:
+		return false
+	if not event.button_index == BUTTON_LEFT:
+		return false
+	if event.pressed:
+		var selection = get_selected_node()
+		var res := get_click_point_with_context(camera, event.position, selection)
+		var pos:Vector3 = res[0]
+		var nrm:Vector3 = res[1]
+
+		# TODO: check if this is adding a new road, or connecting an existing
+
+		# TODO: if there's no good response given back, then we could instead
+		# pass in the most relevant current context selection so it at least uses that plane as
+		# a reference (e.g. use the same height, maybe even assume flat so it maintains hills etc?)
+		# Selection input could be roadpoint, container, or manager (manager would just import
+		# xyz point on the plane facing the camera.
+		_add_next_rp_on_click(pos, nrm, selection)
+	return true
+
+
+func _handle_gui_delete_mode(camera: Camera, event: InputEvent) -> bool:
+	if event is InputEventMouseMotion:
+		return true
+	if not event is InputEventMouseButton:
+		return false
+	if not event.button_index == BUTTON_LEFT:
+		return false
+	if event.pressed:
+		# Do an immediate delete
+		var point = get_nearest_road_point(camera, event.position)
+		_delete_rp_on_click(point)
+	return true
 
 
 ## Render the editor indicators for RoadPoints and RoadLanes if selected.
@@ -115,12 +197,8 @@ func _on_selection_changed() -> void:
 
 	# Show the panel even if selection is scene root, but not if selection is a
 	# scene instance itself (non editable).
-	var eligible = (
-		selected_node is RoadPoint
-		or selected_node is RoadContainer
-		or selected_node is RoadManager
-		or selected_node is RoadIntersection
-		or selected_node is RoadLane)
+	# TOOD: Change show/hide to occur on button-release, for consistency with internal panels.
+	var eligible = is_road_node(selected_node)
 	var non_instance = (not selected_node.filename) or selected_node == get_tree().edited_scene_root
 	if eligible and non_instance:
 		_show_road_toolbar()
@@ -130,7 +208,8 @@ func _on_selection_changed() -> void:
 
 func _on_scene_changed(scene_root: Node) -> void:
 	var selected = get_selected_node()
-	if selected and (selected is RoadContainer or selected is RoadPoint):
+	var eligible = is_road_node(selected)
+	if selected and eligible:
 		_show_road_toolbar()
 	else:
 		_hide_road_toolbar()
@@ -140,7 +219,6 @@ func _on_scene_closed(_value) -> void:
 	_hide_road_toolbar()
 
 
-## Input is
 func _on_mode_change(_mode: int) -> void:
 	tool_mode = _mode  # Instance of RoadToolbar.InputMode
 
@@ -255,6 +333,76 @@ func get_nearest_road_point(camera: Camera, mouse_pos: Vector2)->RoadPoint:
 			return nearest_point
 
 
+## Convert a given click to the nearest, best fitting 3d pos + normal for click.
+##
+## Includes selection node so that if there's no intersection made, we can still
+## raycast onto the xz  or screen xy local plane of the object clicked on.
+##
+## Returns: [Position, Normal]
+func get_click_point_with_context(camera: Camera, mouse_pos: Vector2, selection: Node) -> Array:
+	var src = camera.project_ray_origin(mouse_pos)
+	var nrm = camera.project_ray_normal(mouse_pos)
+	var dist = camera.far
+
+	var space_state =  get_viewport().world.direct_space_state
+	# intersect_ray(from, to, exclude, collision_mask, collide_with_bodies, collide_with_areas)
+	# Unfortunately, must have collide with areas off. And this doesn't pick
+	# up collisions with objects that don't have collisions already added, making
+	# it not as convinient for viewport manipulation.
+	var intersect = space_state.intersect_ray(
+		src, src + nrm * dist, [], 1, true, false)
+
+	if not intersect.empty():
+		return [intersect["position"], intersect["normal"]]
+
+	# if we couldn't directly intersect with something, then place the next
+	# point in the same plane as the initial selection which is also facing
+	# the camera, or in the plane of that object's
+
+	var use_obj_plane = selection is RoadPoint
+
+	# Points used to define offset used to construct a valid Plane
+	var point_y_offset:Vector3
+	var point_x_offset:Vector3
+
+	if use_obj_plane:
+		# Stick within the current selection's xy plane
+		point_y_offset = selection.global_transform.basis.z
+		point_x_offset = selection.global_transform.basis.x
+	else:
+		# Use the camera plane instead
+		point_y_offset = camera.global_transform.basis.y
+		point_x_offset = camera.global_transform.basis.x
+
+	# the normal is the camera.global_transform.basis.z
+	# the reference position is selection.global_transform.origin
+	# which already defines the plane in quesiton.
+	var plane_nrm = -camera.global_transform.basis.z
+	var ref_pt = selection.global_transform.origin
+	var plane = Plane(
+		ref_pt,
+		ref_pt + point_y_offset,
+		ref_pt + point_x_offset)
+
+	var hit_pt = plane.intersects_ray(src, nrm)
+	var up = selection.global_transform.basis.y
+
+	if hit_pt == null:
+		point_y_offset = camera.global_transform.basis.y
+		point_x_offset = camera.global_transform.basis.x
+		plane = Plane(
+			ref_pt,
+			ref_pt + point_y_offset,
+			ref_pt + point_x_offset)
+		hit_pt = plane.intersects_ray(src, nrm)
+		up = selection.global_transform.basis.y
+
+	# TODO: Finally, detect if the point is behind or in front;
+	# if behind, then skip action.
+
+	return [hit_pt, up]
+
+
 func handles(object: Object):
 	# Must return "true" in order to use "forward_spatial_gui_input".
 	return true
@@ -364,7 +512,6 @@ func _create_road_container_do(t_manager: RoadManager, init_sel: Node) -> void:
 	set_selection(t_container)
 
 
-
 func _create_road_container_undo(selected_node: Node, init_sel: Node) -> void:
 	# Make a likely bad assumption that the last child is the one to
 	# be undone, but this is likely quite flakey.
@@ -376,6 +523,237 @@ func _create_road_container_undo(selected_node: Node, init_sel: Node) -> void:
 
 	if initial_children[-1] is RoadContainer:
 		initial_children[-1].queue_free()
+
+
+func _add_next_rp_on_click(pos: Vector3, nrm: Vector3, selection: Node) -> void:
+	var undo_redo = get_undo_redo()
+
+	if not is_instance_valid(selection):
+		push_error("Invalid selection selection, not valid node")
+		return
+
+	var parent: Node
+	var _sel: Node
+	var add_container = false
+	if selection is RoadPoint:
+		parent = selection.get_parent()
+		if selection.next_pt_init and selection.prior_pt_init:
+			print("Fully connected already")
+			# already fully connected, so for now add as just a standalone pt
+			# TODO: In the future, this should create an intersection.
+			_sel = parent
+		else:
+			_sel = selection
+	elif selection is RoadContainer:
+		parent = selection
+		_sel = selection
+	# elif selection is RoadManager:
+	# add_container = true, but would need to somehow pass through reference
+	else: # RoadManager or
+		push_error("Invalid selection context, RoadContainer parent")
+		return
+
+
+	undo_redo.create_action("Add next RoadPoint")
+	undo_redo.add_do_method(self, "_add_next_rp_on_click_do", pos, nrm, _sel, parent)
+	undo_redo.add_undo_method(self, "_add_next_rp_on_click_undo", pos, _sel, parent)
+	undo_redo.commit_action()
+
+
+func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, parent: Node) -> void:
+
+	var next_rp = RoadPoint.new()
+	var adding_to_next = true
+	var dirvec: Vector3 = pos - selection.global_transform.origin
+
+	if selection is RoadPoint:
+		next_rp.name = selection.name # TODO: increment
+
+		if selection.prior_pt_init and selection.next_pt_init:
+			parent.add_child(next_rp)
+			adding_to_next = true #??
+			# Both populated (assume valid), so place this as disconnected.
+			# TOOD in future: turn these all into an intersection?
+			# or make it a sort of "add point in middle" situation? ie somehwere
+			# along the curve of the existing road.
+		elif selection.prior_pt_init:
+			selection.add_road_point(next_rp, RoadPoint.PointInit.NEXT)
+			adding_to_next = true
+		elif selection.next_pt_init:
+			selection.add_road_point(next_rp, RoadPoint.PointInit.PRIOR)
+			adding_to_next = false
+		else:
+			# Neither connection exists, so pick next or prior based on basis.
+			var dir = selection.global_transform.basis.z.dot(dirvec)
+			var do_dir
+			if dir > 0:
+				do_dir = RoadPoint.PointInit.NEXT
+				adding_to_next = true
+			else:
+				do_dir = RoadPoint.PointInit.PRIOR
+				adding_to_next = false
+			selection.add_road_point(next_rp, do_dir)
+
+		# Update rotation along the initially picked axis.
+	elif selection is RoadContainer:
+		parent.add_child(next_rp)
+		next_rp.set_owner(get_tree().get_edited_scene_root())
+		next_rp.name = "RP_001"  # TODO: define this in some central area.
+		next_rp.traffic_dir = [
+			RoadPoint.LaneDir.REVERSE,
+			RoadPoint.LaneDir.REVERSE,
+			RoadPoint.LaneDir.FORWARD,
+			RoadPoint.LaneDir.FORWARD
+		]
+		next_rp.auto_lanes = true
+
+	# Make the road visible halfway above the ground by the gutter height amount.
+	var half_gutter: float = -0.5 * next_rp.gutter_profile.y
+	next_rp.global_transform.origin = pos + nrm * half_gutter
+
+	# Rotate this rp towards the initial selected node
+	if selection is RoadPoint:
+		var look_pos = selection.global_transform.origin
+		if not adding_to_next:
+			# Essentially flip the look 180 so it's not twisted around.
+			print("Flipping dir")
+			look_pos += 2 * dirvec
+		next_rp.look_at(look_pos, nrm)
+
+	set_selection(next_rp)
+
+
+## Assume, potentially badly, that last node is the one to delete
+func _add_next_rp_on_click_undo(pos, selection, parent: Node) -> void:
+	var initial_children = parent.get_children()
+	if len(initial_children) < 1:
+		return
+
+	var prior_selection
+	var was_next_pt: bool
+
+	# Each RoadPoint handles their own cleanup of connected RoadSegments.
+	if not initial_children[-1] is RoadPoint:
+		return
+	var added_node = initial_children[-1]
+	if added_node.prior_pt_init:
+		prior_selection = added_node.get_node(added_node.prior_pt_init)
+		was_next_pt = true
+	elif added_node.next_pt_init:
+		prior_selection = added_node.get_node(added_node.next_pt_init)
+		was_next_pt = false
+	initial_children[-1].queue_free()
+
+	if is_instance_valid(prior_selection):
+		# Clean up the new old connection.
+		if was_next_pt:
+			prior_selection.next_pt_init = ""
+		else:
+			prior_selection.prior_pt_init = ""
+		set_selection(prior_selection)
+
+
+func _delete_rp_on_click(selection: Node):
+	var undo_redo = get_undo_redo()
+
+	if not selection is RoadPoint:
+		push_error("Selection is not a RoadPoint")
+		return
+	elif not is_instance_valid(selection):
+		push_error("Invalid selection selection, not valid node")
+		return
+
+	var rp:RoadPoint = selection
+	var prior_rp = null
+	var prior_samedir: bool = true
+	var next_rp = null
+	var next_samedir: bool = true
+	var dissolve = false
+	if rp.prior_pt_init:
+		prior_rp = rp.get_node(rp.prior_pt_init)
+		if prior_rp.next_pt_init == prior_rp.get_path_to(rp):
+			prior_samedir = true
+		elif prior_rp.prior_pt_init == prior_rp.get_path_to(rp):
+			prior_samedir = false
+		else:
+			push_warning("Should be prior connected %s" % prior_rp.name)
+			pass # not actually mutually connected?
+	if rp.next_pt_init:
+		next_rp = rp.get_node(rp.next_pt_init)
+		if next_rp.prior_pt_init == next_rp.get_path_to(rp):
+			next_samedir = true
+		elif next_rp.prior_pt_init == next_rp.get_path_to(rp):
+			next_samedir = false
+		else:
+			push_warning("Should be prior connected %s" % next_rp.name)
+			pass # not actually mutually connected?
+	if prior_rp != null and next_rp != null:
+		dissolve = true
+
+	# "Do" steps
+
+	undo_redo.create_action("Dissolve RoadPoint")
+	undo_redo.add_do_property(rp, "prior_pt_init", "")
+	undo_redo.add_do_property(rp, "next_pt_init", "")
+	if dissolve:
+		print("Setting up for dissolve")
+		if prior_samedir:
+			undo_redo.add_do_property(prior_rp, "next_pt_init", "")
+			undo_redo.add_do_property(prior_rp, "next_pt_init", prior_rp.get_path_to(next_rp))
+		else:
+			undo_redo.add_do_property(prior_rp, "prior_pt_init", "")
+			undo_redo.add_do_property(prior_rp, "prior_pt_init", prior_rp.get_path_to(next_rp))
+		if next_samedir:
+			undo_redo.add_do_property(next_rp, "prior_pt_init", "")
+			undo_redo.add_do_property(next_rp, "prior_pt_init", next_rp.get_path_to(prior_rp))
+		else:
+			undo_redo.add_do_property(next_rp, "next_pt_init", "")
+			undo_redo.add_do_property(next_rp, "next_pt_init", next_rp.get_path_to(prior_rp))
+	if prior_rp:
+		undo_redo.add_do_method(self, "set_selection", prior_rp)
+	elif next_rp:
+		undo_redo.add_do_method(self, "set_selection", next_rp)
+	else:
+		undo_redo.add_do_method(self, "set_selection", rp.container)
+	undo_redo.add_do_method(rp.get_parent(), "remove_child", rp)  # Queuefree borqs with undoredo
+	# might need to do:
+	# container.remove_segment(seg)
+	if dissolve:
+		undo_redo.add_do_method(prior_rp, "on_transform")
+		undo_redo.add_do_method(next_rp, "on_transform") # Technicall only one should be needed
+
+	# ""Undo" steps
+
+	undo_redo.add_undo_reference(rp)
+	undo_redo.add_undo_method(rp.get_parent(), "add_child", rp, true) # TODO, improve positioning
+	# undo_redo.add_undo_method(rp.get_parent(), "move_child", rp, orig_pos), or use add_child_below_node instead
+	undo_redo.add_undo_method(rp, "set_owner", get_tree().get_edited_scene_root())
+	undo_redo.add_undo_property(rp, "prior_pt_init", rp.prior_pt_init)
+	undo_redo.add_undo_property(rp, "next_pt_init", rp.next_pt_init)
+	if dissolve:
+		if prior_samedir:
+			undo_redo.add_do_property(prior_rp, "next_pt_init", "")
+			undo_redo.add_do_property(prior_rp, "next_pt_init", prior_rp.next_pt_init)
+		else:
+			undo_redo.add_do_property(prior_rp, "prior_pt_init", "")
+			undo_redo.add_do_property(prior_rp, "prior_pt_init", prior_rp.prior_pt_init)
+		if next_samedir:
+			undo_redo.add_do_property(next_rp, "prior_pt_init", "")
+			undo_redo.add_do_property(next_rp, "prior_pt_init", next_rp.prior_pt_init)
+		else:
+			undo_redo.add_do_property(next_rp, "next_pt_init", "")
+			undo_redo.add_do_property(next_rp, "next_pt_init", next_rp.next_pt_init)
+		#undo_redo.add_undo_property(prior_rp, "prior_pt_init", prior_rp.prior_pt_init)
+		#undo_redo.add_undo_property(prior_rp, "next_pt_init", prior_rp.next_pt_init)
+		#undo_redo.add_undo_property(next_rp, "prior_pt_init", next_rp.prior_pt_init)
+		#undo_redo.add_undo_property(next_rp, "next_pt_init", next_rp.next_pt_init)
+	undo_redo.add_undo_method(self, "set_selection", rp)
+	undo_redo.add_undo_method(rp, "on_transform")
+	if dissolve:
+		undo_redo.add_undo_method(prior_rp, "on_transform")
+		undo_redo.add_undo_method(next_rp, "on_transform")
+
+	undo_redo.commit_action()
 
 
 ## Adds a single RoadPoint to the scene
@@ -429,10 +807,8 @@ func _create_2x2_road_do(t_container: RoadContainer, single_point: bool):
 		RoadPoint.LaneDir.FORWARD
 	]
 	first_road_point.auto_lanes = true
-	if get_tree().get_edited_scene_root() == t_container:
-		first_road_point.set_owner(t_container)
-	else:
-		first_road_point.set_owner(t_container.owner)
+	first_road_point.set_owner(get_tree().get_edited_scene_root())
+
 	var second_road_point = RoadPoint.new()
 	second_road_point.name = second_road_point.increment_name(default_name)
 	if single_point == false:

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -104,7 +104,9 @@ func _on_selection_changed() -> void:
 	var eligible = (
 		selected_node is RoadPoint
 		or selected_node is RoadContainer
-		or selected_node is RoadManager)
+		or selected_node is RoadManager
+		or selected_node is RoadIntersection
+		or selected_node is RoadLane)
 	var non_instance = (not selected_node.filename) or selected_node == get_tree().edited_scene_root
 	if eligible and non_instance:
 		_show_road_toolbar()

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -4,12 +4,15 @@ extends EditorPlugin
 
 const RoadPointGizmo = preload("res://addons/road-generator/ui/road_point_gizmo.gd")
 const RoadPointEdit = preload("res://addons/road-generator/ui/road_point_edit.gd")
+const RoadToolbar = preload("res://addons/road-generator/ui/road_toolbar.tscn")
 
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
+var tool_mode # = RoadToolbar.InputMode.SELECT
+
 var road_point_gizmo = RoadPointGizmo.new(self)
 var road_point_editor = RoadPointEdit.new(self)
-var _road_toolbar = preload("res://addons/road-generator/ui/road_toolbar.tscn").instance()
+var _road_toolbar # = RoadToolbar.instance()
 var _edi = get_editor_interface()
 var _eds = get_editor_interface().get_selection()
 var _last_point: Node
@@ -30,6 +33,17 @@ func _enter_tree():
 	#add_custom_type("RoadPoint", "Spatial", preload("road_point.gd"), preload("road_point.png"))
 	#add_custom_type("RoadContainer", "Spatial", preload("road_container.gd"), preload("road_segment.png"))
 	#add_custom_type("RoadLane", "Curve3d", preload("lane_segment.gd"), preload("road_segment.png"))
+
+	var gui = get_editor_interface().get_base_control()
+	_road_toolbar = RoadToolbar.instance()
+	_road_toolbar.gui = gui
+	_road_toolbar.update_icons()
+
+	# Update toolbar connections
+	_road_toolbar.connect("mode_changed", self, "_on_mode_change")
+
+	# Initial mode
+	tool_mode = _road_toolbar.InputMode.SELECT
 
 
 func _exit_tree():
@@ -124,6 +138,11 @@ func _on_scene_changed(scene_root: Node) -> void:
 
 func _on_scene_closed(_value) -> void:
 	_hide_road_toolbar()
+
+
+## Input is
+func _on_mode_change(_mode: int) -> void:
+	tool_mode = _mode  # Instance of RoadToolbar.InputMode
 
 
 func refresh() -> void:
@@ -247,6 +266,8 @@ func handles(object: Object):
 
 
 func _show_road_toolbar() -> void:
+	_road_toolbar.mode = tool_mode
+
 	if not _road_toolbar.get_parent():
 		add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, _road_toolbar)
 		_road_toolbar.selected_nodes = _eds.get_selected_nodes()

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -1,9 +1,74 @@
 tool
 extends HBoxContainer
 
-var create_menu
+signal mode_changed
+
+
+enum InputMode {
+	NONE,  # e.g. if a Road*Node is not selected.
+	SELECT,
+	ADD,
+	DELETE,
+}
+
+var select_mode:Button
+var add_mode:Button
+var delete_mode:Button
+var create_menu:MenuButton
 
 var selected_nodes: Array # of Nodes
+var gui # For fetching built in icons (not yet working)
+var mode # Passed in by parent
 
 func _enter_tree():
+	update_refs()
+
+	match mode:
+		InputMode.SELECT:
+			select_mode.pressed = true
+		InputMode.ADD:
+			add_mode.pressed = true
+		InputMode.DELETE:
+			delete_mode.pressed = true
+
+
+func update_refs():
+	select_mode = $select_mode
+	add_mode = $add_mode
+	delete_mode = $delete_mode
 	create_menu = $CreateMenu
+
+
+func update_icons():
+	update_refs()
+	var icn_curve_edit = gui.get_icon("CurveEdit", "EditorIcons")  # File icon_curve_edit.svg
+	var icn_curve_create = gui.get_icon("CurveCreate", "EditorIcons")  # File icon_curve_create.svg
+	var icn_curve_delete = gui.get_icon("CurveDelete", "EditorIcons")  # File icon_curve_close.svg
+
+	select_mode.icon = icn_curve_edit
+	add_mode.icon = icn_curve_create
+	delete_mode.icon = icn_curve_delete
+
+
+func _on_select_mode_pressed():
+	select_mode.pressed = true
+	add_mode.pressed = false
+	delete_mode.pressed = false
+	mode = InputMode.SELECT
+	emit_signal("mode_changed", mode)
+
+
+func _on_add_mode_pressed():
+	select_mode.pressed = false
+	add_mode.pressed = true
+	delete_mode.pressed = false
+	mode = InputMode.ADD
+	emit_signal("mode_changed", mode)
+
+
+func _on_delete_mode_pressed():
+	select_mode.pressed = false
+	add_mode.pressed = false
+	delete_mode.pressed = true
+	mode = InputMode.DELETE
+	emit_signal("mode_changed", mode)

--- a/addons/road-generator/ui/road_toolbar.tscn
+++ b/addons/road-generator/ui/road_toolbar.tscn
@@ -1,14 +1,43 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/road-generator/ui/road_toolbar.gd" type="Script" id=1]
 [ext_resource path="res://addons/road-generator/ui/road_toolbar_create_menu.gd" type="Script" id=2]
+[ext_resource path="res://addons/road-generator/resources/road_container.png" type="Texture" id=3]
+[ext_resource path="res://addons/road-generator/resources/road_point.png" type="Texture" id=4]
+[ext_resource path="res://addons/road-generator/resources/road_lane.png" type="Texture" id=5]
+[ext_resource path="res://addons/road-generator/ui/gizmo_blue_handle.png" type="Texture" id=6]
 
-[node name="HBoxContainer" type="HBoxContainer"]
+[node name="RoadToolbar" type="HBoxContainer"]
 script = ExtResource( 1 )
 
+[node name="select_mode" type="ToolButton" parent="."]
+margin_right = 28.0
+margin_bottom = 24.0
+toggle_mode = true
+icon = ExtResource( 6 )
+
+[node name="add_mode" type="ToolButton" parent="."]
+margin_left = 32.0
+margin_right = 60.0
+margin_bottom = 24.0
+toggle_mode = true
+icon = ExtResource( 6 )
+
+[node name="delete_mode" type="ToolButton" parent="."]
+margin_left = 64.0
+margin_right = 92.0
+margin_bottom = 24.0
+toggle_mode = true
+icon = ExtResource( 6 )
+
 [node name="CreateMenu" type="MenuButton" parent="."]
-margin_right = 53.0
-margin_bottom = 20.0
-text = "Create"
-items = [ "Refresh roads", null, 0, false, false, 0, 0, null, "", false, "Select container", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "RoadContainer", null, 0, false, false, 2, 0, null, "", false, "RoadPoint", null, 0, false, false, 3, 0, null, "", false, "RoadLane (AI path)", null, 0, false, false, 4, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "2x2 road", null, 0, false, false, 5, 0, null, "", false ]
+margin_left = 96.0
+margin_right = 146.0
+margin_bottom = 24.0
+text = "Roads"
+items = [ "Refresh roads", null, 0, false, false, 0, 0, null, "", false, "Select container", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "RoadContainer", ExtResource( 3 ), 0, false, false, 2, 0, null, "", false, "RoadPoint", ExtResource( 4 ), 0, false, false, 3, 0, null, "", false, "RoadLane (AI path)", ExtResource( 5 ), 0, false, false, 4, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "2x2 road", null, 0, false, false, 5, 0, null, "", false ]
 script = ExtResource( 2 )
+
+[connection signal="pressed" from="select_mode" to="." method="_on_select_mode_pressed"]
+[connection signal="pressed" from="add_mode" to="." method="_on_add_mode_pressed"]
+[connection signal="pressed" from="delete_mode" to="." method="_on_delete_mode_pressed"]


### PR DESCRIPTION
This demo video pretty much sums up the current state:

https://twitter.com/TheDuckCow/status/1713319965993169259

- Working toolbar modes for Add- and Dissolve-RoadPoints
- Some more gracefully handling when the RoadContainer has outdated seg_id's
- For add RoadPoint:
  - Will attempt to place onto a collision
  - If no collision mesh set up under mouse click, then will place the next point in the same plane as the prior selection
  - Functional undo/redo, though could be improved
- Dissolve point:
  - Not really working quite as hoped yet, but it is using technically a more stable undo/redo mechanism that keeps references in memory
  - Thankfully, the "undo" command does work reliably after dissolve, in the meantime users would get about the same and a more stable experience by deleting the node manually.

All tests passing:
`18 passed 0 failed.  Tests finished in 1.6s`