### PR TITLE
Fix not in tree startup errors

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -506,11 +506,20 @@ func _invalidate_edge(_idx, autofix: bool, reason=""):
 
 
 func rebuild_segments(clear_existing=false):
+	if not is_inside_tree():
+		# This most commonly happens in the editor on project restart, where
+		# each opened scene tab is quickly loaded and then apparently unloaded,
+		# so tab one last saved as not active will defer call rebuild, and by
+		# the time rebuild_segments occurs, it has already been disable.
+		# With this early return, we avoid all the issues of this nature:
+		# Cannot get path of node as it is not in a scene tree.
+		# scene/3d/spatial.cpp:407 - Condition "!is_inside_tree()" is true. Returned: Transform()
+		return
 	update_edges()
 	validate_edges(clear_existing)
 	_needs_refresh = false
 	if debug:
-		print("Rebuilding RoadSegments")
+		print("Rebuilding RoadSegments %s" % self.name)
 
 	if clear_existing:
 		segid_map = {}

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -112,10 +112,6 @@ func _ready():
 	update_edges()
 	validate_edges()
 
-	# Per below, this is technicaly redundant/not really doing anything.
-	_dirty = true
-	call_deferred("_dirty_rebuild_deferred")
-
 
 # Workaround for cyclic typing
 func is_road_container() -> bool:

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -390,7 +390,7 @@ func validate_edges(autofix: bool = false) -> bool:
 
 		# Pre-check, ensure local node paths are good.
 		var this_pt = get_node_or_null(this_pt_path)
-		if this_pt == null or not is_instance_valid(this_pt):
+		if  not is_instance_valid(this_pt):
 			is_valid = false
 			_invalidate_edge(_idx, autofix, "edge_rp_local node reference is invalid")
 			continue

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -39,6 +39,9 @@ var _press_init_pos: Vector2
 
 var _new_selection: Node # RoadPoint or RoadContainer
 
+var _edi_debug := false
+
+
 func _enter_tree():
 	add_spatial_gizmo_plugin(road_point_gizmo)
 	add_inspector_plugin(road_point_editor)
@@ -550,8 +553,11 @@ func get_nearest_road_point(camera: Camera, mouse_pos: Vector2) -> RoadPoint:
 			return nearest_point
 
 
+## Get the nearest edge RoadPoint for the given container
 func get_nearest_edge_road_point(container: RoadContainer, camera: Camera, mouse_pos: Vector2):
-	# get the nearest edge RoadPoint for the given container
+	if _edi_debug:
+		print_debug("get_nearest_edge_road_point")
+
 	var closest_rp:RoadPoint
 	var closest_dist: float
 	for pth in container.edge_rp_locals:

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -90,6 +90,8 @@ func rem_lane_rev_pressed():
 
 
 func sel_rp_next_pressed():
+	#gd4
+	# not is empty
 	if sel_road_point.next_pt_init:
 		var next_pt = sel_road_point.get_node(sel_road_point.next_pt_init)
 		_edi.get_selection().call_deferred("remove_node", sel_road_point)
@@ -97,6 +99,8 @@ func sel_rp_next_pressed():
 
 
 func sel_rp_prior_pressed():
+	#gd4
+	# not is empty
 	if sel_road_point.prior_pt_init:
 		var prior_pt = sel_road_point.get_node(sel_road_point.prior_pt_init)
 		_edi.get_selection().call_deferred("remove_node", sel_road_point)

--- a/demo/test_scene.gd
+++ b/demo/test_scene.gd
@@ -29,4 +29,4 @@ func _on_timeout():
 
 func _on_tween_complete(_object, _key):
 	print("Tween finished, new y: ", a_point.global_transform.origin.y)
-	a_point.on_transform()
+	a_point.emit_transform()

--- a/demo/test_scene.tscn
+++ b/demo/test_scene.tscn
@@ -141,7 +141,7 @@ gutter_profile = Vector2( 0.5, -1 )
 prior_pt_init = NodePath("../disc_5")
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( -4.37114e-08, 1, 4.37114e-08, 0, -4.37114e-08, 1, 1, 4.37114e-08, 1.91069e-15, 11.7931, 31.3969, 9.17629 )
+transform = Transform( -4.37114e-08, 0.355401, -0.934714, 0, 0.934714, 0.355401, 1, 1.55351e-08, -4.08576e-08, -31.0353, 19.5009, -0.18366 )
 
 [node name="RigidBody" type="RigidBody" parent="."]
 transform = Transform( 0.985076, -0.172118, 0, 0.163502, 0.935763, 0.312434, -0.0537757, -0.307772, 0.949939, 5.43023, 5.1977, -8.82278 )


### PR DESCRIPTION
Fixing the primary cause of startup console errors if multiple scenes open.

Before this change we could get many errors on startup if we had multiple startup scenes auto-opened with road generator usage. For any scene _other_ that the one which is set to active, we'd get these slew of errors:

```
Cannot get path of node as it is not in a scene tree.
scene/3d/spatial.cpp:407 - Condition "!is_inside_tree()" is true. Returned: Transform()
```

These were hard to debug initially since it gives no culprit line outputs, and may be an issue very unique to the editor. But the scene check is a safer one anyways for rebuild segments worth keeping for production builds too. Need to test exported project still work with this.