### PR TITLE
Added shift-for-bulk operations and copy/paste attributes

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -290,7 +290,7 @@ func get_manager(): # -> Optional[RoadManager]
 	return _manager
 
 
-func get_roadpoints() -> Array:
+func get_roadpoints(skip_edge_connected=false) -> Array:
 	var rps = []
 	for obj in get_children():
 		if not obj is RoadPoint:
@@ -299,6 +299,13 @@ func get_roadpoints() -> Array:
 			continue # Assume local chunk has dealt with the geo visibility.
 		var pt:RoadPoint = obj
 		rps.append(pt)
+
+	if skip_edge_connected:
+		# Filter out pts which shouldn't be lane-changed (ie due to containers)
+		for itm in rps:
+			if itm.cross_container_connected():
+				rps.erase(itm)
+
 	return rps
 
 

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -438,38 +438,37 @@ func get_next_rp():
 	return null
 
 
-## Get the ending node after following this direction
+## Get the last RoadPoint in this direction, allowing for intermediate flipped directions
 func get_last_rp(direction: int):
 	var _next_itr_point = null
 	var _prev_itr_point = null
 	var first_loop := true
-	var _count := 0
-	while _next_itr_point != self:  # Exit cond for a full sircle around
-		_count += 1
-		print("Iteration ", _count)
+	while _next_itr_point != self:  # Exit cond for a full circle around
 		if first_loop:
 			first_loop = false
 			# First iteration, should be deterministic which way to go
 			if direction == PointInit.NEXT:
 				if not self.next_pt_init:
 					return self
-				_next_itr_point = self.get_node(self.next_pt_init)
+				_next_itr_point = self.get_node_or_null(self.next_pt_init)
 			else:
 				if not self.prior_pt_init:
 					return self
-				_next_itr_point = self.get_node(self.prior_pt_init)
+				_next_itr_point = self.get_node_or_null(self.prior_pt_init)
+			if not is_instance_valid(_next_itr_point) or not _next_itr_point.has_method("is_road_point"):
+				return self
 			_prev_itr_point = self
 			continue
 
 		# Thereafter, just make sure the next selection != the last
 		var this_tmp = _next_itr_point.get_node_or_null(_next_itr_point.next_pt_init)
-		if this_tmp == null:
+		if this_tmp == null or not this_tmp.has_method("is_road_point"):
 			# means it was the end of the line (as the other dir would be the prior iter)
 			return _next_itr_point
 		if this_tmp == _prev_itr_point:
 			# Doubled back maybe due to flipped dir; Just try the other direction
 			this_tmp = _next_itr_point.get_node_or_null(_next_itr_point.prior_pt_init)
-		if this_tmp == null:
+		if this_tmp == null or not this_tmp.has_method("is_road_point"):
 			# means it was the end of the line!
 			return _next_itr_point
 		if this_tmp == _prev_itr_point:

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -352,6 +352,22 @@ func is_on_edge() -> bool:
 	return true
 
 
+## Returns true if either the forward or reverse RP connection exists to another container
+##
+## Useful for filtering out edges which should not be modified (given it
+## would no longer match the mirrored RoadPoint on the other container).
+func cross_container_connected() -> bool:
+	if not is_on_edge():
+		return false
+	var _pr = get_prior_rp()
+	if is_instance_valid(_pr) and _pr.container != self.container:
+		return true
+	var _nt = get_next_rp()
+	if is_instance_valid(_nt) and _nt.container != self.container:
+		return true
+	return false
+
+
 ## Indicates whether this direction is connected, accounting for container connections
 func is_prior_connected() -> bool:
 	if self.prior_pt_init:

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -616,20 +616,24 @@ func update_traffic_dir(traffic_update):
 
 
 ## Takes an existing RoadPoint and returns a new copy
