### PR TITLE
Improve auto and manual conversion to godot 4

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -368,6 +368,9 @@ func update_edges():
 				_tmp_rp_targets.append(edge_rp_targets[idx])
 				_tmp_rp_target_dirs.append(edge_rp_target_dirs[idx])
 			else:
+				#gd4
+				#_tmp_containers.append(^"")
+				#_tmp_rp_targets.append(^"")
 				_tmp_containers.append("")
 				_tmp_rp_targets.append("")
 				_tmp_rp_target_dirs.append(-1) # -1 to mean an unconnected index, since valid enums are 0+

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -1,6 +1,8 @@
-## Manager used to generate the actual road segments when needed.
 tool
+## Manager used to generate the actual road segments when needed.
 class_name RoadContainer, "../resources/road_container.png"
+#gd4
+#@icon("res://addons/road-generator/resources/road_container.png")
 extends Spatial
 
 ## Emitted when a road segment has been (re)generated, returning the list
@@ -117,13 +119,17 @@ func is_subscene() -> bool:
 	return filename and self != get_tree().edited_scene_root
 
 
+#gd4
+#func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
+	var warnstr
 
 	if get_tree().get_edited_scene_root() != self:
 		var any_manager := false
 		var _last_par = get_parent()
 		while true:
-			# TODO: make better forward compatible
+			#gd4
+			#if _last_par.get_path() == ^"/root":
 			if _last_par.get_path() == "/root":
 				break
 			if _last_par.has_method("is_road_manager"):
@@ -132,7 +138,10 @@ func _get_configuration_warning() -> String:
 				break
 			_last_par = _last_par.get_parent()
 		if any_manager == false:
-			return "A RoadContainer should either be the scene root, or have a RoadManager somewhere in its parent hierarchy"
+			warnstr = "A RoadContainer should either be the scene root, or have a RoadManager somewhere in its parent hierarchy"
+			#gd4
+			#return [warnstr]
+			return warnstr
 
 	var has_rp_child = false
 	for ch in get_children():
@@ -140,14 +149,22 @@ func _get_configuration_warning() -> String:
 			has_rp_child = true
 			break
 	if not has_rp_child:
-		return "Add RoadPoint nodes as children to form a road, or use the Roads menu in the 3D view header"
+		warnstr = "Add RoadPoint nodes as children to form a road, or use the Roads menu in the 3D view header"
+		#gd4
+		#return [warnstr]
+		return warnstr
 
 	if _needs_refresh:
-		return "Refresh outdated geometry by selecting this node and going to 3D view > Roads menu > Refresh Roads"
+		warnstr = "Refresh outdated geometry by selecting this node and going to 3D view > Roads menu > Refresh Roads"
+		#gd4
+		#return [warnstr]
+		return warnstr
 
 	if _edge_error != "":
-		var warn_str = "Refresh roads to clear invalid connections:\n%s" % _edge_error
-		return warn_str
+		warnstr = "Refresh roads to clear invalid connections:\n%s" % _edge_error
+		#gd4
+		#return [warnstr]
+		return warnstr
 	return ""
 
 
@@ -239,6 +256,8 @@ func get_manager(): # -> Optional[RoadManager]
 	while true:
 		if _last_par == null:
 			break
+		#gd4
+		# if _last_par.get_path() == ^"/root":
 		if _last_par.get_path() == "/root":
 			break
 		if _last_par.has_method("is_road_manager"):
@@ -299,6 +318,8 @@ func update_edges():
 			else:
 				dir_pt_init = pt.next_pt_init
 
+			#gd4
+			#if dir_pt_init == ^"":
 			if dir_pt_init == "":
 				# Set this rp to indicate its next point is the container,
 				# making it aware it is an "edge".
@@ -391,6 +412,8 @@ func validate_edges(autofix: bool = false) -> bool:
 			_invalidate_edge(_idx, autofix, "edge_rp_local_dirs value invalid")
 			continue
 
+		#gd4
+		#if edge_containers[_idx] != ^"":
 		if edge_containers[_idx] != "":
 			# Connection should be there, verify values.
 			var cont = get_node(edge_containers[_idx])
@@ -451,6 +474,9 @@ func _invalidate_edge(_idx, autofix: bool, reason=""):
 	])
 	if not autofix:
 		return
+	#gd4
+	#edge_containers[_idx] = ^""
+	#edge_rp_targets[_idx] = ^""
 	edge_containers[_idx] = ""
 	edge_rp_targets[_idx] = ""
 	edge_rp_target_dirs[_idx] = -1

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -363,7 +363,7 @@ func update_edges():
 				idx = _find_idx
 				break
 
-			if idx >= 0:
+			if idx >= 0 and len(edge_containers) >= idx:
 				_tmp_containers.append(edge_containers[idx])
 				_tmp_rp_targets.append(edge_rp_targets[idx])
 				_tmp_rp_target_dirs.append(edge_rp_target_dirs[idx])
@@ -405,6 +405,8 @@ func validate_edges(autofix: bool = false) -> bool:
 		var target = null  # the presumed connected RP.
 
 		if this_dir == this_pt.PointInit.NEXT:
+			#gd4
+			#if this_pt.next_pt_init != ^"":
 			if this_pt.next_pt_init != "":
 				# Shouldn't be marked as connecting to another local pt, "" indicates edge pt.
 				is_valid = false
@@ -413,6 +415,8 @@ func validate_edges(autofix: bool = false) -> bool:
 			else:
 				target = this_pt.get_next_rp()
 		elif this_dir == this_pt.PointInit.PRIOR:
+			#gd4
+			#if this_pt.prior_pt_init != "":
 			if this_pt.prior_pt_init != "":
 				# Shouldn't be marked as connecting to another local pt, "" indicates edge pt.
 				is_valid = false

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -1,8 +1,8 @@
 tool
-## Manager used to generate the actual road segments when needed.
-class_name RoadContainer, "../resources/road_container.png"
 #gd4
 #@icon("res://addons/road-generator/resources/road_container.png")
+## Manager used to generate the actual road segments when needed.
+class_name RoadContainer, "../resources/road_container.png"
 extends Spatial
 
 ## Emitted when a road segment has been (re)generated, returning the list
@@ -40,17 +40,26 @@ export(bool) var draw_lanes_game := false setget _set_draw_lanes_game, _get_draw
 # TODO: In Godot 4.3ish, these should be @export_storage, hidden to users
 # https://github.com/godotengine/godot/pull/82122
 
-# In godot 4.1, becomes: @export var edge_containers: Array[NodePath]
 # Paths to other containers, relative to this container (self)
+#gd4
+#@export var edge_containers: Array[NodePath]
 export(Array, NodePath) var edge_containers
 # Node paths within other containers, relative to the *target* container (not self here)
+#gd4
+#@export var edge_rp_targets: Array[NodePath]
 export(Array, NodePath) var edge_rp_targets
 # Direction of which RP we are connecting to, used to make unique key along with
 # the edge_rp_targets path above. Enum value of RoadPoint.PointInit
+#gd4
+#@export var edge_rp_target_dirs: Array[int]
 export(Array, int) var edge_rp_target_dirs
 # Node paths within this container, relative to this container
+#gd4
+#@export var edge_rp_locals: Array[NodePath]
 export(Array, NodePath) var edge_rp_locals
 # Local RP directions, enum value of RoadPoint.PointInit
+#gd4
+#@export var edge_rp_local_dirs: Array[int]
 export(Array, int) var edge_rp_local_dirs
 
 # Mapping maintained of individual segments and their corresponding resources.
@@ -165,6 +174,8 @@ func _get_configuration_warning() -> String:
 		#gd4
 		#return [warnstr]
 		return warnstr
