### PR TITLE
More responsive UI with some rebuilds prevented

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -14,22 +14,31 @@ signal on_transform(node)  # for internal purposes, to handle drags
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
-
+## Material applied to the generated meshes, expects specific trimsheet UV layout
 export(Material) var material_resource:Material setget _set_material
 
-# Mesh density of generated segments. -1 implies to use the parent RoadManager's value.
+## Mesh density of generated segments. -1 implies to use the parent RoadManager's value, higher
+## values like 10 mean higher spacing between loop cuts (ie a lower density; this terminology and
+## meaning is unintuitive, but matches the term used within the built in 3D curve property name)
 export(float) var density:float = -1.0  setget _set_density
 
-# Generate procedural road geometry
-# If off, it indicates the developer will load in their own custom mesh + collision.
+## Generate procedural road geometry
+## If off, it indicates the developer will load in their own custom mesh + collision.
 export(bool) var create_geo := true setget _set_create_geo
 # If create_geo is true, then whether to reduce geo mid transform.
 export(bool) var use_lowpoly_preview:bool = false
+## Whether to create approximated curves to fit along the forward, reverse, and center of the road.
+## Visible in the editor, useful for adding procedural generation along road edges or center lane.
 export(bool) var create_edge_curves := false setget _set_create_edge_curves
 
+## Whether to auto create RoadLanes for AI agents to follow, which are extensions of the native
+## 3D Curve, added to the runtime game as a child of RoadPoints when connections exist.
 export(bool) var generate_ai_lanes := false setget _set_gen_ai_lanes
+## Group name to assign to generated RoadLane nodes
 export(String) var ai_lane_group := "road_lanes" setget _set_ai_lane_group
+## Group name to assign to the staic bodies created within a RoadSegment
 export(String) var collider_group_name := "" setget _set_collider_group
+## Meta property name to assign to the static bodies created within a RoadSegment, value will always be true
 export(String) var collider_meta_name := "" setget _set_collider_meta
 
 export(bool) var debug := false

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -8,7 +8,7 @@ extends Spatial
 ## Emitted when a road segment has been (re)generated, returning the list
 ## of updated segments of type Array. Will also trigger on segments deleted,
 ## which will contain a list of nothing.
-signal on_road_updated (updated_segments)
+signal on_road_updated(updated_segments)
 signal on_transform(node)  # for internal purposes, to handle drags
 
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
@@ -702,8 +702,6 @@ func validate_edges(autofix: bool = false) -> bool:
 			pass
 	if is_valid:
 		_edge_error = ""
-		if debug:
-			print("All edges are valid on %s" % self.name)
 	elif debug:
 		print("Found invalid edges on %s" % self.name)
 	return is_valid
@@ -733,7 +731,7 @@ func _invalidate_edge(_idx, autofix: bool, reason=""):
 	edge_rp_target_dirs[_idx] = -1
 
 
-func rebuild_segments(clear_existing=false):
+func rebuild_segments(clear_existing := false):
 	if not is_inside_tree() or not _is_ready:
 		# This most commonly happens in the editor on project restart, where
 		# each opened scene tab is quickly loaded and then apparently unloaded,
@@ -799,6 +797,8 @@ func rebuild_segments(clear_existing=false):
 		print_debug("Road segs rebuilt: ", rebuilt)
 
 	# Aim to do a single signal emission across the whole container update.
+	# TODO: consider not signalling if none rebuilt,
+	# though right now returning = [] will still indicate the check was done (but not by whom)
 	emit_signal("on_road_updated", signal_rebuilt)
 
 

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -129,19 +129,12 @@ func _ready():
 	update_edges()
 	validate_edges()
 
-	# If we call this now, it will end up generating roads twice.
-	rebuild_segments(true)
+	# Waiting to mark _is_ready = true is the way we prevent each property
+	# value change from re-triggering rebuilds during scene setup. It's because
+	# each property value functionally gets "assigned" the value loaded from
+	# the tscn file, and thus triggers its set(get) functions which perform work
 	_is_ready = true
-	# This is due, evidently, to godot loading the scene in such a way where
-	# it actually sets the value to each property and thus also trigger its
-	# setget, and result in calling _dirty_rebuild_deferred. Class properties
-	# are assigned, thus triggering functions like _set_density, before the
-	# _ready function is ever called. Thus by the time _ready is happening,
-	# the _dirty flag is already set.
-
-	# Potentially redundant/recalled during scene init
-	#_dirty = true
-	#call_deferred("_dirty_rebuild_deferred")
+	rebuild_segments(true)
 
 
 # Workaround for cyclic typing

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -99,7 +99,14 @@ func get_containers() -> Array:
 	return res
 
 
+## Blocking function that will wait until all roads have been generated
 func rebuild_all_containers() -> void:
+	for ch in get_containers():
+		ch.rebuild_segments(true)
+
+
+## Regenerates each container with a deferred call per container
+func rebuild_all_containers_deferred() -> void:
 	for ch in get_containers():
 		ch._dirty = true
 		ch._dirty_rebuild_deferred()

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -100,9 +100,9 @@ func get_containers() -> Array:
 
 
 ## Blocking function that will wait until all roads have been generated