-func copy_settings_from(ref_road_point: RoadPoint) -> void:
+func copy_settings_from(ref_road_point: RoadPoint, copy_transform: bool = true) -> void:
+	var tmp_auto_lane = ref_road_point.auto_lanes
 	auto_lanes = false
 	lanes = ref_road_point.lanes.duplicate(true)
 	traffic_dir = ref_road_point.traffic_dir.duplicate(true)
-	auto_lanes = ref_road_point.auto_lanes
+	auto_lanes = tmp_auto_lane
 	lane_width = ref_road_point.lane_width
 	shoulder_width_l = ref_road_point.shoulder_width_l
 	shoulder_width_r = ref_road_point.shoulder_width_r
 	gutter_profile.x = ref_road_point.gutter_profile.x
 	gutter_profile.y = ref_road_point.gutter_profile.y
-	prior_mag = ref_road_point.prior_mag
-	next_mag = ref_road_point.next_mag
-	global_transform = ref_road_point.global_transform
+	create_geo = ref_road_point.create_geo
 	_last_update_ms = ref_road_point._last_update_ms
+
+	if copy_transform:
+		prior_mag = ref_road_point.prior_mag
+		next_mag = ref_road_point.next_mag
+		global_transform = ref_road_point.global_transform
 
 
 ## Returns true if RoadPoint is primary selection in Scene panel

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -422,6 +422,50 @@ func get_next_rp():
 	return null
 
 
+## Get the ending node after following this direction
+func get_last_rp(direction: int):
+	var _next_itr_point = null
+	var _prev_itr_point = null
+	var first_loop := true
+	var _count := 0
+	while _next_itr_point != self:  # Exit cond for a full sircle around
+		_count += 1
+		print("Iteration ", _count)
+		if first_loop:
+			first_loop = false
+			# First iteration, should be deterministic which way to go
+			if direction == PointInit.NEXT:
+				if not self.next_pt_init:
+					return self
+				_next_itr_point = self.get_node(self.next_pt_init)
+			else:
+				if not self.prior_pt_init:
+					return self
+				_next_itr_point = self.get_node(self.prior_pt_init)
+			_prev_itr_point = self
+			continue
+
+		# Thereafter, just make sure the next selection != the last
+		var this_tmp = _next_itr_point.get_node_or_null(_next_itr_point.next_pt_init)
+		if this_tmp == null:
+			# means it was the end of the line (as the other dir would be the prior iter)
+			return _next_itr_point
+		if this_tmp == _prev_itr_point:
+			# Doubled back maybe due to flipped dir; Just try the other direction
+			this_tmp = _next_itr_point.get_node_or_null(_next_itr_point.prior_pt_init)
+		if this_tmp == null:
+			# means it was the end of the line!
+			return _next_itr_point
+		if this_tmp == _prev_itr_point:
+			# Infinite loop issue, shouldn't happen. Just return.
+			return this_tmp
+		_prev_itr_point = _next_itr_point
+		_next_itr_point = this_tmp
+
+	# failed to return early, must be a loop
+	return self
+
+
 # Goal is to assign the appropriate sequence of textures for this lane.
 #
 # This will intelligently construct the sequence of left-right textures, knowing

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -41,6 +41,9 @@ var _new_selection: Node # RoadPoint or RoadContainer
 
 var _edi_debug := false
 
+# For use by road_point_edit and panel, keys are props on RoadPoint
+var copy_attributes:Dictionary = {}
+
 
 func _enter_tree():
 	add_spatial_gizmo_plugin(road_point_gizmo)

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -6,6 +6,7 @@ var _editor_plugin: EditorPlugin
 # EditorInterface, don't use as type:
 # https://github.com/godotengine/godot/issues/85079
 var _edi setget set_edi
+var copy_ref:RoadPoint  # For use in panel to copy settings
 
 
 func _init(editor_plugin: EditorPlugin):
@@ -34,6 +35,10 @@ func parse_begin(object):
 	#panel_instance.on_add_connected_rp.connect(_handle_add_connected_rp)
 	panel_instance.connect("on_lane_change_pressed", self, "_handle_on_lane_change_pressed")
 	panel_instance.connect("on_add_connected_rp", self, "_handle_add_connected_rp")
