### PR TITLE
Added collider to group with assigned meta for easier script fetching

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -29,6 +29,8 @@ export(bool) var create_edge_curves := false setget _set_create_edge_curves
 
 export(bool) var generate_ai_lanes := false setget _set_gen_ai_lanes
 export(String) var ai_lane_group := "road_lanes" setget _set_ai_lane_group
+export(String) var collider_group_name := "" setget _set_collider_group
+export(String) var collider_meta_name := "" setget _set_collider_meta
 
 export(bool) var debug := false
 export(bool) var draw_lanes_editor := false setget _set_draw_lanes_editor, _get_draw_lanes_editor
@@ -209,6 +211,16 @@ func _set_gen_ai_lanes(value: bool) -> void:
 func _set_ai_lane_group(value: String) -> void:
 	_defer_refresh_on_change()
 	ai_lane_group = value
+
+
+func _set_collider_group(value: String) -> void:
+	_defer_refresh_on_change()
+	collider_group_name = value
+
+
+func _set_collider_meta(value: String) -> void:
+	_defer_refresh_on_change()
+	collider_meta_name = value
 
 
 func _set_density(value) -> void:

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -806,10 +806,25 @@ func _build_geo():
 		st.set_material(material)
 	st.generate_normals()
 	road_mesh.mesh = st.commit()
+	road_mesh.cast_shadow = GeometryInstance.SHADOW_CASTING_SETTING_OFF
+	_create_collisions()
+
+
+func _create_collisions() -> void:
 	for ch in road_mesh.get_children():
 		ch.queue_free()  # Prior collision meshes
-	road_mesh.create_trimesh_collision() # Call deferred?
-	road_mesh.cast_shadow = GeometryInstance.SHADOW_CASTING_SETTING_OFF
+
+	# Could also manually create with Mesh.create_trimesh_shape(),
+	# but this is still advertised as a non-cheap solution.
+	road_mesh.create_trimesh_collision()
+	for ch in road_mesh.get_children():
+		if not ch is StaticBody:
+			continue
+		if container.collider_group_name != "":
+			ch.add_to_group(container.collider_group_name)
+		if container.collider_meta_name != "":
+			ch.set_meta(container.collider_meta_name, true)
+		ch.set_meta("_edit_lock_", true)
 
 
 func _insert_geo_loop(

--- a/test/unit/test_road_container.gd
+++ b/test/unit/test_road_container.gd
@@ -292,3 +292,18 @@ func test_container_disconnection():
 	assert_false(res, "Disconnection should fail since not connected in that direction")
 	res = pt1.disconnect_container(RoadPoint.PointInit.NEXT, RoadPoint.PointInit.NEXT)
 	assert_false(res, "Disconnection should fail with invalid edge directions")
+
+func test_container_snap_unsnap():
+	pass
+
+
+func test_collider_assignmens():
+	var container = add_child_autofree(RoadContainer.new())
+	container.collider_group_name = "test_collider_group"
+	container.collider_meta_name = "test_meta_name"
+	create_oneseg_container(container)
+
+	var _members = get_tree().get_nodes_in_group(container.collider_group_name)
+	assert_true(len(_members)>0, "Should have 1+ segmetns in test group name")
+	for _collider in _members:
+		assert_true(_collider.has_meta(container.collider_meta_name), "Meta name should be assigned")


### PR DESCRIPTION
Closes #176 by providing options to assign the generated static colliders. 

Test results:

`24 passed 0 failed.  Tests finished in 1.8s`