### PR TITLE
Fix dissolve and delete roadpoints undo redo

### DIFF
--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -385,7 +385,7 @@ func is_prior_connected() -> bool:
 		#return container.edge_containers[_idx] != ^""
 		return container.edge_containers[_idx] != ""
 	if not self.terminated:
-		push_warning("RP should have been present in container edge list")
+		push_warning("RP should have been present in container edge list (is_prior_connected)")
 	return false
 
 
@@ -403,7 +403,7 @@ func is_next_connected() -> bool:
 		#return container.edge_containers[_idx] != ^""
 		return container.edge_containers[_idx] != ""
 	if not self.terminated:
-		push_warning("RP should have been present in container edge list")
+		push_warning("RP should have been present in container edge list (is_next_connected)")
 	return false
 
 
@@ -422,7 +422,7 @@ func get_prior_rp():
 		var target_container = container.get_node(container.edge_containers[_idx])
 		return target_container.get_node(container.edge_rp_targets[_idx])
 	if not self.terminated:
-		push_warning("RP should have been present in container edge list")
+		push_warning("RP should have been present in container edge list (get_prior_rp)")
 	return null
 
 
@@ -441,7 +441,7 @@ func get_next_rp():
 		var target_container = container.get_node(container.edge_containers[_idx])
 		return target_container.get_node(container.edge_rp_targets[_idx])
 	if not self.terminated:
-		push_warning("RP should have been present in container edge list")
+		push_warning("RP should have been present in container edge list (get_next_rp)")
 	return null
 
 

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -708,6 +708,12 @@ func set_selection(node: Node) -> void:
 	_edi.get_selection().add_node(node)
 
 
+func set_selection_list(nodes: Array) -> void:
+	_edi.get_selection().clear()
+	for _nd in nodes:
+		_edi.get_selection().add_node(_nd)
+
+
 ## Gets nearest RoadPoint if user clicks a Segment. Returns RoadPoint or null.
 func get_nearest_road_point(camera: Camera, mouse_pos: Vector2) -> RoadPoint:
 	var src = camera.project_ray_origin(mouse_pos)
@@ -1095,7 +1101,7 @@ func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, paren
 		var look_pos = selection.global_transform.origin
 		if not adding_to_next:
 			# Essentially flip the look 180 so it's not twisted around.
-			print("Flipping dir")
+			#print("Flipping dir")
 			look_pos += 2 * dirvec
 		next_rp.look_at(look_pos, nrm)
 
@@ -1352,9 +1358,12 @@ func _delete_rp_on_click(selection: Node):
 		# only if fully connected will it combine both sides back together
 		dissolve = true
 
-	print("Dissolve: %s, prior %s samedir %s , next %s smaedir %s" % [
-		dissolve, prior_rp, prior_samedir, next_rp, next_samedir
-	])
+	#print("Dissolve: %s, prior %s samedir %s , next %s smaedir %s" % [
+	#	dissolve, prior_rp, prior_samedir, next_rp, next_samedir])
+
+	# Define the current editor selection for redo'ing afer an undo,
+	# which could be multi selection
+	var editor_selected:Array = _edi.get_selection().get_selected_nodes()
 
 	# Define the action
 	if dissolve:
@@ -1371,33 +1380,21 @@ func _delete_rp_on_click(selection: Node):
 		undo_redo.add_do_method(rp, "disconnect_roadpoint", RoadPoint.PointInit.NEXT, next_dir)
 
 	# Remove the node
-	undo_redo.add_do_method(rp.get_parent(), "remove_child", rp)  # Queuefree borqs with undoredo
-	undo_redo.add_undo_method(rp.get_parent(), "add_child", rp) # TODO, improve positioning
+	undo_redo.add_do_method(rp.get_parent(), "remove_child", rp)
+	undo_redo.add_undo_method(rp.get_parent(), "add_child", rp)
 	undo_redo.add_undo_method(rp, "set_owner", get_tree().get_edited_scene_root())