+	panel_instance.connect("assign_copy_target", self, "_assign_copy_target")
+	panel_instance.connect("apply_settings_target", self, "_apply_settings_target")
+
+	panel_instance.has_copy_ref = true and _editor_plugin.copy_attributes  # hack to bool-ify
 
 
 
@@ -129,3 +134,41 @@ func _handle_add_connected_rp_undo(selection, point_init_type):
 	_edi.get_selection().call_deferred("remove_node", rp)
 	if is_instance_valid(rp):
 		rp.queue_free()
+
+
+func _assign_copy_target(target) -> void:
+	_editor_plugin.copy_attributes = {
+		"traffic_dir": target.traffic_dir,
+		"auto_lanes": target.auto_lanes,
+		"lanes": target.lanes,
+		"lane_width": target.lane_width,
+		"shoulder_width_l": target.shoulder_width_l,
+		"shoulder_width_r": target.shoulder_width_r,
+		"gutter_profile": target.gutter_profile,
+		"create_geo": target.create_geo
+	}
+
+func _apply_settings_target(target, all:bool) -> void:
+	var undo_redo = _editor_plugin.get_undo_redo()
+
+	var _pts: Array
+	if all:
+		undo_redo.create_action("Apply settings to all container RoadPoints")
+		_pts = target.container.get_roadpoints(false) # Skip cross connected
+	else:
+		undo_redo.create_action("Apply settings to RoadPoint")
+		_pts = [target]
+
+	for itm in _pts:
+		for key in _editor_plugin.copy_attributes.keys():
+			undo_redo.add_do_property(itm, key, _editor_plugin.copy_attributes[key])
+			undo_redo.add_undo_property(itm, key, itm.get(key))
+
+	# Ensure geometry gets updated
+	if all:
+		undo_redo.add_do_method(target.container, "rebuild_segments")
+		undo_redo.add_undo_method(target.container, "rebuild_segments")
+	else:
+		undo_redo.add_do_method(target, "emit_transform")
+		undo_redo.add_undo_method(target, "emit_transform")
+	undo_redo.commit_action()

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -45,25 +45,35 @@ func set_edi(value):
 ##
 ## selected: RoadPoint
 ## change_type: RoadPoint.TrafficUpdate enum value
-func _handle_on_lane_change_pressed(selected, change_type):
+func _handle_on_lane_change_pressed(selected, change_type, bulk:bool):
 	var undo_redo = _editor_plugin.get_undo_redo()
+	var loop_over := []
+	if bulk:
+		loop_over = selected.container.get_roadpoints()
+	else:
+		loop_over = [selected]
+
 	match change_type:
 		RoadPoint.TrafficUpdate.ADD_FORWARD:
 			undo_redo.create_action("Add forward lane")
-			undo_redo.add_do_method(selected, "update_traffic_dir", change_type)
-			undo_redo.add_undo_method(selected, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_FORWARD)
+			for _rp in loop_over:
+				undo_redo.add_do_method(_rp, "update_traffic_dir", change_type)
+				undo_redo.add_undo_method(_rp, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_FORWARD)
 		RoadPoint.TrafficUpdate.ADD_REVERSE:
 			undo_redo.create_action("Add reverse lane")
-			undo_redo.add_do_method(selected, "update_traffic_dir", change_type)
-			undo_redo.add_undo_method(selected, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_REVERSE)
+			for _rp in loop_over:
+				undo_redo.add_do_method(_rp, "update_traffic_dir", change_type)
+				undo_redo.add_undo_method(_rp, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_REVERSE)
 		RoadPoint.TrafficUpdate.REM_FORWARD:
 			undo_redo.create_action("Remove forward lane")
-			undo_redo.add_do_method(selected, "update_traffic_dir", change_type)
-			undo_redo.add_undo_method(selected, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_FORWARD)
+			for _rp in loop_over:
+				undo_redo.add_do_method(_rp, "update_traffic_dir", change_type)
+				undo_redo.add_undo_method(_rp, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_FORWARD)
 		RoadPoint.TrafficUpdate.REM_REVERSE:
 			undo_redo.create_action("Remove reverse lane")
