### PR TITLE
Save children to scene to avoid subscene reloading

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -134,6 +134,14 @@ func is_subscene() -> bool:
 	return filename and self != get_tree().edited_scene_root
 
 
+func has_visible_children() -> bool:
+	return debug_scene_visible or visible_children
+
+
+func get_owner() -> Node:
+	return self.owner if is_instance_valid(self.owner) else self
+
+
 #gd4
 #func _get_configuration_warnings() -> PackedStringArray:
 func _get_configuration_warning() -> String:
@@ -517,13 +525,6 @@ func validate_edges(autofix: bool = false) -> bool:
 		print("Found invalid edges on %s" % self.name)
 	return is_valid
 
-
-func has_visible_children() -> bool:
-	return debug_scene_visible or visible_children
-
-
-func get_owner() -> Node:
-	return self.owner if is_instance_valid(self.owner) else self
 
 ## A data cleanup way to clear invalid edges.
 ##

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -64,8 +64,8 @@ func _init(_container):
 
 func _ready():
 	do_roadmesh_creation()
-	if container.debug_scene_visible and is_instance_valid(road_mesh):
-		road_mesh.owner = container.owner
+	if container.has_visible_children() and is_instance_valid(road_mesh):
+		road_mesh.owner = container.get_owner()
 
 
 # Workaround for cyclic typing
@@ -102,8 +102,8 @@ func add_road_mesh() -> void:
 	road_mesh = MeshInstance.new()
 	add_child(road_mesh)
 	road_mesh.name = "road_mesh"
-	if container.debug_scene_visible and is_instance_valid(road_mesh):
-		road_mesh.owner = container.owner
+	if container.has_visible_children() and is_instance_valid(road_mesh):
+		road_mesh.owner = container.get_owner()
 
 
 func remove_road_mesh():
@@ -331,8 +331,8 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		if not is_instance_valid(ln_child) or not ln_child is RoadLane:
 			ln_child = RoadLane.new()
 			_par.add_child(ln_child)
-			if container.debug_scene_visible:
-				ln_child.owner = container.owner
+			if container.has_visible_children():
+				ln_child.owner = container.get_owner()
 			ln_child.add_to_group(container.ai_lane_group)
 			ln_child.set_meta("_edit_lock_", true)
 		else:
@@ -648,7 +648,7 @@ func _update_curve():
 	_set_curve_point(curve, end_point, end_mag, _end_flip_mult)
 
 	# Show this primary curve in the scene hierarchy if the debug state set.
-	if container.debug_scene_visible:
+	if container.has_visible_children():
 		var found_path = false
 		var path_node: Path
 		for ch in self.get_children():
@@ -661,7 +661,7 @@ func _update_curve():
 		if not found_path:
 			path_node = Path.new()
 			self.add_child(path_node)
-			path_node.owner = container.owner
+			path_node.owner = container.get_owner()
 			path_node.name = "RoadSeg primary curve"
 		path_node.curve = curve
 

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -943,7 +943,7 @@ func _insert_geo_loop(
 		# Prepare attributes for add_vertex.
 		# Long edge towards origin, p1
 		#st.add_normal(Vector3(0, 1, 0))
-		quad(
+		_quad(
 			st,
 			[
 				Vector2(uv_l, uv_y_end),
@@ -1026,7 +1026,7 @@ func _insert_geo_loop(
 			uv_r = 0.0 * uv_width
 		# LEFT (between pos:_s and _m, and between uv:_l and _m)
 		# The flat part of the shoulder on both sides
-		quad(
+		_quad(
 			st,
 			[
 				Vector2(uv_m if dir == 1 else uv_l, uv_y_end),
@@ -1043,7 +1043,7 @@ func _insert_geo_loop(
 
 		# The gutter, lower part of the shoulder on both sides.
 		if dir == 1:
-			quad(
+			_quad(
 				st,
 				[
 					Vector2(uv_l, uv_y_end),
@@ -1058,7 +1058,7 @@ func _insert_geo_loop(
 					start_loop + start_basis * (pos_near_l + gutr_near.x) * dir + Vector3(0, gutr_near.y, 0),
 				])
 		else:
-			quad(
+			_quad(
 				st,
 				[
 					Vector2(uv_m, uv_y_end),
@@ -1077,7 +1077,7 @@ func _insert_geo_loop(
 # Generate a quad with two triangles for a list of 4 points/uvs in a row.
 # For convention, do cloclwise from top-left vert, where the diagonal
 # will go from bottom left to top right.
-static func quad(st:SurfaceTool, uvs:Array, pts:Array) -> void:
+static func _quad(st:SurfaceTool, uvs:Array, pts:Array) -> void:
 	# Triangle 1.
 	#gd4
 	#st.set_uv(uvs[0]) # here and below


### PR DESCRIPTION
This PR primarily adds a new setting to cache or save internal auto generator nodes to the scene tree. By being added to the scene tree, things like the mesh array actually get saved. The intent is this means that for instanced scenes, we don't need regenerate roads or anything on the fly such as during transform. This also helps get around the issue of #169 since we'll just make sure the curves don't get regenerated. We'll just recommend that people don't rotate RoadContainers inside dynamic scenes.

This is still a WIP and some things are broken, such as the connection tool going from a dynamic RP to a saved scene (but the other way around works). I'm having to revisit some fundamentals on things like the names of RoadSegments, and I'm also playing with locked settings to help encourage users to not touch what was previously intentionally hidden. But for saved scenes to work as intended, _everything_ needs to be added to the scene.

Closes https://github.com/TheDuckCow/godot-road-generator/issues/109

For reference, what this check box does is described by this image - except one further improvement of this branch is that the RoadLanes pictured below are _no longer_ constantly created and destroyed, which helps with performance and not accidentally deleting users' stuff.

<img width="995" alt="Screen Shot 2024-06-11 at 6 11 46 PM" src="https://github.com/TheDuckCow/godot-road-generator/assets/2958461/f1fb75d3-d497-45c7-94db-ea2e0583923c">