### PR TITLE
4.x Reducing console errors on adding RoadPoint via menu or click

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -919,8 +919,8 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 		return
 	# Update warnings for this or connected containers
 	if point.is_on_edge():
-		var prior = point.get_prior_rp()
-		var next = point.get_next_rp()
+		#var prior = point.get_prior_rp()
+		#var next = point.get_next_rp()
 		# TODO: Need to trigger transform updates on these nodes,
 		# without triggering emit_transform etc, these turn into infinite loops or godot crashes
 		#if is_instance_valid(prior) and prior.container != self:

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -455,7 +455,7 @@ func _handle_gui_add_mode(camera: Camera3D, event: InputEvent) -> int:
 			point = null
 			target = null
 
-		if point and target:
+		if is_instance_valid(point) and is_instance_valid(target):
 			_overlay_hovering_from = camera.unproject_position(target.global_transform.origin)
 			_overlay_rp_hovering = point
 			_overlay_hovering_pos = camera.unproject_position(point.global_transform.origin)
@@ -1053,8 +1053,6 @@ func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, paren
 
 		# Update rotation along the initially picked axis.
 	elif selection is RoadContainer:
-		parent.add_child(next_rp)
-		next_rp.set_owner(get_tree().get_edited_scene_root())
 		next_rp.name = "RP_001"  # TODO: define this in some central area.
 		var _lanes:Array[RoadPoint.LaneDir] = [
 			RoadPoint.LaneDir.REVERSE,
@@ -1064,6 +1062,8 @@ func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, paren
 		]
 		next_rp.traffic_dir = _lanes
 		next_rp.auto_lanes = true
+		parent.add_child(next_rp)
+		next_rp.set_owner(get_tree().get_edited_scene_root())
 
 	# Make the road visible halfway above the ground by the gutter height amount.
 	if nrm == Vector3.ZERO:
@@ -1492,6 +1492,8 @@ func _create_roadpoint_pressed() -> void:
 	else:
 		undo_redo.add_do_method(self, "_create_roadpoint_do", t_container)
 		undo_redo.add_undo_method(self, "_create_roadpoint_undo", t_container)
+		undo_redo.add_do_method(t_container, "update_edges")
+		undo_redo.add_undo_method(t_container, "update_edges")
 	undo_redo.commit_action()
 
 
@@ -1518,8 +1520,6 @@ func _create_roadpoint_do(t_container: RoadContainer):
 	second_road_point.name = second_road_point.increment_name(default_name)
 	first_road_point.add_road_point(second_road_point, RoadPoint.PointInit.NEXT)
 	set_selection(second_road_point)
-
-	t_container.update_edges() # Since we updated a roadpoint name after adding.
 
 
 func _create_roadpoint_undo(t_container: RoadContainer):
@@ -1551,6 +1551,8 @@ func _create_2x2_road_pressed() -> void:
 	undo_redo.create_action("Add 2x2 road segment")
 	undo_redo.add_do_method(self, "_create_2x2_road_do", t_container, false)
 	undo_redo.add_undo_method(self, "_create_2x2_road_undo", t_container, false)
+	undo_redo.add_do_method(t_container, "update_edges")
+	undo_redo.add_undo_method(t_container, "update_edges")
 	undo_redo.commit_action()
 
 
@@ -1583,8 +1585,6 @@ func _create_2x2_road_do(t_container: RoadContainer, single_point: bool):
 		set_selection(second_road_point)
 	else:
 		set_selection(first_road_point)
-
-	t_container.update_edges() # Since we updated a roadpoint name after adding.
 
 
 func _create_2x2_road_undo(selected_node: RoadContainer, single_point: bool) -> void:


### PR DESCRIPTION
Now we have _much_ fewer error printouts when working with the plugin in general, thanks to being a bit more mindful of when calling the update edges routine, and taking care when we actually add the node to the scene.

Before:
<img width="1164" alt="Screen Shot 2024-09-28 at 11 23 24 PM" src="https://github.com/user-attachments/assets/e966be28-39df-4647-8025-537509063435">

With these new changes 🎉 

<img width="886" alt="Screen Shot 2024-09-28 at 11 22 13 PM" src="https://github.com/user-attachments/assets/d3ee6629-7c55-4d31-be53-ebb690bc6e63">

The remaining (4.x only) issue of undo/redo counts is captured in https://github.com/TheDuckCow/godot-road-generator/issues/193 and won't be solved in this v0.5.1 release