-			undo_redo.add_do_method(selected, "update_traffic_dir", change_type)
-			undo_redo.add_undo_method(selected, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_REVERSE)
+			for _rp in loop_over:
+				undo_redo.add_do_method(_rp, "update_traffic_dir", change_type)
+				undo_redo.add_undo_method(_rp, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_REVERSE)
 		_:
 			push_error("Invalid change type")
 			return

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -49,7 +49,7 @@ func _handle_on_lane_change_pressed(selected, change_type, bulk:bool):
 	var undo_redo = _editor_plugin.get_undo_redo()
 	var loop_over := []
 	if bulk:
-		loop_over = selected.container.get_roadpoints()
+		loop_over = selected.container.get_roadpoints(true) # skip connected edges
 	else:
 		loop_over = [selected]
 

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -443,7 +443,7 @@ func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel:
 		var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
 		var _pts = []
 		if bulk:
-			_pts = point.container.get_roadpoints()
+			_pts = point.container.get_roadpoints(true) # Skip cross-connected
 		else:
 			_pts = [point]
 

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -18,6 +18,7 @@ var _editor_plugin: EditorPlugin
 var _editor_selection  # Of type: EditorSelection, but can't type due to exports.
 # Either value, or null if not mid action (magnitude handle mid action).
 var init_handle
+var init_handle_mirror
 var collider := CubeMesh.new()
 var collider_tri_mesh: TriangleMesh
 var lane_widget := Spatial.new()
@@ -291,12 +292,28 @@ func set_mag_handle(gizmo: EditorSpatialGizmo, index: int, camera: Camera, point
 	if (new_mag < 0 and index > 0) or (new_mag > 0 and index == 0):
 		new_mag = 0
 
+	var do_mirror:bool = Input.is_key_pressed(KEY_SHIFT)
+	var set_init: bool = false
 	if init_handle == null:
 		init_handle = new_mag
+		set_init = true
 	if index == 0:
 		roadpoint.prior_mag = -new_mag
+		if set_init:
+			init_handle_mirror = roadpoint.next_mag
+		if do_mirror:
+			roadpoint.next_mag = -new_mag
+		else:
+			roadpoint.next_mag = init_handle_mirror
 	else:
 		roadpoint.next_mag = new_mag
+		# Handle mirroring:
+		if set_init:
+			init_handle_mirror = roadpoint.prior_mag
+		if do_mirror:
+			roadpoint.prior_mag = new_mag
+		else:
+			roadpoint.prior_mag = init_handle_mirror
 	#gd4
 	#_redraw(gizmo)
 	redraw(gizmo)
@@ -374,18 +391,23 @@ func commit_mag_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: b
 	else:
 		if init_handle == null:
 			init_handle = current_value
+			# And init_handle_mirror?
+		var do_mirror:bool = Input.is_key_pressed(KEY_SHIFT)
 
 		if index == HandleType.PRIOR_MAG:
 			undo_redo.create_action("RoadPoint %s in handle" % point.name)
 			undo_redo.add_do_property(point, "prior_mag", current_value)
-			undo_redo.add_undo_property(
-				point,
-				"prior_mag",
-				-init_handle) # Weird this is neg, but seems to be necessary.
+			undo_redo.add_undo_property(point, "prior_mag", -init_handle) # Weird this is neg, but seems to be necessary.
+			if do_mirror:
+				undo_redo.add_do_property(point, "next_mag", current_value)
+				undo_redo.add_undo_property(point, "next_mag", init_handle_mirror)
 		elif index == HandleType.NEXT_MAG:
 			undo_redo.create_action("RoadPoint %s out handle" % point.name)
 			undo_redo.add_do_property(point, "next_mag", current_value)
 			undo_redo.add_undo_property(point, "next_mag", init_handle)
+			if do_mirror:
+				undo_redo.add_do_property(point, "prior_mag", current_value)
+				undo_redo.add_undo_property(point, "prior_mag", -init_handle_mirror)
 
 		# Either way, force gizmo redraw with do/undo (otherwise waits till hover)
 		undo_redo.add_do_method(self, "redraw", gizmo)
@@ -398,6 +420,7 @@ func commit_mag_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: b
 		undo_redo.commit_action()
 		point._notification(Spatial.NOTIFICATION_TRANSFORM_CHANGED)
 		init_handle = null
+		init_handle_mirror = null
 
 
 func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel: bool = false) -> void:
@@ -416,6 +439,14 @@ func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel:
 
 		# Initial state for undo
 		undo_redo.create_action("Change lane count")
+
+		# WIP for bulk change with shift
+#		var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
+#		var _pts = []
+#		if bulk:
+#			_pts = point.container.get_roadpoints()
+#		else:
+#			_pts = [point]
 
 		# Track changes
 		var new_fwd_mag = point.fwd_width_mag

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -440,13 +440,12 @@ func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel:
 		# Initial state for undo
 		undo_redo.create_action("Change lane count")
 
-		# WIP for bulk change with shift
-#		var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
-#		var _pts = []
-#		if bulk:
-#			_pts = point.container.get_roadpoints()
-#		else:
-#			_pts = [point]
+		var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
+		var _pts = []
+		if bulk:
+			_pts = point.container.get_roadpoints()
+		else:
+			_pts = [point]
 
 		# Track changes
 		var new_fwd_mag = point.fwd_width_mag
@@ -472,30 +471,34 @@ func commit_width_handle(gizmo: EditorSpatialGizmo, index: int, restore, cancel:
 			match index:
 				HandleType.REV_WIDTH_MAG:
 					for i in range(lane_change):
-						undo_redo.add_do_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_REVERSE)
-						undo_redo.add_undo_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_REVERSE)
+						for pt in _pts:
+							undo_redo.add_do_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_REVERSE)
+							undo_redo.add_undo_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_REVERSE)
 				HandleType.FWD_WIDTH_MAG:
 					for i in range(lane_change):
-						undo_redo.add_do_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_FORWARD)
-						undo_redo.add_undo_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_FORWARD)
+						for pt in _pts:
+							undo_redo.add_do_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_FORWARD)
+							undo_redo.add_undo_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_FORWARD)
 		elif lane_change < 0:
 			match index:
 				HandleType.REV_WIDTH_MAG:
 					for i in range(lane_change, 0):
-						undo_redo.add_do_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_REVERSE)
-						undo_redo.add_undo_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_REVERSE)
+						for pt in _pts:
+							undo_redo.add_do_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_REVERSE)
+							undo_redo.add_undo_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_REVERSE)
 				HandleType.FWD_WIDTH_MAG:
 					for i in range(lane_change, 0):
-						undo_redo.add_do_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_FORWARD)
-						undo_redo.add_undo_method(
-							point, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_FORWARD)
+						for pt in _pts:
+							undo_redo.add_do_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.REM_FORWARD)
+							undo_redo.add_undo_method(
+								pt, "update_traffic_dir", RoadPoint.TrafficUpdate.ADD_FORWARD)
 
 
 		refresh_gizmo(gizmo)

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -9,6 +9,7 @@ signal on_add_connected_rp(selection, point_init_type)
 # https://github.com/godotengine/godot/issues/85079
 var _edi setget set_edi
 var sel_road_point: RoadPoint
+onready var top_label = $SectionLabel
 onready var btn_add_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_add
 onready var btn_add_lane_rev = $HBoxLanes/HBoxSubLanes/rev_add
 onready var btn_rem_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_minus
@@ -32,6 +33,32 @@ func _ready():
 	btn_sel_rp_prior.connect("pressed", self, "sel_rp_prior_pressed")
 	btn_add_rp_next.connect("pressed", self, "add_rp_next_pressed")
 	btn_add_rp_prior.connect("pressed", self, "add_rp_prior_pressed")