-func rebuild_all_containers() -> void:
+func rebuild_all_containers(clear_existing := false) -> void:
 	for ch in get_containers():
-		ch.rebuild_segments(true)
+		ch.rebuild_segments(clear_existing)
 
 
 ## Regenerates each container with a deferred call per container

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -408,7 +408,13 @@ func _handle_gui_select_mode(camera: Camera, event: InputEvent) -> bool:
 				# Skip the selected container. We already have its Edge RoadPoints
 				continue
 			for edge in sel_rp_edges:
+				if not is_instance_valid(edge):
+					#push_warning("Container has invalid edges: " + selected.name)
+					continue
 				var tgt_edge = cont.get_closest_edge_road_point(edge.global_translation)
+				if not is_instance_valid(tgt_edge):
+					#push_warning("Container has invalid edges: " + cont.name)
+					continue
 				var dist = (edge.global_translation - tgt_edge.global_translation).length()
 				if dist < ROADPOINT_SNAP_THRESHOLD and ((not min_dist) or dist < min_dist):
 					min_dist = dist

--- a/demo/performance_stress_test.gd
+++ b/demo/performance_stress_test.gd
@@ -1,0 +1,26 @@
+extends Spatial
+
+
+onready var manager:RoadManager = $RoadManager
+
+var rebuild_count := 0
+
+func _ready() -> void:
+	var containers := manager.get_containers()
+	var seg_counts := 0
+	for _node in containers:
+		var _cont: RoadContainer = _node
+		var res = _cont.connect("on_road_updated", self, "_roads_updated")
+		assert(res == OK)
+		seg_counts += len(_cont.get_segments())
+
+	var _time_start := OS.get_ticks_msec()
+	manager.rebuild_all_containers()
+	var _time_postgen = OS.get_ticks_msec()
+	print("Time to generate containers: %s ms" % (_time_postgen - _time_start))
+	print("%sx segment rebuilds compared to %s actual segments" % [rebuild_count, seg_counts])
+	assert(rebuild_count == seg_counts)
+
+
+func _roads_updated(segments: Array) -> void:
+	rebuild_count += len(segments)