+	#gd4
+	#return []
 	return ""
 
 
@@ -300,7 +311,12 @@ func update_edges():
 	# TODO: Optomize parent callers to avoid re-calls, e.g. on save.
 	#print("Debug: Updating container edges %s" % self.name)
 
-	# In gd 4, would require more formal typing like Array[NodePath]
+	#gd4
+	#var _tmp_containers:Array[NodePath] = []
+	#var _tmp_rp_targets:Array[NodePath] = []
+	#var _tmp_rp_target_dirs:Array[int] = []
+	#var _tmp_rp_locals:Array[NodePath] = []
+	#var _tmp_rp_local_dirs:Array[int] = []
 	var _tmp_containers:Array = []
 	var _tmp_rp_targets:Array = []
 	var _tmp_rp_target_dirs:Array = []

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -1,8 +1,10 @@
+tool
 ## Center point of an intersection
 ##
 ## Should be contained within a RoadContainer and a sibling to 1+ RoadPoints
-tool
 class_name RoadIntersection, "res://addons/road-generator/resources/road_intersection.png"
+#gd4
+#@icon("res://addons/road-generator/resources/road_intersection.png")
 extends Spatial
 
 
@@ -11,6 +13,8 @@ extends Spatial
 # ------------------------------------------------------------------------------
 
 
+#gd4
+#func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
 	return "Intersections not yet implemented"
 

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -1,10 +1,10 @@
 tool
+#gd4
+#@icon("res://addons/road-generator/resources/road_intersection.png")
 ## Center point of an intersection
 ##
 ## Should be contained within a RoadContainer and a sibling to 1+ RoadPoints
 class_name RoadIntersection, "res://addons/road-generator/resources/road_intersection.png"
-#gd4
-#@icon("res://addons/road-generator/resources/road_intersection.png")
 extends Spatial
 
 
@@ -16,12 +16,17 @@ extends Spatial
 #gd4
 #func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
+	#gd4
+	#return ["Intersections not yet implemented"
 	return "Intersections not yet implemented"
 
 	var par = get_parent()
 	if par.has_method("is_road_container"):
+		#gd4
+		#return []
 		return ""
 	else:
+		#gd4 ["Intersection should be a direct child of a RoadContainer"]
 		return "Intersection should be a direct child of a RoadContainer"
 
 

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -58,6 +58,12 @@ var _display_fins: bool = false
 # ------------------------------------------------------------------------------
 
 
+func _init():
+	#gd4
+	#curve = Curve3D.new()
+	pass
+
+
 func _ready():
 	set_notify_transform(true)
 	set_notify_local_transform(true)
@@ -148,6 +154,10 @@ func _instantiate_geom() -> void:
 
 		var mat = SpatialMaterial.new()
 		mat.flags_unshaded = true
+		mat.flags_disable_ambient_light = true
+		mat.params_depth_draw_mode = SpatialMaterial.DEPTH_DRAW_DISABLED
+		mat.flags_do_not_receive_shadows = true
+		mat.flags_no_depth_test = true
 		mat.flags_do_not_receive_shadows = true
 		mat.params_cull_mode = mat.CULL_DISABLED
 		mat.vertex_color_use_as_albedo = true

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -1,11 +1,11 @@
-# Class for defining a directional or bidirectional lane.
-#
-# Could, but does not have to be, parented to a RoadSegment class object.
-
-# Draw in the editor things like path direction and width
 tool
-extends Path
+## Class for defining a directional or bidirectional lane.
+##
+## Could, but does not have to be, parented to a RoadSegment class object.
 class_name RoadLane, "res://addons/road-generator/resources/road_lane.png"
+#gd4
+#@icon("res://addons/road-generator/resources/road_lane.png")
+extends Path
 
 const COLOR_PRIMARY = Color(0.6, 0.3, 0,3)
 const COLOR_START = Color(0.7, 0.7, 0,7)

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -2,7 +2,8 @@
 #
 # Could, but does not have to be, parented to a RoadSegment class object.
 
-tool # Draw in the editor things like path direction and width
+# Draw in the editor things like path direction and width
+tool
 extends Path
 class_name RoadLane, "res://addons/road-generator/resources/road_lane.png"
 

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -1,10 +1,10 @@
 tool
+#gd4
+#@icon("res://addons/road-generator/resources/road_lane.png")
 ## Class for defining a directional or bidirectional lane.
 ##
 ## Could, but does not have to be, parented to a RoadSegment class object.
 class_name RoadLane, "res://addons/road-generator/resources/road_lane.png"
-#gd4
-#@icon("res://addons/road-generator/resources/road_lane.png")
 extends Path
 
 const COLOR_PRIMARY = Color(0.6, 0.3, 0,3)
@@ -44,7 +44,7 @@ export var lane_next_tag:String  # e.g. R0, R1,...R#, F0, F1, ... F#.
 
 var this_road_segment = null # RoadSegment
 var refresh_geom = true
-var geom # For tool usage, drawing lane directions and end points
+var geom:ImmediateGeometry # For tool usage, drawing lane directions and end points
 
 var _vehicles_in_lane = [] # Registration
 var _draw_in_game: bool = false
@@ -126,6 +126,8 @@ func _instantiate_geom() -> void:
 
 	if not _display_fins:
 		if geom:
+			#gd4
+			#geom.clear_surfaces()
 			geom.clear()
 		return
 	if refresh_geom == false:
@@ -134,6 +136,12 @@ func _instantiate_geom() -> void:
 
 	# Setup immediate geo node if not already.
 	if geom == null:
+		#gd4
+		#var geom_mesh = ImmediateMesh.new()
+		#geom_mesh.set_name("geom")
+		#geom = MeshInstance3D.new()
+		#geom.mesh = geom_mesh
+		#add_child(geom)
 		geom = ImmediateGeometry.new()
 		geom.set_name("geom")
 		add_child(geom)
@@ -155,16 +163,22 @@ func _draw_shark_fins() -> void:
 	var tri_count = floor(curve_length / draw_dist)
 
 	var rev = -1 if reverse_direction else 1
+	#gd4
+	#geom.clear_surfaces()
 	geom.clear()
 	for i in range (0, tri_count):
 		var f = i * curve_length / tri_count
 		var xf = Transform()
 
+		#gd4
+		# interpolate_baked -> sample_baked
 		xf.origin = curve.interpolate_baked(f)
 		var lookat = (
 			curve.interpolate_baked(f + 0.1*rev) - xf.origin
 		).normalized()
 
+		#gd4
+		# Basically prefix all geom.x() with geom.surface_x() below
 		geom.begin(Mesh.PRIMITIVE_TRIANGLES)
 		if i == 0:
 			geom.set_color(COLOR_START)

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -1,8 +1,8 @@
 tool
-## Manager for all children RoadContainers
-class_name RoadManager, "res://addons/road-generator/resources/road_manager.png"
 #gd4
 #@icon("res://addons/road-generator/resources/road_manager.png")
+## Manager for all children RoadContainers
+class_name RoadManager, "res://addons/road-generator/resources/road_manager.png"
 extends Spatial
 
 
@@ -48,6 +48,8 @@ func _ready():
 #func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
 	if _skip_warn_found_rc_child:
+		#gd4
+		#return []
 		return ""
 	var any_containers := false
 	for ch in get_children():
@@ -56,8 +58,12 @@ func _get_configuration_warning() -> String:
 			break
 
 	if any_containers:
+		#gd4
+		#return []
 		return ""
 	else:
