### PR TITLE
Improved defaults and size agnostic widget editing

### DIFF
--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -60,7 +60,7 @@ export(float) var lane_width := 4.0 setget _set_lane_width, _get_lane_width
 export(float) var shoulder_width_l := 2.0 setget _set_shoulder_width_l, _get_shoulder_width_l
 export(float) var shoulder_width_r := 2.0 setget _set_shoulder_width_r, _get_shoulder_width_r
 # Profile: x: how far out the gutter goes, y: how far down to clip.
-export(Vector2) var gutter_profile := Vector2(0.5, -0.5) setget _set_profile, _get_profile
+export(Vector2) var gutter_profile := Vector2(2.0, -2.0) setget _set_profile, _get_profile
 
 # Path to next/prior RoadPoint, relative to this RoadPoint itself.
 export(NodePath) var prior_pt_init setget _set_prior_pt, _get_prior_pt
@@ -496,6 +496,10 @@ func add_road_point(new_road_point: RoadPoint, pt_init):
 
 	new_road_point.name = increment_name(name)
 	new_road_point.set_owner(get_tree().get_edited_scene_root())
+
+	# Override the magnitude values, to better match the lane width.
+	new_road_point.prior_mag = lane_width * len(lanes)
+	new_road_point.next_mag = lane_width * len(lanes)
 
 	var refresh = container._auto_refresh
 	container._auto_refresh = false

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -8,11 +8,11 @@ const RoadToolbar = preload("res://addons/road-generator/ui/road_toolbar.tscn")
 
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
-var tool_mode # = RoadToolbar.InputMode.SELECT
+var tool_mode # Will be a value of: RoadToolbar.InputMode.SELECT
 
 var road_point_gizmo = RoadPointGizmo.new(self)
 var road_point_editor = RoadPointEdit.new(self)
-var _road_toolbar # = RoadToolbar.instance()
+var _road_toolbar
 var _edi = get_editor_interface()
 var _eds = get_editor_interface().get_selection()
 var _last_point: Node
@@ -549,7 +549,7 @@ func _add_next_rp_on_click(pos: Vector3, nrm: Vector3, selection: Node) -> void:
 		_sel = selection
 	# elif selection is RoadManager:
 	# add_container = true, but would need to somehow pass through reference
-	else: # RoadManager or
+	else: # RoadManager or RoadLane.
 		push_error("Invalid selection context, RoadContainer parent")
 		return
 

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -106,68 +106,69 @@ func redraw(gizmo) -> void:
 
 	gizmo.add_collision_triangles(collider_tri_mesh)
 	gizmo.add_mesh(collider, false, null, get_material("collider", gizmo))
-	if point.is_road_point_selected(_editor_selection):
+	if not point.is_road_point_selected(_editor_selection):
+		return
 
-		# Add mag handles
-		var handles = PoolVector3Array()
-		handles.push_back(Vector3(0, 0, -point.prior_mag))
-		handles.push_back(Vector3(0, 0, point.next_mag))
-		gizmo.add_handles(handles, get_material("handles", gizmo))
+	# Add mag handles
+	var handles = PoolVector3Array()
+	handles.push_back(Vector3(0, 0, -point.prior_mag))
+	handles.push_back(Vector3(0, 0, point.next_mag))
+	gizmo.add_handles(handles, get_material("handles", gizmo))
 
-		# Add width handles
-		var width_handles = PoolVector3Array()
-		var rev_width_idle = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
-		var fwd_width_idle = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
-		var rev_width_mag = point.rev_width_mag
-		var fwd_width_mag = point.fwd_width_mag
-		width_handles.push_back(Vector3(rev_width_mag, 0, 0))
-		width_handles.push_back(Vector3(fwd_width_mag, 0, 0))
-		gizmo.add_handles(width_handles, get_material("blue_handles", gizmo))
+	# Add width handles
+	var width_handles = PoolVector3Array()
+	var rev_width_idle = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
+	var fwd_width_idle = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
+	var rev_width_mag = point.rev_width_mag
+	var fwd_width_mag = point.fwd_width_mag
+	width_handles.push_back(Vector3(rev_width_mag, 0, 0))
+	width_handles.push_back(Vector3(fwd_width_mag, 0, 0))
+	gizmo.add_handles(width_handles, get_material("blue_handles", gizmo))
 
