### PR TITLE
46 update lanesegments

### DIFF
--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -297,12 +297,12 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		# in and out at the edges.
 		new_ln.curve.add_point(
 			new_ln.to_local(in_pos),
-			curve.get_point_in(0),
-			curve.get_point_out(0))
+			new_ln.to_local(to_global(curve.get_point_in(0))),
+			new_ln.to_local(to_global(curve.get_point_out(0))))
 		new_ln.curve.add_point(
 			new_ln.to_local(out_pos),
-			curve.get_point_in(1),
-			curve.get_point_out(1))
+			new_ln.to_local(to_global(curve.get_point_in(1))),
+			new_ln.to_local(to_global(curve.get_point_out(1))))
 
 		# Visually display.
 		new_ln.draw_in_editor = container.draw_lanes_editor


### PR DESCRIPTION
Hey @TheDuckCow, there is still ongoing work in this branch. But, here is the incremental change we talked about in order to resolve some of the RoadLane wonkiness.

The simplest test case was to create a 2x2 Road, select both RoadPoints, and rotate 45°. The road geometry looked fine. But, the RoadLanes zigzagged across the road.

What this change does: When adding new RoadLanes, it translates the Curve Point In and Out values from RoadSegment Local Space to Global Space. Then, from Global to RoadPoint/RoadLane Local Space.

An alternative workaround was to add the RoadLanes as children of the RoadSegment instead of the RoadPoint. That fixed the wonkiness. But, it broke the AI logic that expected to find the RoadLanes as children of the RoadPoint.