+		#gd4
+		#return ["No RoadContainer children. Start creating a road by activating the + mode and clicking in the 3D view"]
 		return "No RoadContainer children. Start creating a road by activating the + mode and clicking in the 3D view"
 
 

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -1,6 +1,8 @@
-## Manager for all children RoadContainers
 tool
+## Manager for all children RoadContainers
 class_name RoadManager, "res://addons/road-generator/resources/road_manager.png"
+#gd4
+#@icon("res://addons/road-generator/resources/road_manager.png")
 extends Spatial
 
 
@@ -42,6 +44,8 @@ func _ready():
 	_ui_refresh_set(auto_refresh)
 
 
+#gd4
+#func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
 	if _skip_warn_found_rc_child:
 		return ""

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -162,7 +162,7 @@ func _set_lanes(values):
 	lanes = values
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 func _get_lanes():
 	return lanes
 
@@ -171,7 +171,7 @@ func _set_auto_lanes(value):
 	auto_lanes = value
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 func _get_auto_lanes():
 	return auto_lanes
 
@@ -180,7 +180,7 @@ func _set_dir(values):
 	traffic_dir = values
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 func _get_dir():
 	return traffic_dir
 
@@ -189,7 +189,7 @@ func _set_lane_width(value):
 	lane_width = value
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 func _get_lane_width():
 	return lane_width
 
@@ -198,7 +198,7 @@ func _set_shoulder_width_l(value):
 	shoulder_width_l = value
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 func _get_shoulder_width_l():
 	return shoulder_width_l
 
@@ -207,7 +207,7 @@ func _set_shoulder_width_r(value):
 	shoulder_width_r = value
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 func _get_shoulder_width_r():
 	return shoulder_width_r
 
@@ -216,7 +216,7 @@ func _set_profile(value:Vector2):
 	gutter_profile = value
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 
 
 func _get_profile():
@@ -234,7 +234,7 @@ func _set_prior_pt_init(value:NodePath):
 	# data is always in a good state *ready* for the next refresh
 	_autofix_noncyclic_references(_pre_assign, value, true)
 
-	on_transform()
+	emit_transform()
 
 
 func _get_prior_pt_init():
@@ -252,7 +252,7 @@ func _set_next_pt_init(value:NodePath):
 	# data is always in a good state *ready* for the next refresh
 	_autofix_noncyclic_references(_pre_assign, value, false)
 
-	on_transform()
+	emit_transform()
 
 
 func _get_next_pt_init():
@@ -286,7 +286,7 @@ func _set_create_geo(value: bool) -> void:
 		if ch.has_method("is_road_segment"):
 			ch.do_roadmesh_creation()
 	if value == true:
-		on_transform()
+		emit_transform()
 
 
 # ------------------------------------------------------------------------------
@@ -298,15 +298,16 @@ func _notification(what):
 		return  # Might not be initialized yet.
 	if what == NOTIFICATION_TRANSFORM_CHANGED:
 		var low_poly = Input.is_mouse_button_pressed(BUTTON_LEFT) and Engine.is_editor_hint()
-		on_transform(low_poly)
+		emit_transform(low_poly)
 
 
-func on_transform(low_poly=false):
+func emit_transform(low_poly=false):
 	if _is_internal_updating:
-		# Special internal update should bypass on_transform, such as moving two edges in parallel
+		# Special internal update should bypass emit_transform, such as moving two edges in parallel
 		return
 	if auto_lanes:
 		assign_lanes()
+	# TODO: See if we can make forward compatibility for godot4
 	if is_instance_valid(gizmo):
 		gizmo.get_plugin().refresh_gizmo(gizmo)
 	emit_signal("on_transform", self, low_poly)
@@ -519,7 +520,7 @@ func update_traffic_dir(traffic_update):
 
 	if not is_instance_valid(container):
 		return  # Might not be initialized yet.
-	on_transform()
+	emit_transform()
 
 
 ## Takes an existing RoadPoint and returns a new copy
