### PR TITLE
Improved undo/redo of RoadPoint edit panel's add next/prior rp

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1048,6 +1048,8 @@ func _add_next_rp_on_click(pos: Vector3, nrm: Vector3, selection: Node) -> void:
 				undo_redo.add_do_property(_sel, "prior_mag", handle_mag)
 				undo_redo.add_undo_property(_sel, "prior_mag", _sel.prior_mag)
 		if selection is RoadPoint and not selection.next_pt_init and not selection.prior_pt_init:
+			# Special case: the starting point is not connected to anything, then the user is
+			# probably wanting it to be rotated towards the new point being placed anyways
 			undo_redo.add_do_method(selection, "look_at", pos, selection.global_transform.basis.y)
 			undo_redo.add_undo_property(selection, "global_transform", selection.global_transform)
 		undo_redo.add_do_method(self, "_add_next_rp_on_click_do", pos, nrm, _sel, parent, handle_mag)
@@ -1122,8 +1124,14 @@ func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, paren
 			var look_pos = selection.global_transform.origin
 			if not adding_to_next:
 				# Essentially flip the look 180 so it's not twisted around.
-				#print("Flipping dir")
 				look_pos += 2 * dirvec
+			# Increase the angle a bit more based on the selected's magnitude,
+			# to result in a more natural rotation to ensure the curve doesn't
+			# look like it doubles back.
+			if adding_to_next:
+				look_pos += selection.global_transform.basis.z * selection.next_mag
+			else:
+				look_pos += selection.global_transform.basis.z * selection.prior_mag
 			next_rp.look_at(look_pos, nrm)
 
 	set_selection(next_rp)

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1093,17 +1093,20 @@ func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, paren
 		next_rp.auto_lanes = true
 
 	# Make the road visible halfway above the ground by the gutter height amount.
-	var half_gutter: float = -0.5 * next_rp.gutter_profile.y
-	next_rp.global_transform.origin = pos + nrm * half_gutter
+	if nrm == Vector3.ZERO:
+		pass
+	else:
+		var half_gutter: float = -0.5 * next_rp.gutter_profile.y
+		next_rp.global_transform.origin = pos + nrm * half_gutter
 
-	# Rotate this rp towards the initial selected node
-	if selection is RoadPoint:
-		var look_pos = selection.global_transform.origin
-		if not adding_to_next:
-			# Essentially flip the look 180 so it's not twisted around.
-			#print("Flipping dir")
-			look_pos += 2 * dirvec
-		next_rp.look_at(look_pos, nrm)
+		# Rotate this rp towards the initial selected node
+		if selection is RoadPoint:
+			var look_pos = selection.global_transform.origin
+			if not adding_to_next:
+				# Essentially flip the look 180 so it's not twisted around.
+				#print("Flipping dir")
+				look_pos += 2 * dirvec
+			next_rp.look_at(look_pos, nrm)
 
 	set_selection(next_rp)
 


### PR DESCRIPTION
Consolidate to use the same method as in the click-to-add code. The actual do/undo references there could be improved too, but seems to work stably in the meantime.

This also includes a change to improve the automatic in/out magnitude handles for the new and initially selected RoadPoint, making for more natural graceful turns (but still without modifying the prior curves, so the handles _can_ become asymmetric).

Closes #84 