### PR TITLE
Remove terminating RPs from container edge list

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -465,7 +465,7 @@ func get_open_edges()->Array:
 			# Edge is already connected
 			continue
 		elif edge and edge.terminated:
-			# Edge is terminated
+			# Edge is terminated (TODO: remove this branch, should not longer be in edge list now)
 			continue
 		elif edge:
 			# Edge is available for connections
@@ -561,6 +561,9 @@ func update_edges():
 
 	for ch in get_roadpoints():
 		var pt:RoadPoint = ch
+		if pt.terminated:
+			# Terminated points should not be counted as external edges
+			continue
 
 		for this_dir in [RoadPoint.PointInit.NEXT, RoadPoint.PointInit.PRIOR]:
 			var is_edge := false

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -79,7 +79,7 @@ export(Vector2) var gutter_profile := Vector2(2.0, -0.5) setget _set_profile, _g
 # Path to next/prior RoadPoint, relative to this RoadPoint itself.
 export(NodePath) var prior_pt_init setget _set_prior_pt_init, _get_prior_pt_init
 export(NodePath) var next_pt_init setget _set_next_pt_init, _get_next_pt_init
-export(bool) var terminated := false
+export(bool) var terminated := false setget _set_terminated
 # Handle magniture
 export(float) var prior_mag := 5.0 setget _set_prior_mag, _get_prior_mag
 export(float) var next_mag := 5.0 setget _set_next_mag, _get_next_mag
@@ -276,6 +276,11 @@ func _set_next_pt_init(value:NodePath):
 	emit_transform()
 
 
+func _set_terminated(value: bool) -> void:
+	terminated = value
+	if is_instance_valid(container):
+		container.update_edges()
+
 func _get_next_pt_init():
 	return next_pt_init
 
@@ -379,7 +384,8 @@ func is_prior_connected() -> bool:
 		#gd4
 		#return container.edge_containers[_idx] != ^""
 		return container.edge_containers[_idx] != ""
-	push_warning("RP should have been present in container edge list")
+	if not self.terminated:
+		push_warning("RP should have been present in container edge list")
 	return false
 
 
@@ -396,7 +402,8 @@ func is_next_connected() -> bool:
 		#gd4
 		#return container.edge_containers[_idx] != ^""
 		return container.edge_containers[_idx] != ""
-	push_warning("RP should have been present in container edge list")
+	if not self.terminated:
+		push_warning("RP should have been present in container edge list")
 	return false
 
 
@@ -414,7 +421,8 @@ func get_prior_rp():
 			return null
 		var target_container = container.get_node(container.edge_containers[_idx])
 		return target_container.get_node(container.edge_rp_targets[_idx])
-	push_warning("RP should have been present in container edge list")
+	if not self.terminated:
+		push_warning("RP should have been present in container edge list")
 	return null
 
 
@@ -432,7 +440,8 @@ func get_next_rp():
 			return null
 		var target_container = container.get_node(container.edge_containers[_idx])
 		return target_container.get_node(container.edge_rp_targets[_idx])
-	push_warning("RP should have been present in container edge list")
+	if not self.terminated:
+		push_warning("RP should have been present in container edge list")
 	return null
 
 

--- a/test/unit/test_road_container.gd
+++ b/test/unit/test_road_container.gd
@@ -173,17 +173,14 @@ func test_update_edges():
 
 	# Second case: 2 edges over 2 points
 	create_oneseg_container(container)
-	container.rebuild_segments()
 	assert_eq(len(container.edge_rp_locals), 2, "Should have two edges")
 	validate_edges_equal_size(container)
 
 	# Third case: 2 edges over 3 points
 	var p2 = container.get_roadpoints()[1]
 	var p3 = autoqfree(RoadPoint.new())
-	container.add_child(p3)
 	p2.next_pt_init = p2.get_path_to(p3)
 	p3.prior_pt_init = p3.get_path_to(p2)
-	container.rebuild_segments()
 	assert_eq(len(container.edge_rp_locals), 2, "Should have two edges still")
 	validate_edges_equal_size(container)
 
@@ -191,14 +188,18 @@ func test_update_edges():
 	# In this case, the disconencted point should count as 2 open edges.
 	var p4 = autoqfree(RoadPoint.new())
 	container.add_child(p4)  # unconnected
-	container.rebuild_segments()
-	assert_eq(len(container.edge_rp_locals), 4, "Should have 3 edges now")
+	assert_eq(len(container.edge_rp_locals), 4, "Should have 2+2 edges now")
 	validate_edges_equal_size(container)
 
 	# Fifth case: 3 edges over 4 points, one edge conencted to Container itself.
 	p3.next_pt_init = p3.get_path_to(container)
-	container.rebuild_segments()
-	assert_eq(len(container.edge_rp_locals), 4, "Should still have 3 edges now")
+	assert_eq(len(container.edge_rp_locals), 4, "Should still have 2+2 edges now")
+	validate_edges_equal_size(container)
+
+	# Sixth case: One edge marked as terminated, no longer an "edge" and thus
+	# both directions no longer counted
+	p4.terminated = true
+	assert_eq(len(container.edge_rp_locals), 2, "Back down to 2")
 	validate_edges_equal_size(container)
 
 
@@ -295,6 +296,7 @@ func test_container_disconnection():
 	assert_false(res, "Disconnection should fail since not connected in that direction")
 	res = pt1.disconnect_container(RoadPoint.PointInit.NEXT, RoadPoint.PointInit.NEXT)
 	assert_false(res, "Disconnection should fail with invalid edge directions")
+
 
 func test_container_snap_unsnap():
 	pass


### PR DESCRIPTION
We somewhat recently added the concept of "terminated" RoadPoints, which are meant to represent RoadPoints which are not connected on one or both sides, but are not meant to be considered as open edges from the standpoint of the parent RoadContainer (and thus, not available for connections across RoadContainers).

This change actually ensures the edge list doesn't include these RoadPoints, to avoid downstream checks for "terminated == true", and adds a set-getter to ensure the RoadContainers edge list is always up to date in the editor.