+	update_labels(Input.is_key_pressed(KEY_SHIFT))
+
+func _unhandled_key_input(event: InputEventKey) -> void:
+	if not event.scancode == KEY_SHIFT:
+		return
+	update_labels(event.pressed)
+
+
+func update_labels(shift_pressed: bool) -> void:
+	# Without setting the right min width toggling shift will
+	# actually make the inspector shrink/grow a few pixels,
+	# offsetting the entire 3D view to the left (huge pain!)
+	# TODO: validate this works consistently across OS's and monitor scals/densities,
+	# could also use: # OS.get_screen_max_scale()
+	var fac: float = OS.get_screen_scale()
+	btn_sel_rp_next.rect_min_size.x = 150 * fac
+	btn_add_rp_next.rect_min_size.x = 150 * fac
+
+	if shift_pressed:
+		top_label.text = "Edit Container's RoadPoints"
+		btn_sel_rp_next.text = "Select Last RoadPoint"
+		btn_sel_rp_prior.text = "Select First RoadPoint"
+	else:
+		top_label.text = "Edit RoadPoint"
+		btn_sel_rp_next.text = "Select Next RoadPoint"
+		btn_sel_rp_prior.text = "Select Prior RoadPoint"
 
 
 func update_road_point_panel():

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -70,22 +70,26 @@ func add_lane_fwd_pressed():
 	#gd4
 	# Here and below, change to:
 	#on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD)
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD)
+	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
+	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD, bulk)
 	update_road_point_panel()
 
 
 func add_lane_rev_pressed():
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_REVERSE)
+	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
+	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_REVERSE, bulk)
 	update_road_point_panel()
 
 
 func rem_lane_fwd_pressed():
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.REM_FORWARD)
+	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
+	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.REM_FORWARD, bulk)
 	update_road_point_panel()
 
 
 func rem_lane_rev_pressed():
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.REM_REVERSE)
+	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
+	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.REM_REVERSE, bulk)
 	update_road_point_panel()
 
 

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -4,11 +4,14 @@ extends VBoxContainer
 
 signal on_lane_change_pressed(selection, direction, change_type)
 signal on_add_connected_rp(selection, point_init_type)
+signal assign_copy_target(selection)
+signal apply_settings_target(selection, all)
 
 # EditorInterface, don't use as type:
 # https://github.com/godotengine/godot/issues/85079
 var _edi setget set_edi
 var sel_road_point: RoadPoint
+var has_copy_ref: bool
 onready var top_label = $SectionLabel
 onready var btn_add_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_add
 onready var btn_add_lane_rev = $HBoxLanes/HBoxSubLanes/rev_add
@@ -22,6 +25,9 @@ onready var hbox_add_rp_next = $HBoxAddNextRP
 onready var hbox_add_rp_prior = $HBoxAddPriorRP
 onready var hbox_sel_rp_next = $HBoxSelNextRP
 onready var hbox_sel_rp_prior = $HBoxSelPriorRP
+onready var cp_settings: Button = $HBoxContainer/cp_settings
+onready var apply_setting: Button = $HBoxContainer/apply_setting
+onready var cp_to_all: Button = $HBoxContainer/cp_to_all
 
 
 func _ready():
@@ -50,6 +56,12 @@ func update_labels(shift_pressed: bool) -> void:
 		top_label.text = "Edit RoadPoint"
 		btn_sel_rp_next.text = "Select Next RoadPoint"
 		btn_sel_rp_prior.text = "Select Prior RoadPoint"
+
+	apply_setting.visible = not shift_pressed
+	cp_to_all.visible = shift_pressed
+
+	apply_setting.disabled = not has_copy_ref
+	cp_to_all.disabled = not has_copy_ref
 
 
 func update_road_point_panel():
@@ -162,3 +174,22 @@ func update_selected_road_point(object):
 
 func set_edi(value):
 	_edi = value