@@ -662,7 +663,7 @@ func connect_roadpoint(this_direction: int, target_rp: Node, target_direction: i
 	target_rp._is_internal_updating = false
 
 	container.update_edges()
-	on_transform()
+	emit_transform()
 	return true
 
 
@@ -780,8 +781,8 @@ func connect_container(this_direction: int, target_rp: Node, target_direction: i
 		push_warning("Newly connected RoadPoints don't have the same position/orientation")
 
 	# container.update_edges()
-	on_transform() # Only changes that should happen: Update connections of AI lanes.
-	target_rp.on_transform()
+	emit_transform() # Only changes that should happen: Update connections of AI lanes.
+	target_rp.emit_transform()
 	return true
 
 
@@ -840,9 +841,9 @@ func disconnect_container(this_direction: int, target_direction: int) -> bool:
 		target_ct.edge_rp_targets[target_idx] = ""
 		target_ct.edge_rp_target_dirs[target_idx] = -1
 		if target_pt and is_instance_valid(target_pt):
-			target_pt.on_transform()
+			target_pt.emit_transform()
 
-	on_transform() # Only changes that should happen: Update connections of AI lanes.
+	emit_transform() # Only changes that should happen: Update connections of AI lanes.
 	return true
 
 

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -1,8 +1,8 @@
 tool
-## Definition for a single point handle, which 2+ road segments connect to.
-class_name RoadPoint, "res://addons/road-generator/resources/road_point.png"
 #gd4
 #@icon("res://addons/road-generator/resources/road_point.png")
+## Definition for a single point handle, which 2+ road segments connect to.
+class_name RoadPoint, "res://addons/road-generator/resources/road_point.png"
 extends Spatial
 
 signal on_transform(node, low_poly)
@@ -47,7 +47,17 @@ const COLOR_YELLOW = Color(0.7, 0.7, 0,7)
 const COLOR_RED = Color(0.7, 0.3, 0.3)
 const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPoint.
 
-# Assign the direction of traffic order. This i
+# Assign the direction of traffic order.
+#gd4
+#var _traffic_dir: Array[LaneDir] = [
+#		LaneDir.REVERSE, LaneDir.REVERSE, LaneDir.FORWARD, LaneDir.FORWARD]
+#@export var traffic_dir:Array[LaneDir] = [
+#		LaneDir.REVERSE, LaneDir.REVERSE, LaneDir.FORWARD, LaneDir.FORWARD]:
+#	get:
+#		return _traffic_dir
+#	set(value):
+#		_traffic_dir = value
+#		_notify_network_on_set(value)
 export(Array, LaneDir) var traffic_dir:Array setget _set_dir, _get_dir
 
 # Enables auto assignment of the lanes array below, based on traffic_dir setup.
@@ -853,6 +863,9 @@ func disconnect_container(this_direction: int, target_direction: int) -> bool:
 		push_error("Target RoadContainer did not indicate being connected to this RoadPoint/container")
 		return false
 	else:
+		#gd4
+		#target_ct.edge_containers[target_idx] = ^""
+		#target_ct.edge_rp_targets[target_idx] = ^""
 		target_ct.edge_containers[target_idx] = ""
 		target_ct.edge_rp_targets[target_idx] = ""
 		target_ct.edge_rp_target_dirs[target_idx] = -1
@@ -898,9 +911,13 @@ func validate_junctions():
 	# Clear invalid junctions
 	if is_instance_valid(prior_point):
 		if not _is_junction_valid(prior_point):
+			#gd4
+			#prior_pt_init = ^""
 			prior_pt_init = null
 	if is_instance_valid(next_point):
 		if not _is_junction_valid(next_point):
+			#gd4
+			#next_pt_init = ^""
 			next_pt_init = null
 
 

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -1,6 +1,8 @@
-## Definition for a single point handle, which 2+ road segments connect to.
 tool
+## Definition for a single point handle, which 2+ road segments connect to.
 class_name RoadPoint, "res://addons/road-generator/resources/road_point.png"
+#gd4
+#@icon("res://addons/road-generator/resources/road_point.png")
 extends Spatial
 
 signal on_transform(node, low_poly)
@@ -139,12 +141,18 @@ func _to_string():
 	return "RoadPoint %s (id:%s)" % [self.name,  self.get_instance_id()]
 
 
+#gd4
+#func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
 	var par = get_parent()
 	# Can't type check, circular dependency -____-
 	#if not par is RoadContainer:
 	if not par.has_method("is_road_container"):
+		#gd4
+		#return ["Must be a child of a RoadContainer"]
 		return "Must be a child of a RoadContainer"
+	#gd4
+	#return []
 	return ""
 
 
@@ -307,7 +315,8 @@ func emit_transform(low_poly=false):
 		return
 	if auto_lanes:
 		assign_lanes()
-	# TODO: See if we can make forward compatibility for godot4
+	# TODO: See if we can make forward compatibility for gd4
+	#gd4 need updates
 	if is_instance_valid(gizmo):
 		gizmo.get_plugin().refresh_gizmo(gizmo)
 	emit_signal("on_transform", self, low_poly)
@@ -334,6 +343,8 @@ func is_prior_connected() -> bool:
 			continue
 		if container.edge_rp_local_dirs[_idx] != PointInit.PRIOR:
 			continue
+		#gd4
+		#return container.edge_containers[_idx] != ^""
 		return container.edge_containers[_idx] != ""
 	push_warning("RP should have been present in container edge list")
 	return false
@@ -349,6 +360,8 @@ func is_next_connected() -> bool:
 			continue
 		if container.edge_rp_local_dirs[_idx] != PointInit.NEXT:
 			continue
+		#gd4
+		#return container.edge_containers[_idx] != ^""
 		return container.edge_containers[_idx] != ""
 	push_warning("RP should have been present in container edge list")
 	return false
@@ -826,6 +839,9 @@ func disconnect_container(this_direction: int, target_direction: int) -> bool:
 				break
 
 	# Update this container pointing to target rp
+	#gd4
+	#container.edge_containers[this_idx] = ^""
+	#container.edge_rp_targets[this_idx] = ^""
 	container.edge_containers[this_idx] = ""
 	container.edge_rp_targets[this_idx] = ""
 	container.edge_rp_target_dirs[this_idx] = -1
@@ -866,10 +882,14 @@ func validate_junctions():
 
 	# Get valid Prior and Next RoadPoints for THIS RoadPoint
 	var _tmp_ref
+	#gd4
+	#if not prior_pt_init.is_empty():
 	if prior_pt_init and not prior_pt_init == "":
 		_tmp_ref = get_node(prior_pt_init)
 		if _tmp_ref.has_method("is_road_point"):
 			prior_point = _tmp_ref
+	#gd4
+	#if not prior_pt_init.is_empty():
 	if next_pt_init and not next_pt_init == "":
 		_tmp_ref = get_node(next_pt_init)
 		if _tmp_ref.has_method("is_road_point"):
@@ -893,8 +913,12 @@ func _is_junction_valid(point: RoadPoint)->bool:
 	var next_point: RoadPoint
 
 	# Get valid Prior and Next RoadPoints for INPUT RoadPoint
+	#gd4
+	#if not point.prior_pt_init.is_empty():
 	if point.prior_pt_init and not point.prior_pt_init == "":
 		prior_point = get_node(point.prior_pt_init)
+	#gd4
+	#if not point.next_pt_init.is_empty():
 	if point.next_pt_init and not point.next_pt_init == "":
 		next_point = get_node(point.next_pt_init)
 
@@ -933,11 +957,15 @@ func _autofix_noncyclic_references(
 	#var which_init = "prior_pt_init" if for_prior else "next_pt_init"
 	#print("autofix %s.%s: %s -> %s" % [self.name, which_init, old_point_path, new_point_path])
 
+	#gd4
+	#if old_point_path.is_empty() and new_point_path.is_empty():
 	if old_point_path == "" and new_point_path == "":
 		return
 	elif old_point_path == new_point_path:
 		return
 
+	#gd4
+	#if not new_point_path.is_empty():
 	if new_point_path != "":
 		# Use the just recently set value.
 		is_clearing = false
@@ -975,11 +1003,14 @@ func _autofix_noncyclic_references(
 			point.prior_pt_init = ""
 			seg = self.next_seg
 		container.remove_segment(seg)
-
+	#gd4
+	#elif for_prior and not point.next_pt_init.is_empty():
 	elif for_prior and point.next_pt_init == "":
 		# self's prior RP is `point`, so make point's next RP be self if slot was empty
 		point.next_pt_init = point.get_path_to(self)
 		#print_debug(point.get_path_to(self), " -> ", point.next_pt_init)
+	#gd4
+	#elif not for_prior and point.prior_pt_init.is_empty():
 	elif not for_prior and point.prior_pt_init == "":
 		# Flipped scenario
 		point.prior_pt_init = point.get_path_to(self)

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -706,6 +706,8 @@ func disconnect_roadpoint(this_direction: int, target_direction: int) -> bool:
 				push_error("Failed to disconnect, not already connected to target RoadPoint in the Next direction")
 				return false
 			disconnect_from = get_node(next_pt_init)
+			#gd4
+			#self.next_pt_init = ^""
 			self.next_pt_init = ""
 			seg = self.next_seg
 		PointInit.PRIOR:
@@ -713,6 +715,8 @@ func disconnect_roadpoint(this_direction: int, target_direction: int) -> bool:
 				push_error("Failed to disconnect, not already connected to target RoadPoint in the Next direction")
 				return false
 			disconnect_from = get_node(prior_pt_init)
+			#gd4
+			#self.prior_pt_init = ^""
 			self.prior_pt_init = ""
 			seg = self.prior_seg
 
@@ -724,8 +728,12 @@ func disconnect_roadpoint(this_direction: int, target_direction: int) -> bool:
 
 	match target_direction:
 		PointInit.NEXT:
+			#gd4
+			#disconnect_from.next_pt_init = ^""
 			disconnect_from.next_pt_init = ""
 		PointInit.PRIOR:
+			#gd4
+			#disconnect_from.prior_pt_init = ^""
 			disconnect_from.prior_pt_init = ""
 	self._is_internal_updating = false
 	disconnect_from._is_internal_updating = false
@@ -899,13 +907,13 @@ func validate_junctions():
 	#if not prior_pt_init.is_empty():
 	if prior_pt_init and not prior_pt_init == "":
 		_tmp_ref = get_node(prior_pt_init)
-		if _tmp_ref.has_method("is_road_point"):
+		if is_instance_valid(_tmp_ref) and _tmp_ref.has_method("is_road_point"):
 			prior_point = _tmp_ref
 	#gd4
 	#if not prior_pt_init.is_empty():
 	if next_pt_init and not next_pt_init == "":
 		_tmp_ref = get_node(next_pt_init)
-		if _tmp_ref.has_method("is_road_point"):
+		if is_instance_valid(_tmp_ref) and _tmp_ref.has_method("is_road_point"):
 			next_point = get_node(next_pt_init)
 
 	# Clear invalid junctions
@@ -1014,9 +1022,13 @@ func _autofix_noncyclic_references(
 		# so we can still read self.next_pt_init
 		var seg  # RoadSegment.
 		if for_prior:
+			#gd4
+			#point.next_pt_init = ^""
 			point.next_pt_init = ""
 			seg = self.prior_seg
 		else:
+			#gd4
+			#point.prior_pt_init = ^""
 			point.prior_pt_init = ""
 			seg = self.next_seg
 		container.remove_segment(seg)

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -325,8 +325,10 @@ func emit_transform(low_poly=false):
 		return
 	if auto_lanes:
 		assign_lanes()
-	# TODO: See if we can make forward compatibility for gd4
-	#gd4 need updates
+	#gd4
+	#var _gizmo:Node3DGizmo = get_gizmos()[0]
+	#if is_instance_valid(_gizmo):
+	#	_gizmo.get_plugin().refresh_gizmo(_gizmo)
 	if is_instance_valid(gizmo):
 		gizmo.get_plugin().refresh_gizmo(gizmo)
 	emit_signal("on_transform", self, low_poly)

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -12,7 +12,7 @@ extends Spatial
 
 const LOWPOLY_FACTOR = 3.0
 
-signal check_rebuild(road_segment)
+#signal check_rebuild(road_segment)
 signal seg_ready(road_segment)
 
 export(NodePath) var start_init setget _init_start_set, _init_start_get
@@ -62,8 +62,8 @@ func _ready():
 
 	do_roadmesh_creation()
 
-	var res = connect("check_rebuild", container, "segment_rebuild")
-	assert(res == OK)
+	#var res = connect("check_rebuild", container, "segment_rebuild")
+	#assert(res == OK)
 	#emit_signal("seg_ready", self)
 	#is_dirty = true
 	#emit_signal("check_rebuild", self)

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -631,8 +631,12 @@ func _insert_geo_loop(
 	var start_basis:Vector3
 	var end_loop:Vector3
 	var end_basis:Vector3
+	#gd4
+	#start_loop = curve.sample_baked(offset_s * clength)
 	start_loop = curve.interpolate_baked(offset_s * clength)
 	start_basis = _normal_for_offset(curve, offset_s)
+	#gd4
+	#end_loop = curve.sample_baked(offset_e * clength)
 	end_loop = curve.interpolate_baked(offset_e * clength)
 	end_basis = _normal_for_offset(curve, offset_e)
 
@@ -869,8 +873,10 @@ func _insert_geo_loop(
 # Generate a quad with two triangles for a list of 4 points/uvs in a row.
 # For convention, do cloclwise from top-left vert, where the diagonal
 # will go from bottom left to top right.
-static func quad(st, uvs:Array, pts:Array) -> void:
+static func quad(st:SurfaceTool, uvs:Array, pts:Array) -> void:
 	# Triangle 1.
+	#gd4
+	#st.set_uv(uvs[0]) # here and below
 	st.add_uv(uvs[0])
 	# Add normal explicitly?
 	st.add_vertex(pts[0])

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -12,7 +12,6 @@ extends Spatial
 
 const LOWPOLY_FACTOR = 3.0
 
-#signal check_rebuild(road_segment)
 signal seg_ready(road_segment)
 
 export(NodePath) var start_init setget _init_start_set, _init_start_get
@@ -61,12 +60,6 @@ func _ready():
 		road_mesh.owner = container.owner
 
 	do_roadmesh_creation()
-
-	#var res = connect("check_rebuild", container, "segment_rebuild")
-	#assert(res == OK)
-	#emit_signal("seg_ready", self)
-	#is_dirty = true
-	#emit_signal("check_rebuild", self)
 
 
 # Workaround for cyclic typing
@@ -145,7 +138,6 @@ func _init_start_set(value):
 	is_dirty = true
 	if not is_instance_valid(container):
 		return
-	#emit_signal("check_rebuild", self)
 func _init_start_get():
 	return start_init
 
@@ -155,7 +147,6 @@ func _init_end_set(value):
 	is_dirty = true
 	if not is_instance_valid(container):
 		return
-	#emit_signal("check_rebuild", self)
 func _init_end_get():
 	return end_init
 

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -532,9 +532,11 @@ func _normal_for_offset_eased(curve: Curve3D, sample_position: float) -> Vector3
 		start_offset = sample_position - offset_amount * 0.5
 		end_offset = sample_position + offset_amount * 0.5
 
-	var pt1 := curve.interpolate_baked(start_offset * curve.get_baked_length())
-	var pt2 := curve.interpolate_baked(end_offset * curve.get_baked_length())
-	var tangent_l = pt2 - pt1
+	#gd4
+	# interpolate_baked -> sample_baked
+	var pt1:Vector3 = curve.interpolate_baked(start_offset * curve.get_baked_length())
+	var pt2:Vector3 = curve.interpolate_baked(end_offset * curve.get_baked_length())
+	var tangent_l:Vector3 = pt2 - pt1
 
 	# Using local transforms. Both are transforms relative to the parent RoadContainer,
 	# and the current mesh we are writing to already has the inverse of the start_point
@@ -649,11 +651,11 @@ func _insert_geo_loop(
 
 	# Calculate lane widths
 	var near_width = lerp(start_point.lane_width, end_point.lane_width, offset_s_ease)
-	var near_add_width = lerp(0, end_point.lane_width, offset_s_ease)
-	var near_rem_width = lerp(start_point.lane_width, 0, offset_s_ease)
+	var near_add_width = lerp(0.0, end_point.lane_width, offset_s_ease)
+	var near_rem_width = lerp(start_point.lane_width, 0.0, offset_s_ease)
 	var far_width = lerp(start_point.lane_width, end_point.lane_width, offset_e_ease)
-	var far_add_width = lerp(0, end_point.lane_width, offset_e_ease)
-	var far_rem_width = lerp(start_point.lane_width, 0, offset_e_ease)
+	var far_add_width = lerp(0.0, end_point.lane_width, offset_e_ease)
+	var far_rem_width = lerp(start_point.lane_width, 0.0, offset_e_ease)
 
 	# Sum the lane widths and get position of left edge
 	var near_width_offset

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -520,6 +520,10 @@ func get_nearest_road_point(camera: Camera, mouse_pos: Vector2) -> RoadPoint:
 	var nrm = camera.project_ray_normal(mouse_pos)
 	var dist = camera.far
 
+	#gd4
+	#var space_state = get_viewport().world_3d.direct_space_state
+	#var query = PhysicsRayQueryParameters3D.create(src, src + nrm * dist)
+	#var intersect = space_state.intersect_ray(query)
 	var space_state =  get_viewport().world.direct_space_state
 	var intersect = space_state.intersect_ray(src, src + nrm * dist, [], 1)
 
@@ -580,6 +584,12 @@ func get_click_point_with_context(camera: Camera, mouse_pos: Vector2, selection:
 	var nrm = camera.project_ray_normal(mouse_pos)
 	var dist = camera.far
 
+	#gd4
+	#var space_state = get_viewport().world_3d.direct_space_state
+	#var query = PhysicsRayQueryParameters3D.create(src, src + nrm * dist)
+	#query.collide_with_areas = false
+	#query.collide_with_bodies = true
+	#var intersect = space_state.intersect_ray(query)
 	var space_state =  get_viewport().world.direct_space_state
 	# intersect_ray(from, to, exclude, collision_mask, collide_with_bodies, collide_with_areas)
 	# Unfortunately, must have collide with areas off. And this doesn't pick
@@ -638,7 +648,8 @@ func get_click_point_with_context(camera: Camera, mouse_pos: Vector2, selection:
 
 	return [hit_pt, up]
 
-
+#gd4
+#func _handles(object: Object):
 func handles(object: Object):
 	# Must return "true" in order to use "forward_spatial_gui_input".
 	return true

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -9,9 +9,13 @@ const RoadToolbar = preload("res://addons/road-generator/ui/road_toolbar.tscn")
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
 # Forwards the InputEvent to other EditorPlugins.
-const INPUT_PASS := false # in godot 4: EditorPlugin.AFTER_GUI_INPUT_PASS
+#gd4
+#const INPUT_PASS := EditorPlugin.AFTER_GUI_INPUT_PASS
+const INPUT_PASS := false
 # Prevents the InputEvent from reaching other Editor classes.
-const INPUT_STOP := true # in godot 4: EditorPlugin.AFTER_GUI_INPUT_STOP
+#gd4
+#const INPUT_STOP := EditorPlugin.AFTER_GUI_INPUT_STOP
+const INPUT_STOP := true
 
 
 var tool_mode # Will be a value of: RoadToolbar.InputMode.SELECT
@@ -167,7 +171,11 @@ func forward_spatial_draw_over_viewport(overlay: Control):
 
 ## Handle or pass on event in the 3D editor
 ## If return true, consumes the event, otherwise forwards event
+#gd4
+#func _forward_3d_gui_input(camera: Camera3D, event: InputEvent) -> int:
 func forward_spatial_gui_input(camera: Camera, event: InputEvent) -> bool:
+	#gd4
+	#var ret := 0
 	var ret := false
 
 	var selected = get_selected_node()
@@ -199,6 +207,8 @@ func is_road_node(node: Node) -> bool:
 		or node is RoadIntersection)
 
 
+#gd4
+#func _handle_gui_select_mode(camera: Camera, event: InputEvent) -> int:
 func _handle_gui_select_mode(camera: Camera, event: InputEvent) -> bool:
 	# Event triggers on both press and release. Ignore press and only act on
 	# release. Also, ignore right-click and middle-click.
@@ -232,6 +242,8 @@ func _handle_gui_select_mode(camera: Camera, event: InputEvent) -> bool:
 
 
 ## Handle adding new RoadPoints, connecting, and disconnecting RoadPoints
+#gd4
+#func _handle_gui_add_mode(camera: Camera, event: InputEvent) -> int:
 func _handle_gui_add_mode(camera: Camera, event: InputEvent) -> bool:
 	if event is InputEventMouseMotion or event is InputEventPanGesture:
 		# Handle updating UI overlays to indicate what would happen on click.
@@ -336,6 +348,8 @@ func _handle_gui_add_mode(camera: Camera, event: InputEvent) -> bool:
 	return INPUT_STOP
 
 
+#gd4
+#func _handle_gui_delete_mode(camera: Camera, event: InputEvent) -> int:
 func _handle_gui_delete_mode(camera: Camera, event: InputEvent) -> bool:
 	if event is InputEventMouseMotion or event is InputEventPanGesture:
 		var point = get_nearest_road_point(camera, event.position)
@@ -643,12 +657,19 @@ func _show_road_toolbar() -> void:
 		_road_toolbar.on_show(_eds.get_selected_nodes())
 
 		# Utilities
+		#gd4
+		#_road_toolbar.create_menu.regenerate_pressed.connect(_on_regenerate_pressed)
+		#_road_toolbar.create_menu.select_container_pressed.connect(_on_select_container_pressed)
 		_road_toolbar.create_menu.connect(
 			"regenerate_pressed", self, "_on_regenerate_pressed")
 		_road_toolbar.create_menu.connect(
 			"select_container_pressed", self, "_on_select_container_pressed")
 
 		# Native nodes
+		#gd4
+		#_road_toolbar.create_menu.create_container.connect(_create_container_pressed)
+		#_road_toolbar.create_menu.create_roadpoint.connect(_create_roadpoint_pressed)
+		#_road_toolbar.create_menu.create_lane.connect(_create_lane_pressed)
 		_road_toolbar.create_menu.connect(
 			"create_container", self, "_create_container_pressed")
 		_road_toolbar.create_menu.connect(
@@ -657,6 +678,8 @@ func _show_road_toolbar() -> void:
 			"create_lane", self, "_create_lane_pressed")
 
 		# Specials / prefabs
+		#gd4
+		#_road_toolbar.create_menu.create_2x2_road.connect(_create_2x2_road_pressed)
 		_road_toolbar.create_menu.connect(
 			"create_2x2_road", self, "_create_2x2_road_pressed")
 
@@ -666,12 +689,19 @@ func _hide_road_toolbar() -> void:
 		remove_control_from_container(CONTAINER_SPATIAL_EDITOR_MENU, _road_toolbar)
 
 		# Utilities
+		#gd4
+		#_road_toolbar.create_menu.regenerate_pressed.disconnect(_on_regenerate_pressed)
+		#_road_toolbar.create_menu.select_container_pressed.disconnect(_on_select_container_pressed)
 		_road_toolbar.create_menu.disconnect(
 			"regenerate_pressed", self, "_on_regenerate_pressed")
 		_road_toolbar.create_menu.disconnect(
 			"select_container_pressed", self, "_on_select_container_pressed")
 
 		# Native nodes
+		#gd4
+		#_road_toolbar.create_menu.create_container.disconnect(_create_container_pressed)
+		#_road_toolbar.create_menu.create_roadpoint.disconnect(_create_roadpoint_pressed)
+		#_road_toolbar.create_menu.create_lane.disconnect(_create_lane_pressed)
 		_road_toolbar.create_menu.disconnect(
 			"create_container", self, "_create_container_pressed")
 		_road_toolbar.create_menu.disconnect(
@@ -680,10 +710,12 @@ func _hide_road_toolbar() -> void:
 			"create_lane", self, "_create_lane_pressed")
 
 		# Specials / prefabs
+		#gd4
+		#_road_toolbar.create_menu.create_2x2_road.disconnect(_create_2x2_road_pressed)
 		_road_toolbar.create_menu.disconnect(
 			"create_2x2_road", self, "_create_2x2_road_pressed")
 
-func _on_regenerate_pressed():
+func _on_regenerate_pressed() -> void:
 	var nd = get_selected_node()
 	if nd is RoadManager:
 		for ch_container in nd.get_containers():
@@ -1205,12 +1237,15 @@ func _create_2x2_road_do(t_container: RoadContainer, single_point: bool):
 	var first_road_point = RoadPoint.new()
 	t_container.add_child(first_road_point, true)
 	first_road_point.name = first_road_point.increment_name(default_name)
-	first_road_point.traffic_dir = [
+	#gd4
+	#var new_dirs: Array[RoadPoint.LaneDir] = [
+	var new_dirs := [
 		RoadPoint.LaneDir.REVERSE,
 		RoadPoint.LaneDir.REVERSE,
 		RoadPoint.LaneDir.FORWARD,
 		RoadPoint.LaneDir.FORWARD
 	]
+	first_road_point.traffic_dir = new_dirs
 	first_road_point.auto_lanes = true
 	first_road_point.set_owner(get_tree().get_edited_scene_root())
 

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -3,7 +3,9 @@ extends EditorInspectorPlugin
 const RoadPointPanel = preload("res://addons/road-generator/ui/road_point_panel.tscn")
 var panel_instance
 var _editor_plugin: EditorPlugin
-var _edi :EditorInterface setget set_edi
+# EditorInterface, don't use as type:
+# https://github.com/godotengine/godot/issues/85079
+var _edi setget set_edi
 
 
 func _init(editor_plugin: EditorPlugin):

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -11,22 +11,29 @@ var _edi setget set_edi
 func _init(editor_plugin: EditorPlugin):
 	_editor_plugin = editor_plugin
 
-
+#gd4
+#func can_handle(object):
 func can_handle(object):
 	# Only road points are supported.
+	# TODO: Add RoadContainer and RoadManager in future for bulk ops.
 	return object is RoadPoint
 
 
 # Add controls to the beginning of the Inspector property list
+#gd4
+#func _parse_begin(object):
 func parse_begin(object):
+	#gd4
+	#panel_instance = RoadPointPanel.instantiate()
 	panel_instance = RoadPointPanel.instance()
 	panel_instance.call("set_edi", _edi)
 	panel_instance.call_deferred("update_selected_road_point", object)
 	add_custom_control(panel_instance)
-	panel_instance.connect(
-		"on_lane_change_pressed", self, "_handle_on_lane_change_pressed")
-	panel_instance.connect(
-		"on_add_connected_rp", self, "_handle_add_connected_rp")
+	#gd4
+	#panel_instance.on_lane_change_pressed.connect(_handle_on_lane_change_pressed)
+	#panel_instance.on_add_connected_rp.connect(_handle_add_connected_rp)
+	panel_instance.connect("on_lane_change_pressed", self, "_handle_on_lane_change_pressed")
+	panel_instance.connect("on_add_connected_rp", self, "_handle_add_connected_rp")
 
 
 

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -97,10 +97,14 @@ func setup_lane_widgets():
 	_editor_plugin.add_child(lane_widget)
 
 
+#gd4
+#func _has_gizmo(spatial) -> bool:
 func has_gizmo(spatial) -> bool:
 	return spatial is RoadPoint
 
 
+#gd4
+#func _redraw(gizmo) -> void:
 func redraw(gizmo) -> void:
 	gizmo.clear()
 	var point = gizmo.get_spatial_node() as RoadPoint
@@ -129,6 +133,8 @@ func redraw(gizmo) -> void:
 	gizmo.add_lines(lines, get_material("main", gizmo), false)
 
 	gizmo.add_collision_triangles(collider_tri_mesh)
+	#gd4
+	#gizmo.add_mesh(collider, get_material("collider", gizmo))
 	gizmo.add_mesh(collider, false, null, get_material("collider", gizmo))
 	if not point.is_road_point_selected(_editor_selection):
 		return
@@ -137,6 +143,8 @@ func redraw(gizmo) -> void:
 	var handles = PoolVector3Array()
 	handles.push_back(Vector3(0, 0, -point.prior_mag))
 	handles.push_back(Vector3(0, 0, point.next_mag))
+	#gd4
+	#gizmo.add_handles(handles, get_material("handles", gizmo), [], false, false)
 	gizmo.add_handles(handles, get_material("handles", gizmo))
 
 	# Add width handles
@@ -153,6 +161,8 @@ func redraw(gizmo) -> void:
 	var fwd_width_mag = point.fwd_width_mag
 	width_handles.push_back(Vector3(rev_width_mag, 0, 0))
 	width_handles.push_back(Vector3(fwd_width_mag, 0, 0))
+	#gd4
+	#gizmo.add_handles(width_handles, get_material("blue_handles"), [], false, false)
 	gizmo.add_handles(width_handles, get_material("blue_handles", gizmo))
 
 	# Add lane widget
@@ -235,7 +245,18 @@ func get_handle_value(gizmo: EditorSpatialGizmo, index: int) -> float:
 
 
 ## Function called when user drags the roadpoint handles.
-func set_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, point: Vector2) -> void:
+#gd4
+#func _set_handle(
+#		gizmo: EditorNode3DGizmo,
+#		handle_id: int,
+#		secondary: bool,
+#		camera: Camera3D,
+#		screen_pos: Vector2) -> void:
+func set_handle(
+		gizmo: EditorSpatialGizmo,
+		index: int,
+		camera: Camera,
+		point: Vector2) -> void:
 	match index:
 		HandleType.PRIOR_MAG, HandleType.NEXT_MAG:
 			#set_mag_handle(gizmo, index, camera, point)
@@ -276,6 +297,8 @@ func set_mag_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, point
 		roadpoint.prior_mag = -new_mag
 	else:
 		roadpoint.next_mag = new_mag
+	#gd4
+	#_redraw(gizmo)
 	redraw(gizmo)
 
 
@@ -318,6 +341,8 @@ func set_width_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, poi
 				roadpoint.rev_width_mag = new_mag
 			HandleType.FWD_WIDTH_MAG:
 				roadpoint.fwd_width_mag = new_mag
+		#gd4
+		#_redraw(gizmo)
 		redraw(gizmo)
 
 
@@ -468,6 +493,8 @@ func refresh_gizmo(gizmo: EditorSpatialGizmo):
 	point.rev_width_mag = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
 	point.fwd_width_mag = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
 	lane_widget.visible = false
+	#gd4
+	#_redraw(gizmo)
 	redraw(gizmo)
 
 

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -141,6 +141,9 @@ func redraw(gizmo) -> void:
 
 	# Add width handles
 	var width_handles = PoolVector3Array()
+	#gd4
+	#var rev_width_idle = _get_handle_value(gizmo, HandleType.REV_WIDTH_MAG, false)
+	#var fwd_width_idle = _get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG, false)
 	var rev_width_idle = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
 	var fwd_width_idle = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
 	if need_size_update:
@@ -191,7 +194,7 @@ func redraw(gizmo) -> void:
 			div.visible = false
 
 
-# Godot 4 compatibility:
+#gd4
 #func _get_handle_name(gizmo: EditorNode3DGizmo, index: int, secondary: bool) -> String:
 func get_handle_name(gizmo: EditorSpatialGizmo, index: int) -> String:
 	var point = gizmo.get_spatial_node() as RoadPoint
@@ -208,10 +211,10 @@ func get_handle_name(gizmo: EditorSpatialGizmo, index: int) -> String:
 			return "RoadPoint %s unknown handle" % point.name
 
 
-# Godot 4:
+#gd4
 #func _get_handle_value(gizmo: EditorNode3DGizmo, index: int, secondary: bool) -> Variant:
 func get_handle_value(gizmo: EditorSpatialGizmo, index: int) -> float:
-#	print("get_handle_value")
+	# Should return float.
 	var point = gizmo.get_spatial_node() as RoadPoint
 	var lane_width = point.lane_width
 	var lane_count = len(point.traffic_dir)
@@ -284,8 +287,12 @@ func set_width_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, poi
 	if roadpoint.is_road_point_selected(_editor_selection):
 		var old_mag_vector # Handle's old local position.
 		if index == HandleType.REV_WIDTH_MAG:
+			#gd4
+			#old_mag_vector = Vector3(_get_handle_value(gizmo, HandleType.REV_WIDTH_MAG, false), 0, 0)
 			old_mag_vector = Vector3(get_handle_value(gizmo, HandleType.REV_WIDTH_MAG), 0, 0)
 		else: # HandleType.FWD_WIDTH_MAG
+			#gd4
+			#old_mag_vector = Vector3(_get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG, false), 0, 0)
 			old_mag_vector = Vector3(get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG), 0, 0)
 		var intersect = _intersect_2D_point_with_3D_plane(roadpoint, old_mag_vector, camera, point)
 
@@ -314,7 +321,7 @@ func set_width_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, poi
 		redraw(gizmo)
 
 
-# Godot4:
+#gd4
 #func _commit_handle(gizmo: EditorNode3DGizmo,
 #					index: int, secondary: bool,
 #					restore: Variant,
@@ -332,6 +339,8 @@ func commit_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: bool 
 
 func commit_mag_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: bool = false) -> void:
 	var point = gizmo.get_spatial_node() as RoadPoint
+	#gd4
+	#var current_value = _get_handle_value(gizmo, index, false)
 	var current_value = get_handle_value(gizmo, index)
 	var undo_redo = _editor_plugin.get_undo_redo()
 
@@ -368,6 +377,8 @@ func commit_mag_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: b
 
 func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: bool = false) -> void:
 	var point = gizmo.get_spatial_node() as RoadPoint
+	#gd4
+	#var current_value = _get_handle_value(gizmo, index, false)
 	var current_value = get_handle_value(gizmo, index)
 	var undo_redo = _editor_plugin.get_undo_redo()
 
@@ -384,6 +395,9 @@ func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel:
 		# Track changes
 		var new_fwd_mag = point.fwd_width_mag
 		var new_rev_mag = point.rev_width_mag
+		#gd4
+		#var rev_width_mag = _get_handle_value(gizmo, HandleType.REV_WIDTH_MAG, false)
+		#var fwd_width_mag = _get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG, false)
 		var rev_width_mag = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
 		var fwd_width_mag = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
 		var old_mag_sum = fwd_width_mag + rev_width_mag
@@ -448,6 +462,9 @@ func _intersect_2D_point_with_3D_plane(spatial, target, camera, screen_point) ->
 ## Sets width handles to outside lane edges, hides lane widget, and redraws.
 func refresh_gizmo(gizmo: EditorSpatialGizmo):
 	var point = gizmo.get_spatial_node()
+	#gd4
+	#point.rev_width_mag = _get_handle_value(gizmo, HandleType.REV_WIDTH_MAG, false)
+	#point.fwd_width_mag = _get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG, false)
 	point.rev_width_mag = get_handle_value(gizmo, HandleType.REV_WIDTH_MAG)
 	point.fwd_width_mag = get_handle_value(gizmo, HandleType.FWD_WIDTH_MAG)
 	lane_widget.visible = false

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -34,8 +34,12 @@ var road_width_line_mesh := CubeMesh.new()
 
 var prior_lane_width: float = -1
 
-func get_name():
+func get_name() -> String:
 	return "RoadPoint"
+
+# For godot 4
+func _get_gizmo_name() -> String:
+	return get_name()
 
 
 func _init(editor_plugin: EditorPlugin):
@@ -187,6 +191,8 @@ func redraw(gizmo) -> void:
 			div.visible = false
 
 
+# Godot 4 compatibility:
+#func _get_handle_name(gizmo: EditorNode3DGizmo, index: int, secondary: bool) -> String:
 func get_handle_name(gizmo: EditorSpatialGizmo, index: int) -> String:
 	var point = gizmo.get_spatial_node() as RoadPoint
 	match index:
@@ -202,6 +208,8 @@ func get_handle_name(gizmo: EditorSpatialGizmo, index: int) -> String:
 			return "RoadPoint %s unknown handle" % point.name
 
 
+# Godot 4:
+#func _get_handle_value(gizmo: EditorNode3DGizmo, index: int, secondary: bool) -> Variant:
 func get_handle_value(gizmo: EditorSpatialGizmo, index: int) -> float:
 #	print("get_handle_value")
 	var point = gizmo.get_spatial_node() as RoadPoint
@@ -306,6 +314,11 @@ func set_width_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, poi
 		redraw(gizmo)
 
 
+# Godot4:
+#func _commit_handle(gizmo: EditorNode3DGizmo,
+#					index: int, secondary: bool,
+#					restore: Variant,
+#					cancel: bool = false) -> void:
 func commit_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: bool = false) -> void:
 
 	match index:

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -67,6 +67,9 @@ func update_road_point_panel():
 
 
 func add_lane_fwd_pressed():
+	#gd4
+	# Here and below, change to:
+	#on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD)
 	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD)
 	update_road_point_panel()
 

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -5,8 +5,10 @@ extends VBoxContainer
 signal on_lane_change_pressed(selection, direction, change_type)
 signal on_add_connected_rp(selection, point_init_type)
 
+# EditorInterface, don't use as type:
+# https://github.com/godotengine/godot/issues/85079
+var _edi setget set_edi
 var sel_road_point: RoadPoint
-var _edi: EditorInterface setget set_edi
 onready var btn_add_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_add
 onready var btn_add_lane_rev = $HBoxLanes/HBoxSubLanes/rev_add
 onready var btn_rem_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_minus

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -53,7 +53,7 @@ func on_show(_selected_nodes: Array):
 func update_icons():
 	update_refs()
 	#gd4
-	#var theme = gui.get_editor_interface().get_base_control().theme
+	#var theme = EditorInterface.get_editor_theme()
 	var theme = gui
 	var icn_curve_edit = theme.get_icon("CurveEdit", "EditorIcons")  # File icon_curve_edit.svg
 	var icn_curve_create = theme.get_icon("CurveCreate", "EditorIcons")  # File icon_curve_create.svg

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -52,7 +52,7 @@ func on_show(_selected_nodes: Array):
 
 func update_icons():
 	update_refs()
-	# gd4
+	#gd4
 	#var theme = gui.get_editor_interface().get_base_control().theme
 	var theme = gui
 	var icn_curve_edit = theme.get_icon("CurveEdit", "EditorIcons")  # File icon_curve_edit.svg

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -52,9 +52,12 @@ func on_show(_selected_nodes: Array):
 
 func update_icons():
 	update_refs()
-	var icn_curve_edit = gui.get_icon("CurveEdit", "EditorIcons")  # File icon_curve_edit.svg
-	var icn_curve_create = gui.get_icon("CurveCreate", "EditorIcons")  # File icon_curve_create.svg
-	var icn_curve_delete = gui.get_icon("CurveDelete", "EditorIcons")  # File icon_curve_close.svg
+	# gd4
+	#var theme = gui.get_editor_interface().get_base_control().theme
+	var theme = gui
+	var icn_curve_edit = theme.get_icon("CurveEdit", "EditorIcons")  # File icon_curve_edit.svg
+	var icn_curve_create = theme.get_icon("CurveCreate", "EditorIcons")  # File icon_curve_create.svg
+	var icn_curve_delete = theme.get_icon("CurveDelete", "EditorIcons")  # File icon_curve_close.svg
 
 	select_mode.icon = icn_curve_edit
 	add_mode.icon = icn_curve_create

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -1,6 +1,10 @@
 tool
 extends HBoxContainer
 
+#gd4
+# To make the toolbar class work with the new UI, need to go into the tscn
+# file and then for each of the _mode buttons, set the theme: type variation
+# to FlatButton which should be already available.
 
 signal mode_changed
 

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -18,14 +18,14 @@ enum CreateMenu {
 	SELECT_CONTAINER,
 	CONTAINER,
 	POINT,
-	LANE
+	LANE,
 	TWO_X_TWO,
 }
 
 enum MenuMode {
 	STANDARD,
 	SAVED_SUBSCENE, # Don't offer to create children
-	EDGE_SELECTED # Not yet used, could offer intersections/next pieces to add.
+	EDGE_SELECTED, # Not yet used, could offer intersections/next pieces to add.
 }
 
 var menu_mode = MenuMode.STANDARD

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -179,7 +179,7 @@ func test_on_road_updated_pt_transform():
 	# Trigger a transform equivalent to moving the point in the viewport.
 	# Changing global_transform doesn't work since it checks for editor,
 	# so we need to directly call the on_transform function.
-	p1.on_transform()
+	p1.emit_transform()
 
 	# Validate that the road segment was generated (based on signal emission)
 	var res = get_signal_parameters(container, 'on_road_updated')


### PR DESCRIPTION
This is based on going through some manual updates after using the auto conversion tool. More changes could be made to help improve this.

Note: this is NOT representing a conversion to godot 4 itself, just making it easier. In the event we actually decide to properly support godot 4 and godot 3 in parallel, these changes will make it much more manageable.