-	#undo_redo.add_undo_property(rp, "prior_pt_init", rp.prior_pt_init)
-	#undo_redo.add_undo_property(rp, "next_pt_init", rp.next_pt_init)
-
-	# Have to do reconnection undo steps after re-adding
-	if is_instance_valid(prior_rp):
-		undo_redo.add_undo_method(rp, "connect_roadpoint", RoadPoint.PointInit.PRIOR, prior_rp, prior_dir)
-	if is_instance_valid(next_rp):
-		undo_redo.add_undo_method(rp, "connect_roadpoint", RoadPoint.PointInit.NEXT, next_rp, next_dir)
 
 	# Update do/undo selections
 	if is_instance_valid(next_rp):
 		undo_redo.add_do_method(self, "set_selection", next_rp)
-		undo_redo.add_undo_method(self, "set_selection", selection)
 	elif is_instance_valid(prior_rp):
 		undo_redo.add_do_method(self, "set_selection", prior_rp)
-		undo_redo.add_undo_method(self, "set_selection", selection)
 	else:
 		undo_redo.add_do_method(self, "set_selection", rp.container)
-		undo_redo.add_undo_method(self, "set_selection", selection)
+	undo_redo.add_undo_method(self, "set_selection_list", editor_selected)
 
-	# If necessary, reconnect the two edges back
+	# If in dissolve mode, connect RPs in both directions to each other
 	if dissolve:
-		print("Setting up for dissolve")
-		print("assigning: this ", prior_dir, " vs next", next_dir)
 		undo_redo.add_do_method(
 			prior_rp,
 			"connect_roadpoint",
@@ -1405,32 +1402,21 @@ func _delete_rp_on_click(selection: Node):
 			next_rp,
 			next_dir
 		)
-
-
 		undo_redo.add_undo_method(
-			rp,
-			"connect_roadpoint",
-			RoadPoint.PointInit.PRIOR,
 			prior_rp,
-			prior_dir
-		)
-		undo_redo.add_undo_method(
-			rp,
-			"connect_roadpoint",
-			RoadPoint.PointInit.NEXT,
-			next_rp,
+			"disconnect_roadpoint",
+			prior_dir,
 			next_dir
 		)
-		#undo_redo.add_do_method(container, "rebuild_segments", false)
-	#undo_redo.add_undo_method(self, "set_selection", rp)
-	#undo_redo.add_undo_method(rp, "on_transform")
-	# Trigger on prior and next to clean up extra geo needed
-	# TODO: Directly triggering on_transform wasn't enough, having to do rebuild_segments instead
-	# TODO: to increase performance, should be able to more directly clean up
-	# the one road seg that's leftover here somehow.
-	#if dissolve:
-	undo_redo.add_undo_method(container, "rebuild_segments", false)
+		undo_redo.add_do_method(container, "rebuild_segments", false)
 
+	# Have to do reconnection undo steps after re-adding and un-dissolve connections
+	if is_instance_valid(prior_rp):
+		undo_redo.add_undo_method(rp, "connect_roadpoint", RoadPoint.PointInit.PRIOR, prior_rp, prior_dir)
+	if is_instance_valid(next_rp):
+		undo_redo.add_undo_method(rp, "connect_roadpoint", RoadPoint.PointInit.NEXT, next_rp, next_dir)
+
+	undo_redo.add_undo_method(container, "rebuild_segments", false)
 	undo_redo.add_undo_reference(rp)
 	undo_redo.commit_action()
 


### PR DESCRIPTION
The Dissolve and Delete RoadPoint funciton in the toolbar was largely broken up until now. With this PR, the undo and redo stack is working very nicely, without any errors in the console (except in some edge cases where it seems some internals call transform, but only yielding "not in tree" errors which don't actually impact the output).

See demo here, showing this in detail:

https://github.com/user-attachments/assets/47f9540c-534e-4fa6-a6ff-658a89e8fac7

