### PR TITLE
Applying discovered fix to make resources editable and avoid errors

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -833,7 +833,7 @@ func get_click_point_with_context(camera: Camera3D, mouse_pos: Vector2, selectio
 
 func _handles(object: Object):
 	# Must return "true" in order to use "forward_spatial_gui_input".
-	return true
+	return object is Node3D
 
 
 # ------------------------------------------------------------------------------

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -31,6 +31,8 @@ func _parse_begin(object):
 
 	if is_instance_valid(_editor_plugin): 
 		panel_instance.has_copy_ref = true and _editor_plugin.copy_attributes 
+	else:
+		panel_instance.has_copy_ref = false
 
 
 func set_edi(value):

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -29,7 +29,8 @@ func _parse_begin(object):
 	panel_instance.assign_copy_target.connect(_assign_copy_target)
 	panel_instance.apply_settings_target.connect(_apply_settings_target)
 
-	panel_instance.has_copy_ref = true and _editor_plugin.copy_attributes  # hack to bool-ify
+	if is_instance_valid(_editor_plugin): 
+		panel_instance.has_copy_ref = true and _editor_plugin.copy_attributes 
 
 
 func set_edi(value):


### PR DESCRIPTION
Gets around an issue which could cause custom or other resources to not properly be editable, due to over-scoped editor handler function.

Resolves #195 