+
+
+func _on_cp_settings_pressed() -> void:
+	has_copy_ref = true
+	apply_setting.disabled = false
+	cp_to_all.disabled = false
+	emit_signal("assign_copy_target", sel_road_point)
+
+
+func _on_cp_to_all_pressed() -> void:
+	if not has_copy_ref:
+		return
+	emit_signal("apply_settings_target", sel_road_point, true)
+
+
+func _on_apply_setting_pressed() -> void:
+	if not has_copy_ref:
+		return
+	emit_signal("apply_settings_target", sel_road_point, false)

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -42,17 +42,8 @@ func _unhandled_key_input(event: InputEventKey) -> void:
 
 
 func update_labels(shift_pressed: bool) -> void:
-	# Without setting the right min width toggling shift will
-	# actually make the inspector shrink/grow a few pixels,
-	# offsetting the entire 3D view to the left (huge pain!)
-	# TODO: validate this works consistently across OS's and monitor scals/densities,
-	# could also use: # OS.get_screen_max_scale()
-	var fac: float = OS.get_screen_scale()
-	btn_sel_rp_next.rect_min_size.x = 150 * fac
-	btn_add_rp_next.rect_min_size.x = 150 * fac
-
 	if shift_pressed:
-		top_label.text = "Edit Container's RoadPoints"
+		top_label.text = "Edit RoadPoints [multi]"
 		btn_sel_rp_next.text = "Select Last RoadPoint"
 		btn_sel_rp_prior.text = "Select First RoadPoint"
 	else:

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -92,19 +92,29 @@ func rem_lane_rev_pressed():
 func sel_rp_next_pressed():
 	#gd4
 	# not is empty
-	if sel_road_point.next_pt_init:
-		var next_pt = sel_road_point.get_node(sel_road_point.next_pt_init)
-		_edi.get_selection().call_deferred("remove_node", sel_road_point)
-		_edi.get_selection().call_deferred("add_node", next_pt)
+	if not sel_road_point.next_pt_init:
+		return
+
+	var next_pt = sel_road_point.get_node(sel_road_point.next_pt_init)
+	if Input.is_key_pressed(KEY_SHIFT):
+		# Jump to to the "end" roadpoint in this direction (if it loops around, returns the same)
+		next_pt = next_pt.get_last_rp(RoadPoint.PointInit.NEXT)
+	_edi.get_selection().call_deferred("remove_node", sel_road_point)
+	_edi.get_selection().call_deferred("add_node", next_pt)
 
 
 func sel_rp_prior_pressed():
 	#gd4
 	# not is empty
-	if sel_road_point.prior_pt_init:
-		var prior_pt = sel_road_point.get_node(sel_road_point.prior_pt_init)
-		_edi.get_selection().call_deferred("remove_node", sel_road_point)
-		_edi.get_selection().call_deferred("add_node", prior_pt)
+	if not sel_road_point.prior_pt_init:
+		return
+
+	var prior_pt = sel_road_point.get_node(sel_road_point.prior_pt_init)
+	if Input.is_key_pressed(KEY_SHIFT):
+		# Jump to to the "end" roadpoint in this direction (if it loops around, returns the same)
+		prior_pt = prior_pt.get_last_rp(RoadPoint.PointInit.PRIOR)
+	_edi.get_selection().call_deferred("remove_node", sel_road_point)
+	_edi.get_selection().call_deferred("add_node", prior_pt)
 
 
 func add_rp_next_pressed():

--- a/addons/road-generator/ui/road_point_panel.tscn
+++ b/addons/road-generator/ui/road_point_panel.tscn
@@ -43,9 +43,11 @@ text = "Lanes:"
 margin_left = 45.0
 margin_right = 1024.0
 margin_bottom = 22.0
+rect_clip_content = true
 hint_tooltip = "Add RoadPoint to end of road"
 size_flags_horizontal = 3
 text = "+ Next RoadPoint"
