### PR TITLE
Updating default density to 1 loop for 4m for improved performance

### DIFF
--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -11,7 +11,7 @@ extends Spatial
 # ------------------------------------------------------------------------------
 
 
-export(float) var density:float = 2.0  setget _set_density # Mesh density of generated segments.
+export(float) var density:float = 4.0  setget _set_density # Mesh density of generated segments.
 
 
 # ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -74,7 +74,7 @@ export(float) var lane_width := 4.0 setget _set_lane_width, _get_lane_width
 export(float) var shoulder_width_l := 2.0 setget _set_shoulder_width_l, _get_shoulder_width_l
 export(float) var shoulder_width_r := 2.0 setget _set_shoulder_width_r, _get_shoulder_width_r
 # Profile: x: how far out the gutter goes, y: how far down to clip.
-export(Vector2) var gutter_profile := Vector2(2.0, -2.0) setget _set_profile, _get_profile
+export(Vector2) var gutter_profile := Vector2(2.0, -0.5) setget _set_profile, _get_profile
 
 # Path to next/prior RoadPoint, relative to this RoadPoint itself.
 export(NodePath) var prior_pt_init setget _set_prior_pt_init, _get_prior_pt_init

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -27,7 +27,7 @@ var end_point:RoadPoint
 var curve:Curve3D
 var road_mesh:MeshInstance
 var material:Material
-var density := 2.00 # Distance between loops, bake_interval in m applied to curve for geo creation.
+var density := 4.00 # Distance between loops, bake_interval in m applied to curve for geo creation.
 var container # The managing container node for this road segment (grandparent).
 
 var is_dirty := true


### PR DESCRIPTION
I find that applying a density of 4 (which reads "1 mesh loop every 4 meters") is a better default than our current 2x, which has twice as many loop cuts. At 4m with the default lane width also of 4m, it makes for nearly square but long rectangles.

at density=2 (previewws)
<img width="911" alt="Screen Shot 2024-06-19 at 10 53 40 PM" src="https://github.com/TheDuckCow/godot-road-generator/assets/2958461/44fcd0cc-4927-4c65-8043-6f9df2fcddda">

at density=4 (new)
<img width="919" alt="Screen Shot 2024-06-19 at 10 53 19 PM" src="https://github.com/TheDuckCow/godot-road-generator/assets/2958461/84b52cbf-b818-4ce8-b2e2-f37d3f17e910">

Of course, really sharp turns will still look a little low poly on the outside edge. And turns with roads with a higher number of lanes will also tend to look courser. But I do feel this is still a good general default starting place. In wheel steal game, for instance, we have a density of 3 but if not for the discontinuity of CSG mesh creation, would push it higher.