### PR TITLE
Establish connections between RoadContainers

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -255,9 +255,12 @@ func get_segments() -> Array:
 			segs.append(pt_ch)
 	return segs
 
+
 ## Update export variable lengths and counts to account for connection to
 ## other RoadContainers
 func update_edges():
+	# TODO: Optomize parent callers to avoid re-calls, e.g. on save.
+	#print("Debug: Updating container edges %s" % self.name)
 
 	var _tmp_containers := []
 	var _tmp_rp_targets := []
@@ -590,7 +593,7 @@ func _check_migrate_points():
 	])
 
 
-# Cleanup the road segments specifically, in case they aren't children.
+## Cleanup the road segments specifically, in case they aren't children.
 func _exit_tree():
 	# TODO: Verify we don't get orphans below.
 	# However, at the time of this early exit, doing this prevented roads

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -96,6 +96,9 @@ func is_road_container() -> bool:
 	return true
 
 
+func is_subscene() -> bool:
+	return filename and self != get_tree().edited_scene_root
+
 func _get_configuration_warning() -> String:
 
 	if get_tree().get_edited_scene_root() != self:

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -613,22 +613,26 @@ func connect_roadpoint(this_direction: int, target_rp: Node, target_direction: i
 	match target_direction:
 		PointInit.NEXT:
 			if target_rp.next_pt_init:
-				push_error("The connecting RP's next point is already set")
+				push_error("The connecting RP's next point is already set %s:%s" % [
+					target_rp.name, target_rp.next_pt_init])
 				return false # already connected
 		PointInit.PRIOR:
 			if target_rp.prior_pt_init:
-				push_error("The connecting RP's prior point is already set")
+				push_error("The connecting RP's prior point is already set: %s:%s" % [
+					target_rp.name, target_rp.prior_pt_init])
 
 	# Now do actual property setting
 	match this_direction:
 		PointInit.NEXT:
 			if self.next_pt_init:
-				push_error("RP's next point is already set")
+				push_error("This RP's next point is already set: %s:%s" % [
+					self.name, self.next_pt_init])
 				return false # already connected
 			self.next_pt_init = local_path
 		PointInit.PRIOR:
 			if self.prior_pt_init:
-				push_error("RP's prior point is already set")
+				push_error("This RP's prior point is already set: %s:%s" % [
+					self.name, self.prior_pt_init])
 				return false # already connected
 			self.prior_pt_init = local_path
 

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -609,7 +609,7 @@ func connect_roadpoint(this_direction: int, target_rp: Node, target_direction: i
 	self._is_internal_updating = true
 	target_rp._is_internal_updating = true
 
-	# Short circuit before setting any properties if we need to exit, hence
+	# Short circuit before setting any properties if we need to exit.
 	match target_direction:
 		PointInit.NEXT:
 			if target_rp.next_pt_init:
@@ -620,6 +620,8 @@ func connect_roadpoint(this_direction: int, target_rp: Node, target_direction: i
 			if target_rp.prior_pt_init:
 				push_error("The connecting RP's prior point is already set: %s:%s" % [
 					target_rp.name, target_rp.prior_pt_init])
+				return false
+
 
 	# Now do actual property setting
 	match this_direction:

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -627,7 +627,7 @@ func connect_roadpoint(this_direction: int, target_rp: Node, target_direction: i
 				return false # already connected
 			self.next_pt_init = local_path
 		PointInit.PRIOR:
-			if self.next_pt_init:
+			if self.prior_pt_init:
 				push_error("RP's prior point is already set")
 				return false # already connected
 			self.prior_pt_init = local_path

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -936,7 +936,12 @@ func _connect_rp_on_click(rp_a, rp_b):
 		var from_rp = null # the one in the same container it'll connect to.
 		var cross_rp = null # the one in another container
 
-		if rp_a.container.is_subscene() and rp_b.container.is_subscene():
+
+		if rp_a.global_transform.origin == rp_b.global_transform.origin:
+			# They are already in the same position, so we should not add a new RP anyways.
+			# TODO: Could also check for rotation being aligned.
+			pass
+		elif rp_a.container.is_subscene() and rp_b.container.is_subscene():
 			push_warning("Connected RoadContainer of saved scenes may not visually appaer connected")
 			# TODO: Create a new container in the middle which connects these two,
 			# or offer to snape one to the other.

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -240,11 +240,6 @@ func _handle_gui_add_mode(camera: Camera, event: InputEvent) -> bool:
 		var src_is_contianer := false
 		var target:RoadPoint
 
-		# Check if selection or parent is a subscene, if so treat as though the
-		# manager were selected
-		if point and point.container.is_subscene():
-			point = null
-
 		if selection is RoadContainer:
 			src_is_contianer = true
 			var closest_rp = get_nearest_edge_road_point(selection, camera, event.position)

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -121,11 +121,11 @@ func forward_spatial_draw_over_viewport(overlay: Control):
 	if _overlay_hint_disconnect:
 		# Hovering node is directly connected to this node already, offer to disconnect
 		col = Color.coral
-	elif hovering.next_pt_init and hovering.prior_pt_init:
+	elif hovering.is_next_connected() and hovering.is_prior_connected():
 		# Where we're coming from is already fully connected.
 		# Eventually though, this could be an intersection.
 		return
-	elif selected.next_pt_init and selected.prior_pt_init:
+	elif selected.is_next_connected() and selected.is_prior_connected():
 		# Fully connected, though eventually this could be an intersection.
 		return
 	elif selected.container != hovering.container:
@@ -272,17 +272,17 @@ func _handle_gui_add_mode(camera: Camera, event: InputEvent) -> bool:
 				_overlay_rp_hovering = null
 				_overlay_hint_disconnect = false
 				_overlay_hint_connection = false
-			elif target.prior_pt_init and target.get_node(target.prior_pt_init) == point:
+			elif target.get_prior_rp() == point:
 				# If this pt is directly connected to the target, offer quick dis-connect tool
 				_overlay_rp_selected = target
 				_overlay_hint_disconnect = true
 				_overlay_hint_connection = false
-			elif target.next_pt_init and target.get_node(target.next_pt_init) == point:
+			elif target.get_next_rp() == point:
 				# If this pt is directly connected to the selection, offer quick dis-connect tool
 				_overlay_rp_selected = target
 				_overlay_hint_disconnect = true
 				_overlay_hint_connection = false
-			elif target.prior_pt_init and target.next_pt_init:
+			elif target.is_prior_connected() and target.is_next_connected():
 				# Fully connected roadpoint, nothing to do.
 				# In the future, this could be a mode to convert into an intersection
 				_overlay_rp_selected = null
@@ -950,16 +950,16 @@ func _disconnect_rp_on_click(rp_a, rp_b):
 
 	var from_dir
 	var target_dir
-	if rp_a.prior_pt_init and rp_a.get_node(rp_a.prior_pt_init) == rp_b:
+	if rp_a.get_prior_rp() == rp_b:
 		from_dir = RoadPoint.PointInit.PRIOR
-	elif rp_a.next_pt_init and rp_a.get_node(rp_a.next_pt_init) == rp_b:
+	elif rp_a.get_next_rp() == rp_b:
 		from_dir = RoadPoint.PointInit.NEXT
 	else:
 		push_error("Not initially connected")
 		return
-	if rp_b.prior_pt_init and rp_b.get_node(rp_b.prior_pt_init) == rp_a:
+	if rp_b.get_prior_rp() == rp_a:
 		target_dir = RoadPoint.PointInit.PRIOR
-	elif rp_b.next_pt_init and rp_b.get_node(rp_b.next_pt_init) == rp_a:
+	elif rp_b.get_next_rp() == rp_a:
 		target_dir = RoadPoint.PointInit.NEXT
 	else:
 		push_error("Not initially connected")

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -1,10 +1,8 @@
 tool
 extends HBoxContainer
 
-const ToolbarMenu = preload("res://addons/road-generator/ui/road_toolbar_create_menu.gd")
 
 signal mode_changed
-
 
 enum InputMode {
 	NONE,  # e.g. if a Road*Node is not selected.
@@ -21,6 +19,7 @@ var create_menu:MenuButton
 var selected_nodes: Array # of Nodes
 var gui # For fetching built in icons (not yet working)
 var mode # Passed in by parent
+
 
 func _enter_tree():
 	update_refs()
@@ -48,13 +47,7 @@ func on_show(_selected_nodes: Array):
 	var is_subscene := false
 	if len(selected_nodes) > 0:
 		primary_sel = selected_nodes[0]
-		if primary_sel.has_method("is_subscene"):
-			is_subscene = primary_sel.is_subscene()
-	create_menu.on_toolbar_show()
-	if is_subscene:
-		create_menu.menu_mode = create_menu.MenuMode.SAVED_SUBSCENE
-	else:
-		create_menu.menu_mode = create_menu.MenuMode.STANADARD
+	create_menu.on_toolbar_show(primary_sel)
 
 
 func update_icons():

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -1,6 +1,8 @@
 tool
 extends HBoxContainer
 
+const ToolbarMenu = preload("res://addons/road-generator/ui/road_toolbar_create_menu.gd")
+
 signal mode_changed
 
 
@@ -22,7 +24,6 @@ var mode # Passed in by parent
 
 func _enter_tree():
 	update_refs()
-
 	match mode:
 		InputMode.SELECT:
 			select_mode.pressed = true
@@ -37,6 +38,23 @@ func update_refs():
 	add_mode = $add_mode
 	delete_mode = $delete_mode
 	create_menu = $CreateMenu
+
+
+func on_show(_selected_nodes: Array):
+	selected_nodes = _selected_nodes
+	print("On show:", selected_nodes)
+
+	var primary_sel = null
+	var is_subscene := false
+	if len(selected_nodes) > 0:
+		primary_sel = selected_nodes[0]
+		if primary_sel.has_method("is_subscene"):
+			is_subscene = primary_sel.is_subscene()
+	create_menu.on_toolbar_show()
+	if is_subscene:
+		create_menu.menu_mode = create_menu.MenuMode.SAVED_SUBSCENE
+	else:
+		create_menu.menu_mode = create_menu.MenuMode.STANADARD
 
 
 func update_icons():

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -36,7 +36,12 @@ func _enter_tree() -> void:
 	pup.connect("id_pressed", self, "_create_menu_item_clicked")
 
 
-func on_toolbar_show() -> void:
+func on_toolbar_show(primary_sel: Node) -> void:
+	if primary_sel.has_method("is_subscene") and primary_sel.is_subscene():
+		menu_mode = MenuMode.SAVED_SUBSCENE
+	else:
+		menu_mode = MenuMode.STANDARD
+
 	var pup:Popup = get_popup()
 	var idx = 0
 	pup.clear()

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -22,11 +22,24 @@ enum CreateMenu {
 	TWO_X_TWO,
 }
 
+enum MenuMode {
+	STANDARD,
+	SAVED_SUBSCENE, # Don't offer to create children
+	EDGE_SELECTED # Not yet used, could offer intersections/next pieces to add.
+}
+
+var menu_mode = MenuMode.STANDARD
+
+
 func _enter_tree() -> void:
+	var pup:Popup = get_popup()
+	pup.connect("id_pressed", self, "_create_menu_item_clicked")
+
+
+func on_toolbar_show() -> void:
 	var pup:Popup = get_popup()
 	var idx = 0
 	pup.clear()
-	pup.connect("id_pressed", self, "_create_menu_item_clicked")
 
 	pup.add_item("Refresh roads", CreateMenu.REGENERATE)
 	pup.set_item_tooltip(idx, "Re-generate geometry and resolve warnings")
@@ -34,6 +47,10 @@ func _enter_tree() -> void:
 	pup.add_item("Select container", CreateMenu.SELECT_CONTAINER)
 	pup.set_item_tooltip(idx, "Select this RoadPoint's parent RoadContainer")
 	idx += 1
+
+	if menu_mode == MenuMode.SAVED_SUBSCENE:
+		# Don't offer to modify subscenes
+		return
 
 	pup.add_separator()
 	idx += 1

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -189,3 +189,23 @@ func test_on_road_updated_pt_transform():
 		var segments_updated = res[0]
 		assert_eq(len(segments_updated), 1, "Single segment created")
 		assert_signal_emit_count(container, "on_road_updated", 1, "One signal call")
+
+
+func test_connect_roadpoint():
+	var container = add_child_autofree(RoadContainer.new())
+	container._auto_refresh = false
+
+	var points = create_unconnected_container(container)
+	var p1 = points[0]
+	var p2 = points[1]
+
+	var res = p1.connect_roadpoint(RoadPoint.PointInit.NEXT, p2, RoadPoint.PointInit.PRIOR)
+	assert_true(res, "Connect RPs with no prior connections")
+	res = p1.connect_roadpoint(RoadPoint.PointInit.NEXT, p2, RoadPoint.PointInit.PRIOR)
+	assert_false(res, "Should fail to re-connect the same RP and direction")
+	res = p1.connect_roadpoint(RoadPoint.PointInit.PRIOR, p2, RoadPoint.PointInit.PRIOR)
+	assert_false(res, "Should fail to connect an already connected directions")
+
+
+func test_roadpoint_disconnection():
+	pending('Roadpoint disconnection test not implemented yet')

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -208,4 +208,27 @@ func test_connect_roadpoint():
 
 
 func test_roadpoint_disconnection():
-	pending('Roadpoint disconnection test not implemented yet')
+	# Setup: create and connect two RoadPoints
+	var container = add_child_autofree(RoadContainer.new())
+	container._auto_refresh = false
+
+	var points = create_unconnected_container(container)
+	var p1 = points[0]
+	var p2 = points[1]
+
+	# Connect the two together
+	p1.next_pt_init = p1.get_path_to(p2)
+	p2.prior_pt_init = p2.get_path_to(p1)
+
+	container._auto_refresh = true
+	# should have a child segment now, TODO assert this.
+	watch_signals(container)
+
+	# Now use the disconnect function explicitly
+	var res = p1.disconnect_roadpoint(RoadPoint.PointInit.NEXT, RoadPoint.PointInit.PRIOR)
+	assert_true(res, "Should be able to disconnect valid connection")
+	res = p1.disconnect_roadpoint(RoadPoint.PointInit.NEXT, RoadPoint.PointInit.PRIOR)
+	assert_false(res, "Should fail to disconnect already disconnected rp")
+	res = p1.disconnect_roadpoint(RoadPoint.PointInit.PRIOR, RoadPoint.PointInit.PRIOR)
+	assert_false(res, "Should fail to disconnect invalid connection prior to prior")
+


### PR DESCRIPTION
Until now, users have not been able to make connections between two different RoadContainers with the interactive tool (and doing so manually with paths would create unexpected artifacts). In this branch, we first start to allow for connections. This is a stepping stone to fully support generalize custom prefab scene creation while retaining traffic AI guides (RoadLanes).

Edited at time of being review-ready:

- When connecting RoadContainers, we detect if the two highlighted RoadPoints (on each respective RoadContainer) are already overlapping in 3D space
- If yes, directly connect them through export var chaining.
- If no, create a new roadpoint at the right position, then connect that _new_ roadpoint to the new container.
  - This new roadpoint is added as a child of the container of the selected node;
  - Unless that node is a saved subscene, in which case it'll switch to making it a child of the _other_ container involved
  - If both containers are saved subscenes, then: an error is pushed instead. In the future, we'll have snapping tools to connect these two saved scenes together, or the potential to create a new "bridging" RoadContainer between two segments
- Undo/redo should be fully functioning.

Not yet implemented:
- Correctly setting the prior/next point on the RoadLane's across containers. Right now, any vehicle following a RoadLane to the end of its RoadContainer will see "nothing is next". Will improve in the future.