### PR TITLE
Resolved texture assignment for segments between flipped RoadPoints

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -219,8 +219,10 @@ func _dirty_rebuild_deferred() -> void:
 func _set_draw_lanes_editor(value: bool):
 	_draw_lanes_editor = value
 	for seg in get_segments():
-		seg.update_lane_visibility()
-
+		if not generate_ai_lanes:
+			seg.clear_lane_segments()
+		else:
+			seg.update_lane_visibility()
 
 
 func _get_draw_lanes_editor() -> bool:
@@ -680,14 +682,6 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 		new_seg.material = material_resource
 		new_seg.check_rebuild()
 
-		if generate_ai_lanes:
-			new_seg.generate_lane_segments()
-
-		if create_edge_curves:
-			new_seg.generate_edge_curves()
-		else:
-			new_seg.clear_edge_curves()
-
 		return [true, new_seg]
 
 
@@ -769,11 +763,6 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 		point.prior_seg.low_poly = use_lowpoly
 		point.prior_seg.is_dirty = true
 		point.prior_seg.call_deferred("check_rebuild")
-		point.prior_seg.generate_edge_curves()
-		if not use_lowpoly:
-			point.prior_seg.generate_lane_segments()
-		else:
-			point.prior_seg.clear_lane_segments()
 		segs_updated.append(point.prior_seg)  # Track an updated RoadSegment
 
 	elif point.prior_pt_init and point.get_node(point.prior_pt_init).visible:
@@ -787,12 +776,6 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 		point.next_seg.low_poly = use_lowpoly
 		point.next_seg.is_dirty = true
 		point.next_seg.call_deferred("check_rebuild")
-		point.next_seg.generate_edge_curves()
-		if not use_lowpoly:
-			point.next_seg.generate_lane_segments()
-		else:
-			if point.next_seg:
-				point.next_seg.clear_lane_segments()
 		segs_updated.append(point.next_seg)  # Track an updated RoadSegment
 	elif point.next_pt_init and point.get_node(point.next_pt_init).visible:
 		var next = point.get_node(point.next_pt_init)

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -660,6 +660,11 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 	else:
 		var new_seg = RoadSegment.new(self)
 
+		# Must not move from origin, else geometry offsets would occur. Also
+		# implies to user to not interact with this item if ever exposed.
+		new_seg.set_meta("_edit_lock_", true)
+		new_seg.set_meta("_edit_group_", true)
+
 		# We want to, as much as possible, deterministically add the RoadSeg
 		# as a child of a consistent RoadPoint. Even though the segment is
 		# connected to two road points, it will only be placed as a parent of

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -602,6 +602,18 @@ func _rebuild():
 	# Create a low and high poly road, start with low poly.
 	_build_geo()
 
+	if container.create_edge_curves:
+		generate_edge_curves()
+	else:
+		clear_edge_curves()
+	# Check if lowpoly AND in the editor, to bypass lane drawing for performance.
+	# TODO: remove this, once road_lane visualizer drawing is far more efficient
+	var skip_update: bool = low_poly and Engine.is_editor_hint()
+	if container.generate_ai_lanes and not skip_update:
+		generate_lane_segments()
+	else:
+		clear_lane_segments()
+
 
 func _update_curve():
 	curve.clear_points()

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -737,6 +737,17 @@ func _normal_for_offset_eased(curve: Curve3D, sample_position: float) -> Vector3
 
 	return normal_l.normalized()
 
+## @babybedbug's first code contribution! It's not functional code, but hey.
+#func build_grandparent(car):
+#	var beep = "ctylicious"
+#	var st = not in_my backyard
+#	if stroad_count AudioEffectEQ10
+#	&hearts; @ the gig
+#	<i> divas are working </i>
+#	knock knock
+#	divas are putting their lashes on
+#	return xoxoxo
+
 
 func _build_geo():
 	if not is_instance_valid(road_mesh):


### PR DESCRIPTION
This was an issue if two connected RoadPoints were both pointed towards each other or away from each other while being directly connected.

This does not yet resolve related issues with the RoadLane construction, though there are some improvements in making them reuse existing roadlanes.

Added new test for this scenario, now passing. Edit: Updated again now and still all passing

Closes #136 