### PR TITLE
Eliminating duplicate segments with changes in connection direction.

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -392,7 +392,8 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 	# TODO: The id setup below will have issues if a "next" goes into "prior", ie rev dir
 	# but doing this for simplicity now.
 
-	var sid = "%s-%s" % [pt1.get_instance_id(), pt2.get_instance_id()]
+	#var sid = "%s-%s" % [pt1.get_instance_id(), pt2.get_instance_id()]
+	var sid = RoadSegment.get_id_for_points(pt1, pt2)
 	if sid in segid_map and is_instance_valid(segid_map[sid]):
 		var was_rebuilt = segid_map[sid].check_rebuild()
 		return [was_rebuilt, segid_map[sid]]

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -410,6 +410,14 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 		new_seg.low_poly = low_poly
 		new_seg.start_point = pt1
 		new_seg.end_point = pt2
+		if pt1.next_pt_init != pt1.get_path_to(pt2):
+			new_seg._start_flip = true
+		else:
+			new_seg._start_flip = false
+		if pt2.prior_pt_init != pt2.get_path_to(pt1):
+			new_seg._end_flip = true
+		else:
+			new_seg._end_flip = false
 		segid_map[sid] = new_seg
 		new_seg.material = material_resource
 		new_seg.check_rebuild()

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -565,30 +565,37 @@ func connect_roadpoint(this_direction: int, target_rp: Node, target_direction: i
 ## Function to explicitly connect this RoadNode to another
 func disconnect_roadpoint(this_direction: int, target_direction: int):
 	#print("Disconnecting %s (%s) and the target's (%s)" % [self, this_direction, target_direction])
-	var refresh = container._auto_refresh
-	container._auto_refresh = false
 	var disconnect_from: Node
+
+	self._is_internal_updating = true
+	var seg
 
 	match this_direction:
 		PointInit.NEXT:
 			disconnect_from = get_node(next_pt_init)
 			self.next_pt_init = ""
+			seg = self.next_seg
 		PointInit.PRIOR:
 			disconnect_from = get_node(prior_pt_init)
 			self.prior_pt_init = ""
+			seg = self.prior_seg
+
+	disconnect_from._is_internal_updating = true
+
 	match target_direction:
 		PointInit.NEXT:
 			disconnect_from.next_pt_init = ""
 		PointInit.PRIOR:
 			disconnect_from.prior_pt_init = ""
-	container._auto_refresh = refresh
-	if not container._auto_refresh:
-		container._needs_refresh = true
+	self._is_internal_updating = false
+	disconnect_from._is_internal_updating = false
+
+	container.remove_segment(seg)
+
 	self.validate_junctions()
 	disconnect_from.validate_junctions()
 
 	container.update_edges()
-	on_transform()
 
 
 func connect_container(container: Node, set_next):

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -105,17 +105,27 @@ func remove_road_mesh():
 
 ## Unique identifier for a segment based on what its connected to.
 func get_id() -> String:
-	# TODO: consider changing so that the smaller resource id is first,
-	# so that we avoid bidirectional issues.
-	if start_point and end_point:
-		name = "%s-%s" % [start_point.get_instance_id(), end_point.get_instance_id()]
-	elif start_point:
-		name = "%s-x" % start_point.get_instance_id()
-	elif end_point:
-		name = "x-%s" % end_point.get_instance_id()
-	else:
-		name = "x-x"
+	name = get_id_for_points(start_point, end_point)
 	return name
+
+
+## Generic function for getting a consistent ID given a start and end point
+static func get_id_for_points(_start:RoadPoint, _end:RoadPoint) -> String:
+	var id: String
+	if _start and _end:
+		var start_id = _start.get_instance_id()
+		var end_id = _end.get_instance_id()
+		if start_id < end_id:
+			id = "%s-%s" % [start_id, end_id]
+		else:
+			id = "%s-%s" % [end_id, start_id]
+	elif _start:
+		id = "%s-x" % _start.get_instance_id()
+	elif _end:
+		id = "x-%s" % _end.get_instance_id()
+	else:
+		id = "x-x"
+	return id
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Work in progress, to ensure users can connect roads RoadPoints, even if the face opposing directions. This is important as someone could be joining two different chains of roads that have many points and all face the wrong way compared to another stretch of road.

RoadPoints are ideally agnostic of direction, although a given RoadPoint will "own" one or more RoadSegment children. So in the event two roadpoints are facing each other (ie they both claim they are each others' "Next RoadPoint" for instance), one of them will inherently take ownership of the connection between them. We need to make sure to do this in a reliable, deterministic way.