--- a/demo/performance_stress_test.tscn
+++ b/demo/performance_stress_test.tscn
@@ -1,0 +1,807 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://addons/road-generator/nodes/road_container.gd" type="Script" id=1]
+[ext_resource path="res://addons/road-generator/resources/road_texture.material" type="Material" id=2]
+[ext_resource path="res://addons/road-generator/nodes/road_manager.gd" type="Script" id=3]
+[ext_resource path="res://addons/road-generator/nodes/road_point.gd" type="Script" id=4]
+[ext_resource path="res://demo/performance_stress_test.gd" type="Script" id=5]
+
+[sub_resource type="PlaneMesh" id=1]
+size = Vector2( 800, 700 )
+
+[sub_resource type="SpatialMaterial" id=2]
+albedo_color = Color( 0.439216, 0.556863, 0.470588, 1 )
+
+[node name="PerformanceStressTest" type="Spatial"]
+script = ExtResource( 5 )
+
+[node name="RoadManager" type="Spatial" parent="."]
+script = ExtResource( 3 )
+
+[node name="Road_001" type="Spatial" parent="RoadManager"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -223.524, 0, 0 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_001",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../crossroads"), NodePath("../Road_007") ]
+edge_rp_targets = [ NodePath("RP_001"), NodePath("RP_001") ]
+edge_rp_target_dirs = [ 0, 0 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_004") ]
+edge_rp_local_dirs = [ 0, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_001"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64294 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_001"]
+transform = Transform( 0.889155, -0.00163741, 0.457603, 0, 0.999994, 0.0035782, -0.457606, -0.00318157, 0.88915, -52.9417, -8.74535, 36.6253 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 54.4479
+next_mag = 54.4479
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_001"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341447, 0.999988, 0.0035379, 0.935004, -0.00444717, 0.35461, -14.1285, -8.60375, -67.9345 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_004")
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="RP_004" type="Spatial" parent="RoadManager/Road_001"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, -32.6386, -8.99536, -139.203 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_003")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="Road_007" type="Spatial" parent="RoadManager"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -287.324, 2.18279e-11, -144.846 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_007",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_001"), NodePath("../Road_011") ]
+edge_rp_targets = [ NodePath("RP_004"), NodePath("RP_003") ]
+edge_rp_target_dirs = [ 1, 1 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_004") ]
+edge_rp_local_dirs = [ 0, 0 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_007"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64294 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_007"]
+transform = Transform( 0.889155, -0.00163741, 0.457603, 0, 0.999994, 0.0035782, -0.457606, -0.00318157, 0.88915, -52.9417, -8.74535, 36.6253 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 54.4479
+next_mag = 54.4479
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_007"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341447, 0.999988, 0.0035379, 0.935004, -0.00444717, 0.35461, -79.42, -8.84603, -153.206 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_004")
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="RP_004" type="Spatial" parent="RoadManager/Road_007"]
+transform = Transform( 0.243998, 0.00209715, 0.969774, -0.00482447, 0.999988, -0.000948636, -0.969764, -0.00444717, 0.244005, -3.87503, -8.39848, -160.534 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+prior_mag = 29.5707
+next_mag = 29.5707
+
+[node name="Road_009" type="Spatial" parent="RoadManager"]
+transform = Transform( 1, -2.32831e-10, 1.78814e-07, 0, 1, -5.82077e-10, -1.78814e-07, 5.82077e-10, 1, -118.566, 3.03403e-05, -104.409 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_009",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ "", NodePath("../crossroads") ]
+edge_rp_targets = [ "", NodePath("RP_005") ]
+edge_rp_target_dirs = [ -1, 1 ]
+edge_rp_locals = [ NodePath("RP_003"), NodePath("RP_004") ]
+edge_rp_local_dirs = [ 1, 0 ]
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_009"]
+transform = Transform( 0.999385, -0.0016374, 0.0350143, 0.00152499, 0.999994, 0.00323696, -0.0350194, -0.00318157, 0.999382, -53.5183, -8.80458, 18.3113 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_004")
+prior_mag = 29.7258
+next_mag = 29.7258
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_009"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341447, 0.999988, 0.0035379, 0.935004, -0.00444717, 0.35461, -14.1285, -8.60375, -67.9345 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="RP_004" type="Spatial" parent="RoadManager/Road_009"]
+transform = Transform( 0.998589, -7.23345e-05, 0.053107, -3.09124e-11, 0.999999, 0.00136206, -0.0531071, -0.00136013, 0.998588, -48.2367, -8.78322, 76.4899 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="Road_010" type="Spatial" parent="RoadManager"]
+transform = Transform( -1, 4.65661e-10, -2.6077e-07, 6.67869e-17, 1, -8.14907e-10, 2.90573e-07, -5.82077e-10, -1, -146.823, 3.06601e-05, -240.278 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_010",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_011"), NodePath("../Road_009") ]
+edge_rp_targets = [ NodePath("RP_001"), NodePath("RP_003") ]
+edge_rp_target_dirs = [ 0, 1 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_003") ]
+edge_rp_local_dirs = [ 0, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_010"]
+transform = Transform( -0.0505929, -1.30103e-17, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64293 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_010"]
+transform = Transform( 0.889155, -0.00163741, 0.457603, 0, 0.999994, 0.0035782, -0.457606, -0.00318157, 0.88915, -52.9417, -8.74535, 36.6253 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 54.4479
+next_mag = 54.4479
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_010"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341447, 0.999988, 0.0035379, 0.935004, -0.00444717, 0.35461, -14.1285, -8.60375, -67.9345 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="Road_011" type="Spatial" parent="RoadManager"]
+transform = Transform( 1, -4.65661e-10, 3.46452e-07, 6.59195e-17, 1, -8.14907e-10, -3.76254e-07, 5.82077e-10, 1, -209.146, 3.03817e-05, -251.564 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_011",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_010"), NodePath("../Road_007") ]
+edge_rp_targets = [ NodePath("RP_001"), NodePath("RP_004") ]
+edge_rp_target_dirs = [ 0, 0 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_003") ]
+edge_rp_local_dirs = [ 0, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_011"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64294 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_011"]
+transform = Transform( 0.462312, -0.0016374, 0.886716, -0.00206417, 0.999994, 0.00292279, -0.886715, -0.00318157, 0.462305, -53.4888, -8.77643, 27.1324 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 54.4479
+next_mag = 54.4479
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_011"]
+transform = Transform( 0.243999, 0.00209715, 0.969774, -0.00482447, 0.999988, -0.000948636, -0.969764, -0.00444717, 0.244006, -82.0527, -8.39851, -53.8162 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_002")
+prior_mag = 29.5707
+next_mag = 52.689
+
+[node name="Road_005" type="Spatial" parent="RoadManager"]
+transform = Transform( -0.953132, 0.000823611, -0.302553, 0.00198438, 0.999992, -0.0035292, 0.302548, -0.00396417, -0.953126, 72.6631, 0.269027, -93.7067 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_005",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../crossroads2"), NodePath("../crossroads2") ]
+edge_rp_targets = [ NodePath("RP_003"), NodePath("RP_006") ]
+edge_rp_target_dirs = [ 0, 0 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_003") ]
+edge_rp_local_dirs = [ 0, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_005"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64294 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_005"]
+transform = Transform( 0.889155, -0.00163741, 0.457603, 0, 0.999994, 0.0035782, -0.457606, -0.00318157, 0.88915, -52.9417, -8.74535, 36.6253 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 54.4479
+next_mag = 54.4479
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_005"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341448, 0.999988, 0.00353792, 0.935004, -0.00444717, 0.354611, -22.2624, -8.37658, -20.6746 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="crossroads" type="Spatial" parent="RoadManager"]
+transform = Transform( 0.050593, 0, -0.998719, 0, 1, 0, 0.998719, 0, 0.050593, -174.817, 4.21801, 14.6347 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "crossroads",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_001"), NodePath("../Road_006"), NodePath("../Road_009"), NodePath("../crossroads3") ]
+edge_rp_targets = [ NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_004"), NodePath("RP_003") ]
+edge_rp_target_dirs = [ 0, 1, 0, 0 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_005"), NodePath("RP_009") ]
+edge_rp_local_dirs = [ 0, 0, 1, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -9.86789, -13.2134, 17.0682 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+
+[node name="RP_002" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( 0.99999, -6.16287e-06, 0.00452467, 0, 0.999999, 0.00136206, -0.00452468, -0.00136204, 0.999989, -10.6984, -12.9634, -38.2405 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_006")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="RP_003" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( 0.00200708, 0, 0.999998, 0, 1, 0, -0.999998, 0, 0.00200708, 17.372, -13.2134, -10.9459 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_004")
+
+[node name="RP_004" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( -0.00251761, -0.00136205, 0.999996, 0, 0.999999, 0.00136206, -0.999997, 3.42913e-06, -0.0025176, -10.0935, -13.201, -10.2371 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_005")
+next_pt_init = NodePath("../RP_003")
+prior_mag = 16.0
+next_mag = 16.057
+
+[node name="RP_005" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( -0.00251761, -0.00136205, 0.999996, 0, 0.999999, 0.00136206, -0.999997, 3.42913e-06, -0.0025176, -42.0937, -13.0012, -10.1565 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_004")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="RP_006" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( 0.691816, 0.00379305, -0.722064, 0.000987756, 0.99998, 0.00619935, 0.722073, -0.00500203, 0.691799, 23.6082, -12.7579, -71.1098 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_007")
+next_pt_init = NodePath("../RP_002")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="RP_007" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( 0.355349, 0.00701996, -0.934707, 0.000897941, 0.999969, 0.00785147, 0.934733, -0.00362932, 0.355332, 86.339, 6.64803, -91.377 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+gutter_profile = Vector2( 0.1, -2 )
+prior_pt_init = NodePath("../RP_008")
+next_pt_init = NodePath("../RP_006")
+prior_mag = 29.277
+next_mag = 29.277
+
+[node name="RP_008" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( 0.756972, 0.00830849, -0.653395, -0.00294245, 0.999952, 0.00930639, 0.653441, -0.00512209, 0.75696, 150.224, -13.1741, -150.57 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_009")
+next_pt_init = NodePath("../RP_007")
+prior_mag = 39.9215
+next_mag = 39.9215
+
+[node name="RP_009" type="Spatial" parent="RoadManager/crossroads"]
+transform = Transform( -0.300634, -0.00391743, 0.953732, -0.00215351, 0.999992, 0.00342861, -0.953738, -0.00102312, -0.30064, 112.229, -12.9167, -230.156 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_008")
+prior_mag = 54.0473
+next_mag = 54.0473
+
+[node name="crossroads3" type="Spatial" parent="RoadManager"]
+transform = Transform( 0.350388, 0.000823612, -0.936605, 0.00342428, 0.999992, 0.00216039, 0.936599, -0.00396417, 0.350382, 44.3944, 4.47878, 102.588 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "crossroads3",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_006"), NodePath("../Road_004"), NodePath("../crossroads"), NodePath("../Road_003") ]
+edge_rp_targets = [ NodePath("RP_002"), NodePath("RP_003"), NodePath("RP_009"), NodePath("RP_005") ]
+edge_rp_target_dirs = [ 1, 1, 1, 0 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_002"), NodePath("RP_003"), NodePath("RP_005") ]
+edge_rp_local_dirs = [ 0, 1, 0, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/crossroads3"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -9.86789, -13.2134, 17.0682 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+
+[node name="RP_002" type="Spatial" parent="RoadManager/crossroads3"]
+transform = Transform( 0.99999, -6.16287e-06, 0.00452467, 0, 0.999999, 0.00136206, -0.00452468, -0.00136204, 0.999989, -10.6984, -12.9634, -38.2405 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_001")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="RP_003" type="Spatial" parent="RoadManager/crossroads3"]
+transform = Transform( 0.00200708, 0, 0.999998, 0, 1, 0, -0.999998, 0, 0.00200708, 17.372, -13.2134, -10.9459 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_004")
+
+[node name="RP_004" type="Spatial" parent="RoadManager/crossroads3"]
+transform = Transform( -0.00251761, -0.00136205, 0.999996, 0, 0.999999, 0.00136206, -0.999997, 3.42913e-06, -0.0025176, -10.0935, -13.201, -10.2371 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_005")
+next_pt_init = NodePath("../RP_003")
+prior_mag = 16.0
+next_mag = 16.057
+
+[node name="RP_005" type="Spatial" parent="RoadManager/crossroads3"]
+transform = Transform( -0.00251761, -0.00136205, 0.999996, 0, 0.999999, 0.00136206, -0.999997, 3.42913e-06, -0.0025176, -42.0937, -13.0012, -10.1565 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_004")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="Road_002" type="Spatial" parent="RoadManager"]
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_002",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../crossroads2"), NodePath("../Road_004") ]
+edge_rp_targets = [ NodePath("RP_005"), NodePath("RP_002") ]
+edge_rp_target_dirs = [ 1, 0 ]
+edge_rp_locals = [ NodePath("RP_003"), NodePath("RP_004") ]
+edge_rp_local_dirs = [ 1, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_002"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64294 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+next_pt_init = NodePath("../RP_004")
+prior_mag = 42.2535
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_002"]
+transform = Transform( 0.290876, -0.0016374, 0.95676, -0.00256773, 0.999994, 0.00249204, -0.956757, -0.00318157, 0.29087, -52.9417, -8.74535, 36.6253 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 40.2279
+next_mag = 40.2279
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_002"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341447, 0.999988, 0.0035379, 0.935004, -0.00444717, 0.35461, -14.1285, -8.60375, -67.9345 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="RP_004" type="Spatial" parent="RoadManager/Road_002"]
+transform = Transform( -0.889155, 0.00163741, -0.457603, 1.59817e-10, 0.999994, 0.0035782, 0.457606, 0.00318157, -0.88915, 127.932, -8.87194, 7.92201 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_001")
+prior_mag = 36.7641
+next_mag = 36.7641
+
+[node name="Road_003" type="Spatial" parent="RoadManager"]
+transform = Transform( 0.308771, -0.00130918, -0.951136, -0.00215585, 0.999996, -0.0020763, 0.951134, 0.00269161, 0.308767, 1.09491, 0.672367, -136.634 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_003",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../crossroads2"), NodePath("../crossroads3") ]
+edge_rp_targets = [ NodePath("RP_002"), NodePath("RP_005") ]
+edge_rp_target_dirs = [ 1, 1 ]
+edge_rp_locals = [ NodePath("RP_001"), NodePath("RP_005") ]
+edge_rp_local_dirs = [ 0, 0 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_003"]
+transform = Transform( -0.0505929, 0, 0.998719, 0, 1, 0, -0.998719, 0, -0.0505929, 31.1614, -8.99536, 5.64294 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+prior_mag = 124.458
+next_mag = 42.2535
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_003"]
+transform = Transform( 0.907326, -0.00163741, -0.420424, 0.00282327, 0.999994, 0.00219833, 0.420418, -0.00318157, 0.907325, -111.917, -9.16494, -64.9002 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_001")
+prior_mag = 54.4479
+next_mag = 54.4479
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_003"]
+transform = Transform( -0.370357, 0.00209715, -0.928887, 0.00490763, 0.999988, 0.000300952, 0.928877, -0.00444717, -0.370363, 13.161, 9.50704, -64.7532 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+gutter_profile = Vector2( 0.1, -2 )
+prior_pt_init = NodePath("../RP_004")
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="RP_004" type="Spatial" parent="RoadManager/Road_003"]
+transform = Transform( -0.63821, 0.00333059, -0.769857, 0.00476213, 0.999989, 0.000378408, 0.769849, -0.00342465, -0.638218, 133.492, 1.61056, -1.47764 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+gutter_profile = Vector2( 0.1, -2 )
+prior_pt_init = NodePath("../RP_005")
+next_pt_init = NodePath("../RP_003")
+prior_mag = 42.1942
+next_mag = 42.1942
+
+[node name="RP_005" type="Spatial" parent="RoadManager/Road_003"]
+transform = Transform( -0.046574, -0.00703253, 0.998891, -0.00434346, 0.999967, 0.0068376, -0.998906, -0.00402017, -0.0466034, 198.468, -8.8822, 24.4344 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_004")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="Road_004" type="Spatial" parent="RoadManager"]
+transform = Transform( -1, -2.32831e-10, -5.96046e-08, 0, 1, -3.49246e-10, 8.9407e-08, 1.16415e-10, -1, 62.3228, -2.08616e-07, 11.2859 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_004",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_002"), "" ]
+edge_rp_targets = [ NodePath("RP_004"), NodePath("") ]
+edge_rp_target_dirs = [ 1, -1 ]
+edge_rp_locals = [ NodePath("RP_002"), NodePath("RP_003") ]
+edge_rp_local_dirs = [ 0, 1 ]
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_004"]
+transform = Transform( 0.889155, -0.00163741, 0.457603, 0, 0.999994, 0.0035782, -0.457606, -0.00318157, 0.88915, -65.6091, -8.87194, 3.36388 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+prior_mag = 36.7641
+next_mag = 36.7641
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_004"]
+transform = Transform( 0.354622, 0.00209715, -0.935008, 0.00341447, 0.999988, 0.0035379, 0.935004, -0.00444717, 0.35461, -14.1285, -8.60375, -67.9345 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_002")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="crossroads2" type="Spatial" parent="RoadManager"]
+transform = Transform( 0.935899, -0.000823612, 0.352267, 0.00216726, 0.999992, -0.00341994, -0.352261, 0.00396417, 0.935894, 28.8341, 4.45384, -73.2056 )
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "crossroads2",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../Road_003"), NodePath("../Road_005"), NodePath("../Road_002"), NodePath("../Road_005") ]
+edge_rp_targets = [ NodePath("RP_001"), NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_003") ]
+edge_rp_target_dirs = [ 0, 0, 1, 1 ]
+edge_rp_locals = [ NodePath("RP_002"), NodePath("RP_003"), NodePath("RP_005"), NodePath("RP_006") ]
+edge_rp_local_dirs = [ 1, 0, 1, 0 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/crossroads2"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -9.86789, -13.2134, 17.0682 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_002")
+next_pt_init = NodePath("../RP_006")
+next_mag = 47.9984
+
+[node name="RP_002" type="Spatial" parent="RoadManager/crossroads2"]
+transform = Transform( 0.99999, -6.16287e-06, 0.00452467, 0, 0.999999, 0.00136206, -0.00452468, -0.00136204, 0.999989, -10.6984, -12.9634, -38.2405 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_001")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="RP_003" type="Spatial" parent="RoadManager/crossroads2"]
+transform = Transform( 0.00200708, 0, 0.999998, 0, 1, 0, -0.999998, 0, 0.00200708, 17.372, -13.2134, -10.9459 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_004")
+
+[node name="RP_004" type="Spatial" parent="RoadManager/crossroads2"]
+transform = Transform( -0.00251761, -0.00136205, 0.999996, 0, 0.999999, 0.00136206, -0.999997, 3.42913e-06, -0.0025176, -10.0935, -13.201, -10.2371 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_005")
+next_pt_init = NodePath("../RP_003")
+prior_mag = 16.0
+next_mag = 16.057
+
+[node name="RP_005" type="Spatial" parent="RoadManager/crossroads2"]
+transform = Transform( -0.00251761, -0.00136205, 0.999996, 0, 0.999999, 0.00136206, -0.999997, 3.42913e-06, -0.0025176, -42.0937, -13.0012, -10.1565 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_004")
+prior_mag = 16.0
+next_mag = 16.0
+
+[node name="RP_006" type="Spatial" parent="RoadManager/crossroads2"]
+transform = Transform( -0.304949, 0.00200636, 0.952367, -0.00177781, 0.999995, -0.00267595, -0.952367, -0.00250916, -0.304944, 69.3402, -12.6209, 18.141 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_001")
+prior_mag = 41.7109
+next_mag = 41.7109
+
+[node name="Road_006" type="Spatial" parent="RoadManager"]
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_006",
+"test_meta": "0"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+edge_containers = [ NodePath("../crossroads3"), "" ]
+edge_rp_targets = [ NodePath("RP_001"), "" ]
+edge_rp_target_dirs = [ 0, -1 ]
+edge_rp_locals = [ NodePath("RP_002"), NodePath("RP_003") ]
+edge_rp_local_dirs = [ 1, 1 ]
+
+[node name="RP_001" type="Spatial" parent="RoadManager/Road_006"]
+transform = Transform( 0.20465, 0, 0.978835, 0, 1, 0, -0.978835, 0, 0.20465, -48.0273, -3.14191, 95.7585 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_002")
+prior_mag = 50.185
+next_mag = 50.185
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_006"]
+transform = Transform( 0.350388, 0.000823612, -0.936605, 0.00342428, 0.999992, 0.00216039, 0.936599, -0.00396417, 0.350382, 24.9397, -8.7314, 99.3785 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_001")
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_006"]
+transform = Transform( 0.998819, 0, 0.0485884, 0, 1, 0, -0.0485884, 0, 0.998819, -163.006, -8.99536, 31.4306 )
+script = ExtResource( 4 )
+traffic_dir = [ 2, 2, 1, 1 ]
+lanes = [ 2, 4, 4, 2 ]
+next_pt_init = NodePath("../RP_001")
+next_mag = 55.299
+
+[node name="Road_012" type="Spatial" parent="RoadManager"]
+script = ExtResource( 1 )
+__meta__ = {
+"GRG_NAME": "Road_012"
+}
+material_resource = ExtResource( 2 )
+use_lowpoly_preview = true
+
+[node name="RP_002" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( 0.0257647, 0.000896598, -0.999668, 0, 1, 0.000896895, 0.999668, -2.31082e-05, 0.0257647, -315.205, 0.44335, 221.301 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_009")
+next_pt_init = NodePath("../RP_003")
+prior_mag = 78.0113
+next_mag = 78.0113
+
+[node name="RP_003" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( -0.999752, 0.00266551, -0.0221094, 0.00260702, 0.999993, 0.00267407, 0.0221164, 0.00261577, -0.999752, -431.493, 0.820068, 153.15 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_002")
+next_pt_init = NodePath("../RP_004")
+prior_mag = 56.6013
+next_mag = 56.6013
+
+[node name="RP_004" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( -0.999976, 0.002669, -0.00632794, 0.00264889, 0.999991, 0.00318334, 0.00633639, 0.0031665, -0.999975, -435.083, 2.16829, -269.08 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_003")
+next_pt_init = NodePath("../RP_005")
+prior_mag = 42.737
+next_mag = 42.737
+
+[node name="RP_005" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( -0.00551068, 0.000295028, 0.999985, 0.00518466, 0.999986, -0.000266457, -0.999971, 0.00518311, -0.00551213, -347.239, 2.52646, -358.976 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_004")
+next_pt_init = NodePath("../RP_006")
+prior_mag = 86.61
+next_mag = 86.61
+
+[node name="RP_006" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( -0.0142105, -0.000154529, 0.999899, 0.00518678, 0.999986, 0.000228257, -0.999886, 0.0051895, -0.0142096, 153.027, 2.60188, -357.159 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_005")
+next_pt_init = NodePath("../RP_007")
+prior_mag = 45.9124
+next_mag = 45.9124
+
+[node name="RP_007" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( 0.999897, -0.00227099, 0.0141943, 0.002312, 0.999993, -0.00287345, -0.0141877, 0.00290597, 0.999895, 248.814, 2.50555, -277.091 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_006")
+next_pt_init = NodePath("../RP_008")
+prior_mag = 46.572
+next_mag = 46.572
+
+[node name="RP_008" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( 0.999946, -0.00225148, -0.0101717, 0.00222772, 0.999995, -0.00234651, 0.010177, 0.00232373, 0.999946, 252.388, 1.57936, 130.373 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_007")
+next_pt_init = NodePath("../RP_009")
+prior_mag = 41.5545
+next_mag = 41.5545
+
+[node name="RP_009" type="Spatial" parent="RoadManager/Road_012"]
+transform = Transform( 0.00337993, -0.000874618, -0.999994, -0.000314968, 1, -0.000875688, 0.999994, 0.000317926, 0.00337965, 182.357, 1.46444, 214.633 )
+script = ExtResource( 4 )
+traffic_dir = [ 1, 1, 1, 1 ]
+lanes = [ 0, 3, 3, 2 ]
+prior_pt_init = NodePath("../RP_008")
+next_pt_init = NodePath("../RP_002")
+prior_mag = 55.8926
+next_mag = 55.8926
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.405541, 0.914077, 0, -0.914077, 0.405541, -86.7622, 282.968, 146.685 )
+fov = 80.0
+far = 500.0
+
+[node name="floor" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -95.4111, -9.95611, -65.84 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )

--- a/demo/simple_demo.tscn
+++ b/demo/simple_demo.tscn
@@ -1,23 +1,36 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/road-generator/nodes/road_point.gd" type="Script" id=1]
 [ext_resource path="res://addons/road-generator/nodes/road_container.gd" type="Script" id=2]
 [ext_resource path="res://addons/road-generator/resources/road_texture.material" type="Material" id=3]
 [ext_resource path="res://addons/road-generator/nodes/road_manager.gd" type="Script" id=4]
 
+[sub_resource type="PlaneMesh" id=1]
+size = Vector2( 200, 200 )
+
+[sub_resource type="SpatialMaterial" id=2]
+albedo_color = Color( 0.376471, 0.596078, 0.4, 1 )
+
+[sub_resource type="CubeMesh" id=3]
+size = Vector3( 200, 1, 200 )
+
+[sub_resource type="PlaneMesh" id=4]
+size = Vector2( 20, 20 )
+
 [node name="Spatial" type="Spatial"]
 
 [node name="RoadManager" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.551694, 0, -0.343994 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.551694, 15.0473, -0.343994 )
 script = ExtResource( 4 )
 
 [node name="RoadContainer" type="Spatial" parent="RoadManager"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 16.9962, 0.516998, -17.0343 )
 script = ExtResource( 2 )
 material_resource = ExtResource( 3 )
 use_lowpoly_preview = true
 
 [node name="RP_001" type="Spatial" parent="RoadManager/RoadContainer"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7.46775, 0, -7.2427 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7.46775, -0.178818, -7.2427 )
 script = ExtResource( 1 )
 traffic_dir = [ 2, 1 ]
 lanes = [ 5, 5 ]
@@ -27,7 +40,7 @@ prior_mag = 12.0106
 next_mag = 15.6816
 
 [node name="RP_002" type="Spatial" parent="RoadManager/RoadContainer"]
-transform = Transform( 0.992258, 0, -0.12419, 0, 1, 0, 0.12419, 0, 0.992258, -8.9407e-07, 0, 32 )
+transform = Transform( 0.992258, 0, -0.12419, 0, 1, 0, 0.12419, 0, 0.992258, 0, -0.337743, 32 )
 script = ExtResource( 1 )
 traffic_dir = [ 2, 1 ]
 lanes = [ 5, 5 ]
@@ -37,37 +50,39 @@ prior_mag = 20.4879
 next_mag = 12.5911
 
 [node name="RP_003" type="Spatial" parent="RoadManager/RoadContainer"]
-transform = Transform( -0.370339, 0.0143865, -0.928785, 0, 0.99988, 0.0154877, 0.928897, 0.00573569, -0.370294, -55.874, 1, 64.3428 )
+transform = Transform( -0.370339, 0.0143865, -0.928785, 0, 0.99988, 0.0154877, 0.928897, 0.00573569, -0.370294, -55.8915, -0.217126, 64.3358 )
 script = ExtResource( 1 )
 traffic_dir = [ 2, 2, 1, 1, 1 ]
 lanes = [ 2, 4, 4, 3, 2 ]
+gutter_profile = Vector2( 2, -1 )
 prior_pt_init = NodePath("../RP_006")
 next_pt_init = NodePath("../RP_004")
 prior_mag = 31.7792
 next_mag = 22.0669
 
 [node name="RP_004" type="Spatial" parent="RoadManager/RoadContainer"]
-transform = Transform( -0.975633, 0.126177, 0.179496, 0.0135937, 0.851285, -0.524527, -0.218986, -0.509306, -0.832257, -75.4414, 17.3831, 0.315222 )
+transform = Transform( -0.975633, 0.107686, 0.191163, 0.0135937, 0.899263, -0.437196, -0.218986, -0.423944, -0.878815, -75.4414, 7.4078, 0.315222 )
 script = ExtResource( 1 )
 traffic_dir = [ 2, 2, 1, 1, 1 ]
 lanes = [ 2, 4, 4, 3, 2 ]
+gutter_profile = Vector2( 2, -20 )
 prior_pt_init = NodePath("../RP_003")
 next_pt_init = NodePath("../RP_005")
 prior_mag = 39.1419
 next_mag = 16.0
 
 [node name="RP_005" type="Spatial" parent="RoadManager/RoadContainer"]
-transform = Transform( 0.533503, -0.0195546, 0.845572, 0.0151977, 0.999793, 0.0135323, -0.845661, 0.00563117, 0.53369, -17.4717, 2.27198, -37.7687 )
+transform = Transform( 0.308035, 0.00513505, 0.951361, 0.0113829, 0.999894, -0.00908259, -0.951307, 0.013627, 0.307944, -17.4218, -0.279123, -37.7831 )
 script = ExtResource( 1 )
 traffic_dir = [ 2, 2, 1, 1 ]
 lanes = [ 2, 4, 4, 2 ]
 prior_pt_init = NodePath("../RP_004")
 next_pt_init = NodePath("../RP_001")
-prior_mag = 16.0
+prior_mag = 26.2211
 next_mag = 16.0
 
 [node name="RP_006" type="Spatial" parent="RoadManager/RoadContainer"]
-transform = Transform( 0.797377, 0.0135357, -0.60333, 0.0032786, 0.999636, 0.02676, 0.603473, -0.0233159, 0.797042, -6.88818, 0.819894, 63.1532 )
+transform = Transform( 0.797377, 0.0135357, -0.60333, 0.0032786, 0.999636, 0.02676, 0.603473, -0.0233159, 0.797042, -6.90231, -0.223975, 63.1775 )
 script = ExtResource( 1 )
 traffic_dir = [ 2, 2, 1, 1, 1 ]
 lanes = [ 2, 4, 4, 3, 2 ]
@@ -75,3 +90,23 @@ prior_pt_init = NodePath("../RP_002")
 next_pt_init = NodePath("../RP_003")
 prior_mag = 15.9757
 next_mag = 13.9234
+
+[node name="floor" type="MeshInstance" parent="."]
+visible = false
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )
+
+[node name="DirectionalLight" type="DirectionalLight" parent="."]
+transform = Transform( 0.982703, 6.80993e-08, -0.185187, 0.184972, -0.0481525, 0.981563, -0.00891712, -0.99884, -0.0473196, -11.1828, 43.4366, 1.02305 )
+shadow_enabled = true
+directional_shadow_mode = 0
+directional_shadow_max_distance = 200.0
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.666868, 0 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 2 )
+
+[node name="MeshInstance2" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -20.4752, 16.2328, 0.427807 )
+mesh = SubResource( 4 )

--- a/test/unit/test_road_container.gd
+++ b/test/unit/test_road_container.gd
@@ -91,8 +91,11 @@ func test_road_container_create():
 	# Since only setup, still should not have triggered on update.
 	assert_signal_emit_count(container, "on_road_updated", 0, "Don't signal setup")
 	container.rebuild_segments()
+	assert_eq(container.get_child_count(), 0, "Should have no children")
 	# Now it's updated
 	assert_signal_emit_count(container, "on_road_updated", 1, "Signal after rebuild")
+	# No children = road update called, but nothing rebuilt
+	assert_signal_emitted_with_parameters(container, "on_road_updated", [[]])
 
 
 func test_on_road_updated_single_segment():


### PR DESCRIPTION
Reworked the container start up procedure to have avoid doing a deferred geometry generation call in some cases. Now, instead of depending on the auto-calling of deferred loading via export var property setget callbacks, we now avoid doing generation during getting ready.

Added a stress test file which can be used for speed checking of generation in the future, as well as updated unittests to reinforce pre-existing behavior of emitting the `on_road_updated` signal on RoadContainers even if no road segments are generated (such as having no children, or if clear_existing=false while all road segmetns already have initial meshes in place).

Also improved in-code documentation for export vars.

### Breaking change:

The `RoadManager.rebuild_all_containers` function is no longer a deferred call but will rather block until all segments are built (use the new `rebuild_all_containers_deferred` function for the old behavior), and also has an argument `clear_existing` which is off by default now - which means pre-existing callers will move from a full rebuilding of road segments to only rebuilding dirtied/known missing road segments.