-		# Add lane widget
-		lane_widget.visible = true
-		lane_widget.transform = point.global_transform
-		arrow_left.translation = Vector3(rev_width_mag, 0, 0)
-		arrow_right.translation = Vector3(fwd_width_mag, 0, 0)
-		var line_width = fwd_width_mag - rev_width_mag
-		var line_pos = (rev_width_mag + fwd_width_mag) / 2
-		road_width_line_mesh.size = Vector3(line_width, 0.2, 0.2)
-		road_width_line.translation = Vector3(line_pos, 0, 0)
+	# Add lane widget
+	lane_widget.visible = true
+	lane_widget.transform = point.global_transform
+	arrow_left.translation = Vector3(rev_width_mag, 0, 0)
+	arrow_right.translation = Vector3(fwd_width_mag, 0, 0)
+	var line_width = fwd_width_mag - rev_width_mag
+	var line_pos = (rev_width_mag + fwd_width_mag) / 2
+	road_width_line_mesh.size = Vector3(line_width, 0.2, 0.2)
+	road_width_line.translation = Vector3(line_pos, 0, 0)
 
-		# Add lane dividers:
-		# Start placing dividers at side opposite of dragged handle. Draw
-		# dividers for real and potential lanes based on handle position. Re-use
-		# existing dividers. Create more dividers when needed. Hide dividers
-		# when not needed.
-		var lane_width = point.lane_width
-		var lane_count
-		var div_start_pos
-		var lane_width_offset = lane_width * LaneOffset
+	# Add lane dividers:
+	# Start placing dividers at side opposite of dragged handle. Draw
+	# dividers for real and potential lanes based on handle position. Re-use
+	# existing dividers. Create more dividers when needed. Hide dividers
+	# when not needed.
+	var lane_width = point.lane_width
+	var lane_count
+	var div_start_pos
+	var lane_width_offset = lane_width * LaneOffset
 
-		if rev_width_mag != rev_width_idle:
-			div_start_pos = fwd_width_idle - lane_width_offset
-			lane_count = floor(abs((fwd_width_idle - rev_width_mag + lane_width_offset) / lane_width)) + 1
-			lane_width = -lane_width
+	if rev_width_mag != rev_width_idle:
+		div_start_pos = fwd_width_idle - lane_width_offset
+		lane_count = floor(abs((fwd_width_idle - rev_width_mag + lane_width_offset) / lane_width)) + 1
+		lane_width = -lane_width
+	else:
+		div_start_pos = rev_width_idle + lane_width_offset
+		lane_count = floor(abs((rev_width_idle - fwd_width_mag - lane_width_offset) / lane_width)) + 1
+
+	var x_pos = div_start_pos
+	var div_count = lane_dividers.get_child_count()
+	var div: Spatial
+	for i in range(max(lane_count, div_count)):
+		if div_count == 0 or i >= div_count:
+			div = lane_divider.duplicate()
+			lane_dividers.add_child(div)
 		else:
-			div_start_pos = rev_width_idle + lane_width_offset
-			lane_count = floor(abs((rev_width_idle - fwd_width_mag - lane_width_offset) / lane_width)) + 1
+			div = lane_dividers.get_child(i)
 
