### PR TITLE
Added instructions and script for command line testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ addons/godot-reload-scene/
 *.DS_store
 # Place where local instances of godot go, for automated testing
 godot_versions.txt
+.gut_editor_shortcuts.cfg
 
 # Official gitignore items to include for Asset Library contributions, per:
 # https://raw.githubusercontent.com/aaronfranke/gitignore/godot/Godot.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ addons/gut/
 addons/godot-plugin-refresher/
 addons/godot-reload-scene/
 *.DS_store
+# Place where local instances of godot go, for automated testing
+godot_versions.txt
 
 # Official gitignore items to include for Asset Library contributions, per:
 # https://raw.githubusercontent.com/aaronfranke/gitignore/godot/Godot.gitignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,12 @@ To get GUT set up:
 
 To run tests, you now should see a "GUT" tab at the bottom of your main window (to the right of Animation). Inside this window, you just need to `Run All` to run all tests.
 
+You can also run tests from the command line (script set up for Linux/Max OSX):
+
+1. Create a `godot_versions.txt` file in the root of the repo. This should not be checked in (already added to gitignores)
+1. Create a single line with the path to the godot versions you want to use for testing. It should be the full path to the binary executable (not just the .app, for instance on OSX)
+1. Then execute `run_tests.sh` and you should see test results in progress. As of this writing, Godot opens, tests run, and then godot closes all in less than 5 seconds.
+
 
 ## General guidance
 

--- a/release.sh
+++ b/release.sh
@@ -22,9 +22,11 @@ echo ""
 echo "Current status (should be empty!)"
 git status
 
-# TODO(Patrick): Directly run tests here in the future and capture success.
-echo "Did you manually run tests?"
-read -p "(Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+./run_tests.sh
+if [ "$?" != "0" ]; then
+    echo "Tests failed $LINENO."
+    exit 1
+fi
 
 # Extract the current version number.
 VER=$(grep "version=" addons/road-generator/plugin.cfg | awk -F'"' '{print $2}')

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,18 @@
+# Run all tests using GUT.
+
+cd src
+GODOT=$(cat godot_versions.txt)
+
+# Execute tests.
+"$GODOT" -s addons/gut/gut_cmdln.gd \
+	--path $PWD \
+	--no-window \
+	-d \
+	-gconfig=.gut_editor_config.json
+
+echo ""
+if [ "$?" != "0" ]; then
+	echo "Tests failed $LINENO."
+	exit 1
+fi
+echo "Tests passed"


### PR DESCRIPTION
This included script makes it easier to run test automatically on the command line. This is a potential stepping stone to eventually supporting test-running via github actions. Included script is for OSX and linux only (only tested on OSX though)