### PR TITLE
[171] Fixed incorrect connection of road lanes

### DIFF
--- a/demo/procedural_generator/procedural_generator.gd
+++ b/demo/procedural_generator/procedural_generator.gd
@@ -81,8 +81,6 @@ func remove_rp(edge_rp: RoadPoint) -> void:
 	# Defer to allow time to free cars first, if using despawn_cars above
 	edge_rp.call_deferred("queue_free")
 
-const LaneDir = preload("res://../../addons/road-generator/nodes/road_point.gd").LaneDir
-const LaneType = preload("res://../../addons/road-generator/nodes/road_point.gd").LaneType
 
 ## Add a new roadpoint in a given direction
 func add_next_rp(rp: RoadPoint, dir: int) -> void:

--- a/demo/procedural_generator/procedural_generator.gd
+++ b/demo/procedural_generator/procedural_generator.gd
@@ -81,6 +81,8 @@ func remove_rp(edge_rp: RoadPoint) -> void:
 	# Defer to allow time to free cars first, if using despawn_cars above
 	edge_rp.call_deferred("queue_free")
 
+const LaneDir = preload("res://../../addons/road-generator/nodes/road_point.gd").LaneDir
+const LaneType = preload("res://../../addons/road-generator/nodes/road_point.gd").LaneType
 
 ## Add a new roadpoint in a given direction
 func add_next_rp(rp: RoadPoint, dir: int) -> void:
@@ -93,11 +95,27 @@ func add_next_rp(rp: RoadPoint, dir: int) -> void:
 	# Copy initial things like lane counts and orientation
 	new_rp.copy_settings_from(rp, true)
 
+	new_rp.traffic_dir=[]
+	new_rp.lanes=[]
+
+	randomize()
+	for i in range(randi()%4 + 1):
+		new_rp.traffic_dir.append(LaneDir.REVERSE)
+		new_rp.lanes.append(LaneType.SLOW)
+	for i in range(randi()%3):
+		new_rp.traffic_dir.append(LaneDir.REVERSE)
+		new_rp.lanes.append(LaneType.FAST)
+	for i in range(randi()%3):
+		new_rp.traffic_dir.append(LaneDir.FORWARD)
+		new_rp.lanes.append(LaneType.FAST)
+	for i in range(randi()%4 + 1):
+		new_rp.traffic_dir.append(LaneDir.FORWARD)
+		new_rp.lanes.append(LaneType.SLOW)
+
 	# Placement of a new roadpoint with interval no larger than buffer,
 	# to avoid flicker removal/adding with the culling system
 
 	# Randomly rotate the offset vector slightly
-	randomize()
 	var _transform := new_rp.transform
 	var angle_range := 30 # Random angle rotation range
 	var random_angle: float = rand_range(-angle_range / 2.0, angle_range / 2.0) # Generate a random angle within the range

--- a/demo/procedural_generator/procedural_generator.gd
+++ b/demo/procedural_generator/procedural_generator.gd
@@ -100,17 +100,17 @@ func add_next_rp(rp: RoadPoint, dir: int) -> void:
 
 	randomize()
 	for i in range(randi()%4 + 1):
-		new_rp.traffic_dir.append(LaneDir.REVERSE)
-		new_rp.lanes.append(LaneType.SLOW)
+		new_rp.traffic_dir.append(RoadPoint.LaneDir.REVERSE)
+		new_rp.lanes.append(RoadPoint.LaneType.SLOW)
 	for i in range(randi()%3):
-		new_rp.traffic_dir.append(LaneDir.REVERSE)
-		new_rp.lanes.append(LaneType.FAST)
+		new_rp.traffic_dir.append(RoadPoint.LaneDir.REVERSE)
+		new_rp.lanes.append(RoadPoint.LaneType.FAST)
 	for i in range(randi()%3):
-		new_rp.traffic_dir.append(LaneDir.FORWARD)
-		new_rp.lanes.append(LaneType.FAST)
+		new_rp.traffic_dir.append(RoadPoint.LaneDir.FORWARD)
+		new_rp.lanes.append(RoadPoint.LaneType.FAST)
 	for i in range(randi()%4 + 1):
-		new_rp.traffic_dir.append(LaneDir.FORWARD)
-		new_rp.lanes.append(LaneType.SLOW)
+		new_rp.traffic_dir.append(RoadPoint.LaneDir.FORWARD)
+		new_rp.lanes.append(RoadPoint.LaneType.SLOW)
 
 	# Placement of a new roadpoint with interval no larger than buffer,
 	# to avoid flicker removal/adding with the culling system


### PR DESCRIPTION
Used updated procedural-generation demo to test
The main unsupported case I was working on was when one direction of the road expands while another shrinks

as an example for a problematic case:
R,R,R,F,F <-> R,R,F,F,F
from what I see, the algorithm was trying to calculate which road point is wider (while both are the same)

I mostly worked on godot4 branch, but checked that it works on dev branch as well
I think its related to https://github.com/TheDuckCow/godot-road-generator/issues/171https://github.com/TheDuckCow/godot-road-generator/issues/171