-		var x_pos = div_start_pos
-		var div_count = lane_dividers.get_child_count()
-		var div: Spatial
-		for i in range(max(lane_count, div_count)):
-			if div_count == 0 or i >= div_count:
-				div = lane_divider.duplicate()
-				lane_dividers.add_child(div)
-			else:
-				div = lane_dividers.get_child(i)
-
-			if i < lane_count:
-				div.visible = true
-				div.translation = Vector3(x_pos, 0, 0)
-				x_pos += lane_width
-			else:
-				div.visible = false
+		if i < lane_count:
+			div.visible = true
+			div.translation = Vector3(x_pos, 0, 0)
+			x_pos += lane_width
+		else:
+			div.visible = false
 
 
 func get_handle_name(gizmo: EditorSpatialGizmo, index: int) -> String:

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -12,6 +12,7 @@ enum HandleType {
 
 const GizmoBlueHandle := preload("res://addons/road-generator/ui/gizmo_blue_handle.png")
 const LaneOffset := 0.25
+const BaseColliderSize := Vector3(2, 0.175, 2)
 
 var _editor_plugin: EditorPlugin
 var _editor_selection  # Of type: EditorSelection, but can't type due to exports.
@@ -31,6 +32,7 @@ var arrow_right_mesh := PrismMesh.new()
 var lane_divider_mesh := CubeMesh.new()
 var road_width_line_mesh := CubeMesh.new()
 
+var prior_lane_width: float = -1
 
 func get_name():
 	return "RoadPoint"
@@ -46,7 +48,7 @@ func _init(editor_plugin: EditorPlugin):
 	var mat_blue_handles = get_material("blue_handles")
 	mat_blue_handles.albedo_texture = GizmoBlueHandle
 	init_handle = null
-	collider.size = Vector3(2, 0.175, 2)
+	collider.size = BaseColliderSize
 	collider_tri_mesh = collider.generate_triangle_mesh()
 	setup_lane_widgets()
 
@@ -98,6 +100,24 @@ func has_gizmo(spatial) -> bool:
 func redraw(gizmo) -> void:
 	gizmo.clear()
 	var point = gizmo.get_spatial_node() as RoadPoint
+	var need_size_update = prior_lane_width < 0 or prior_lane_width != point.lane_width
+	prior_lane_width = point.lane_width
+
+	# Add lane dividers:
+	# Start placing dividers at side opposite of dragged handle. Draw
+	# dividers for real and potential lanes based on handle position. Re-use
+	# existing dividers. Create more dividers when needed. Hide dividers
+	# when not needed.
+	var lane_width = point.lane_width
+	var width_scale: float = lane_width / 4.0  # 4m is the default for which assets were scaled.
+	var width_scale_v := Vector3(width_scale, width_scale, width_scale)
+	var lane_count
+	var div_start_pos
+	var lane_width_offset = lane_width * LaneOffset
+
+	# Re-process the handler
+	if need_size_update:
+		collider.size = BaseColliderSize * width_scale
 
 	var lines = PoolVector3Array()
 	lines.push_back(Vector3(0, 1, 0))
@@ -119,6 +139,9 @@ func redraw(gizmo) -> void:
 	var width_handles = PoolVector3Array()
 	var rev_width_idle = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
 	var fwd_width_idle = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
+	if need_size_update:
+		point.rev_width_mag = rev_width_idle
+		point.fwd_width_mag = fwd_width_idle
 	var rev_width_mag = point.rev_width_mag
 	var fwd_width_mag = point.fwd_width_mag
 	width_handles.push_back(Vector3(rev_width_mag, 0, 0))
@@ -129,21 +152,13 @@ func redraw(gizmo) -> void:
 	lane_widget.visible = true
 	lane_widget.transform = point.global_transform
 	arrow_left.translation = Vector3(rev_width_mag, 0, 0)
+	arrow_left.scale = width_scale_v
 	arrow_right.translation = Vector3(fwd_width_mag, 0, 0)
+	arrow_right.scale = width_scale_v
 	var line_width = fwd_width_mag - rev_width_mag
 	var line_pos = (rev_width_mag + fwd_width_mag) / 2
-	road_width_line_mesh.size = Vector3(line_width, 0.2, 0.2)
+	road_width_line_mesh.size = Vector3(line_width, 0.2 * width_scale, 0.2 * width_scale)
 	road_width_line.translation = Vector3(line_pos, 0, 0)
-
-	# Add lane dividers:
-	# Start placing dividers at side opposite of dragged handle. Draw
-	# dividers for real and potential lanes based on handle position. Re-use
-	# existing dividers. Create more dividers when needed. Hide dividers
-	# when not needed.
-	var lane_width = point.lane_width
-	var lane_count
-	var div_start_pos
-	var lane_width_offset = lane_width * LaneOffset
 
 	if rev_width_mag != rev_width_idle:
 		div_start_pos = fwd_width_idle - lane_width_offset
@@ -166,6 +181,7 @@ func redraw(gizmo) -> void:
 		if i < lane_count:
 			div.visible = true
 			div.translation = Vector3(x_pos, 0, 0)
+			div.scale = Vector3(width_scale, width_scale, width_scale)
 			x_pos += lane_width
 		else:
 			div.visible = false
@@ -426,4 +442,5 @@ func refresh_gizmo(gizmo: EditorSpatialGizmo):
 
 
 func on_selection_changed():
+	prior_lane_width = -1
 	lane_widget.visible = false


### PR DESCRIPTION
We now have nicer defaults for the gutter and initial road magnitudes which correspond to the width of the road. Additionally, we have full resolved https://github.com/TheDuckCow/godot-road-generator/issues/90

See the following small scale:
<img width="821" alt="Screen Shot 2023-10-15 at 12 03 44 AM" src="https://github.com/TheDuckCow/godot-road-generator/assets/2958461/b2024b67-ff57-4f67-92c2-a6c1badf5f70">


Only consequence is that when selecting RoadPoints of different lane widths, all widgets change at the same moment. But, the one actively being selected is always as desired.