+clip_text = true
 
 [node name="HBoxSelNextRP" type="HBoxContainer" parent="."]
 visible = false
@@ -65,8 +67,10 @@ text = "Lanes:"
 margin_left = 45.0
 margin_right = 1024.0
 margin_bottom = 22.0
+rect_clip_content = true
 size_flags_horizontal = 3
 text = "Select Next RoadPoint"
+clip_text = true
 
 [node name="HBoxLanes" type="HBoxContainer" parent="."]
 margin_top = 44.0
@@ -143,8 +147,10 @@ text = "Lanes:"
 margin_left = 45.0
 margin_right = 1024.0
 margin_bottom = 22.0
+rect_clip_content = true
 size_flags_horizontal = 3
 text = "Select Prior RoadPoint"
+clip_text = true
 
 [node name="HBoxAddPriorRP" type="HBoxContainer" parent="."]
 margin_top = 70.0
@@ -163,6 +169,8 @@ text = "Lanes:"
 margin_left = 45.0
 margin_right = 1024.0
 margin_bottom = 22.0
+rect_clip_content = true
 hint_tooltip = "Add RoadPoint to beginning of road"
 size_flags_horizontal = 3
 text = "+ Prior RoadPoint"
+clip_text = true

--- a/addons/road-generator/ui/road_point_panel.tscn
+++ b/addons/road-generator/ui/road_point_panel.tscn
@@ -174,3 +174,56 @@ hint_tooltip = "Add RoadPoint to beginning of road"
 size_flags_horizontal = 3
 text = "+ Prior RoadPoint"
 clip_text = true
+
+[node name="spacer" type="Control" parent="."]
+margin_top = 96.0
+margin_right = 1024.0
+margin_bottom = 101.0
+rect_min_size = Vector2( 0, 5 )
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+margin_top = 105.0
+margin_right = 1024.0
+margin_bottom = 127.0
+
+[node name="spacer" type="Label" parent="HBoxContainer"]
+modulate = Color( 1, 1, 1, 0 )
+margin_top = 4.0
+margin_right = 41.0
+margin_bottom = 18.0
+rect_min_size = Vector2( 40, 0 )
+text = "Lanes:"
+
+[node name="cp_settings" type="Button" parent="HBoxContainer"]
+margin_left = 45.0
+margin_right = 532.0
+margin_bottom = 22.0
+rect_clip_content = true
+size_flags_horizontal = 3
+text = "Copy Settings"
+clip_text = true
+
+[node name="apply_setting" type="Button" parent="HBoxContainer"]
+margin_left = 536.0
+margin_right = 1024.0
+margin_bottom = 22.0
+rect_clip_content = true
+size_flags_horizontal = 3
+disabled = true
+text = "Apply"
+clip_text = true
+
+[node name="cp_to_all" type="Button" parent="HBoxContainer"]
+visible = false
+margin_left = 700.0
+margin_right = 1024.0
+margin_bottom = 22.0
+rect_clip_content = true
+size_flags_horizontal = 3
+disabled = true
+text = "Apply All"
+clip_text = true
+
+[connection signal="pressed" from="HBoxContainer/cp_settings" to="." method="_on_cp_settings_pressed"]
+[connection signal="pressed" from="HBoxContainer/apply_setting" to="." method="_on_apply_setting_pressed"]
+[connection signal="pressed" from="HBoxContainer/cp_to_all" to="." method="_on_cp_to_all_pressed"]


### PR DESCRIPTION
For all 3D widget as well as the relevant RoadPoint's Inspector Panel buttons, we now can hold shift when performing/completing actions for different effects. As implemented right now, holding shift lets you:

- Mirror the prior/next magnitude when dragging the orange gizmo widget
- Add or remove a lane to _all_ RoadPoints on the same RoadContainer after pressing the button or dragging the blue gizmo
- Select the first or last (connected) RoadPoint within the same container via the RoadPoint panel

Would be great to also add a "copy all attributes" button too, to make it easy to tweak one RoadPoint and copy it over to the others.