### PR TITLE
Add road connector to flatten Terrain3D

### DIFF
--- a/addons/road-generator/connectors/terrain3d_road_connector.gd
+++ b/addons/road-generator/connectors/terrain3d_road_connector.gd
@@ -72,7 +72,7 @@ func configure_road_update_signal() -> void:
 			_cont.on_road_updated.disconnect(_schedule_refresh)
 
 
-func do_full_refresh():
+func do_full_refresh() -> void:
 	if not is_configured():
 		return
 	configure_road_update_signal()
@@ -134,7 +134,7 @@ func get_road_width(point: RoadPoint) -> float:
 	)
 
 
-func flatten_terrain_via_roadsegment(segment: RoadSegment):
+func flatten_terrain_via_roadsegment(segment: RoadSegment) -> void:
 	if not is_instance_valid(segment):
 		return
 	if not is_instance_valid(segment.start_point) or not is_instance_valid(segment.end_point):

--- a/addons/road-generator/connectors/terrain3d_road_connector.gd
+++ b/addons/road-generator/connectors/terrain3d_road_connector.gd
@@ -16,15 +16,25 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 		configure_road_update_signal()
 ## Vertical offset to help avoid z-fighting, negative values will sink the terrain underneath the road
 @export var offset:float = -0.5
+## Additional flattening to do beyond the edge of the road in meters
+## Note: Not yet implemented
+@export var edge_margin:float = 0.1
+## The falloff to apply for height changes from the edge of the road
+## Note: Not yet implemented
+@export var edge_falloff:float = 2
 # TODO: add property for density
 # TODO: add property for falloff beyond edges of road
-## If enabled, auto refresh the terrain when updating roads
+## If enabled, auto refresh the terrain while manipulating roads
 @export var auto_refresh:bool = false:
 	set(value):
 		auto_refresh = value
 		configure_road_update_signal()
+
 ## Immediately level the terrain to match roads
 @export_tool_button("Refresh", "Callable") var refresh_action = do_full_refresh
+
+# If using Auto Refresh, how often to update the UI (lower values = heavier cpu use)
+var refresh_timer: float = 0.05
 
 var _pending_updates:Dictionary = {} # TODO: type as RoadSegments, need to update internal typing
 var _timer:SceneTreeTimer
@@ -47,6 +57,9 @@ func is_configured() -> bool:
 
 
 func configure_road_update_signal() -> void:
+	if not Engine.is_editor_hint():
+		# Don't run outside of an editor context
+		return
 	if not is_instance_valid(road_manager):
 		return
 	# TODO: Primary road generator project to expose this on the manager level, to bubble up from
@@ -60,9 +73,9 @@ func configure_road_update_signal() -> void:
 
 
 func do_full_refresh():
-	print("do_full_refresh")
 	if not is_configured():
 		return
+	configure_road_update_signal()
 	for _container in road_manager.get_containers():
 		_container = _container as RoadContainer
 		var segs:Array = _container.get_segments()
@@ -70,34 +83,35 @@ func do_full_refresh():
 
 
 func _schedule_refresh(segments: Array) -> void:
-	print("_schedule_refresh")
 	_mutex.lock()
 	for _seg in segments:
 		# Using a dictionary to accumulate updates to process
 		_pending_updates[_seg] = true
 	if not is_instance_valid(_timer):
-		print("\tCreated timer")
-		_timer = get_tree().create_timer(0.2)
+		_timer = get_tree().create_timer(refresh_timer)
 	else:
-		print("\tTime left: ", _timer.get_time_left())
+		pass
 	if not _timer.timeout.is_connected(_refresh_scheduled_segments):
-		print("\tConnecting timer")
 		_timer.timeout.connect(_refresh_scheduled_segments)
 	_mutex.unlock()
 
 
 func _refresh_scheduled_segments() -> void:
-	print("_refresh_scheduled_segments")
+	if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
+		_mutex.lock()
+		_timer = null
+		call_deferred("_schedule_refresh", [])
+		_mutex.unlock()
+		return
 	_mutex.lock()
-	var _segs := _pending_updates.duplicate()
+	var _segs := _pending_updates.keys()
 	_pending_updates.clear()
 	_timer = null
 	_mutex.unlock()
-	refresh_roadsegments(_segs.keys())
+	refresh_roadsegments(_segs)
 	
 
 func refresh_roadsegments(segments: Array) -> void:
-	print("refresh_roadsegments")
 	if not is_configured():
 		push_warning("Terrain-Road configuration invalid")
 		return
@@ -111,7 +125,6 @@ func refresh_roadsegments(segments: Array) -> void:
 	terrain.data.update_maps(Terrain3DRegion.MapType.TYPE_HEIGHT)
 
 
-
 # TODO: Move this utility into the RoadSegment (with offset) or RoadPoint class (no offset)
 func get_road_width(point: RoadPoint) -> float:
 	return (point.gutter_profile.x*2
@@ -121,29 +134,87 @@ func get_road_width(point: RoadPoint) -> float:
 	)
 
 
-func flatten_terrain_via_roadsegment(segment:RoadSegment):
-	var curve:Curve3D = segment.curve
-	var points = curve.get_baked_points()
-	
+func flatten_terrain_via_roadsegment(segment: RoadSegment):
+	if not is_instance_valid(segment):
+		return
 	if not is_instance_valid(segment.start_point) or not is_instance_valid(segment.end_point):
 		return
-	
-	# Get the starting/ending widths to interpolate between
-	var start_width:float = get_road_width(segment.start_point)
-	#var end_width:float = get_road_width(segment.end_point)
-	
-	var _prev = segment.global_transform.origin + segment.global_transform.basis * points[0]
-	for pidx in range(1, points.size()):
-		var point = segment.global_transform.origin + segment.global_transform.basis * points[pidx]
-		var road_height = point.y + offset # Subtract some to avoid z-fighting
-		terrain.data.set_height(point, road_height)
-		var fwd = (point - _prev).normalized()
-		var side = Vector3.UP.cross(fwd)
-		var width = start_width / 2 # todo, interpolate betwen start/end widths
-		# Start at 1 since we already hit 0
-		for i in range(1, width):
-			terrain.data.set_height(point + (side*i), road_height)
-			terrain.data.set_height(point - (side*i), road_height)
-		#print("\t\tFlattening %s:%s offset %s to %s" % [pidx, point, side, road_height])
-		_prev = point
-	
+
+	var mesh := segment.road_mesh.mesh
+	if mesh == null:
+		return
+
+	var curve: Curve3D = segment.curve
+	var start_width: float = get_road_width(segment.start_point)
+	var end_width: float = get_road_width(segment.end_point)
+	var vertex_spacing: float = terrain.vertex_spacing
+
+	# Get global bounding box from mesh, expanded by affected smoothing radius
+	var local_aabb: AABB = mesh.get_aabb()
+	var offsets := Vector3(edge_margin+edge_falloff, 0, edge_margin+edge_falloff)
+	var aabb: AABB = segment.road_mesh.global_transform * segment.road_mesh.get_aabb()
+	var aabb_min := aabb.position - offsets
+	var aabb_max := aabb.position + aabb.size + offsets
+
+	# Snap bounds to terrain grid
+	var min := Vector3(aabb_min.x, 0, aabb_min.z).snapped(Vector3(vertex_spacing, 0, vertex_spacing))
+	var max := Vector3(aabb_max.x, 0, aabb_max.z).snapped(Vector3(vertex_spacing, 0, vertex_spacing)) + Vector3(vertex_spacing, 0, vertex_spacing)
+
+	var world_to_local := segment.global_transform.affine_inverse()
+
+	var x = min.x
+	while x <= max.x:
+		var z = min.z
+		while z <= max.z:
+			var world_pos := Vector3(x, 0.0, z)
+			var local_pos := world_to_local * world_pos
+
+			var closest_distance := curve.get_closest_offset(local_pos)
+			var curve_point := curve.sample_baked(closest_distance)
+			var world_curve_point := segment.global_transform * curve_point
+
+			# Check if we are beyond the egde of this RoadSegment, and thus
+			# would overlap with updates done by the next RoadSegment
+			if closest_distance == 0.0:
+				var _offset = world_pos - segment.start_point.global_position 
+				var zdist:float = abs(segment.start_point.global_transform.basis.z.dot(_offset))
+				if zdist > vertex_spacing:
+					z += vertex_spacing
+					continue
+			if closest_distance == curve.get_baked_length():
+				var _offset = world_pos - segment.start_point.global_position 
+				var zdist:float = abs(segment.end_point.global_transform.basis.z.dot(_offset))
+				if zdist > vertex_spacing:
+					z += vertex_spacing
+					continue
+			
+			# TODO: project this world position onto the xz plane of the transform
+			# returned at this curvepoint, to account for road tilting
+			# Likely making use of: sample_baked_with_rotation
+			var road_y := world_curve_point.y + offset
+			
+			var lateral_vector := world_pos - Vector3(world_curve_point.x, 0.0, world_curve_point.z)
+
+			var t := clamp(closest_distance / curve.get_baked_length(), 0.0, 1.0)
+			# Note: this will not be exact as it's not actually linear, as there
+			# is some ease/smoothing done for lane count / width changes
+			# TODO: Need to account for RoadPoint alignment, right now assumes CENTERED
+			# Offset by lane_width * number rev lanes if not centered.
+			var width := lerp(start_width, end_width, t)
+			
+			var lat_dist: float = lateral_vector.length()
+			if lat_dist <= width / 2.0 + edge_margin:
+				# Flatten to exactly match the road, adding shoulder margin
+				var terrain_pos := Vector3(x, road_y, z)
+				terrain.data.set_height(terrain_pos, road_y)
+			elif lat_dist <= width / 2.0 + edge_margin + edge_falloff:
+				# Smoothly interpolate height beyon shoulder to prior height
+				# TODO: improve possible creasing issues caused here
+				var terrain_pos := Vector3(x, road_y, z)
+				var reference_height := terrain.data.get_height(terrain_pos)
+				var factor: float = (lat_dist - edge_margin - width / 2.0) / edge_falloff
+				var smoothed_height := lerp(road_y, reference_height, ease(factor, -1.5))
+				terrain.data.set_height(terrain_pos, smoothed_height)
+
+			z += vertex_spacing
+		x += vertex_spacing

--- a/addons/road-generator/connectors/terrain3d_road_connector.gd
+++ b/addons/road-generator/connectors/terrain3d_road_connector.gd
@@ -1,0 +1,147 @@
+@tool
+extends Node
+
+const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
+
+# Terrain3D
+## Reference to the Terrain3D instance, to be flattened
+@export var terrain:Terrain3D:
+	set(value):
+		terrain = value
+		configure_road_update_signal()
+## Reference to the RoadManager instance, read only
+@export var road_manager:RoadManager:
+	set(value):
+		road_manager = value
+		configure_road_update_signal()
+## Vertical offset to help avoid z-fighting, negative values will sink the terrain underneath the road
+@export var offset:float = -0.5
+# TODO: add property for density
+# TODO: add property for falloff beyond edges of road
+## If enabled, auto refresh the terrain when updating roads
+@export var auto_refresh:bool = false:
+	set(value):
+		auto_refresh = value
+		configure_road_update_signal()
+## Immediately level the terrain to match roads
+@export_tool_button("Refresh", "Callable") var refresh_action = do_full_refresh
+
+var _pending_updates:Array = [] # TODO: type as RoadSegments, need to update internal typing
+var _timer:SceneTreeTimer
+var _mutex:Mutex
+
+func _ready() -> void:
+	_mutex = Mutex.new()
+	configure_road_update_signal()
+
+
+func is_configured() -> bool:
+	var has_error:bool = false
+	if not is_instance_valid(road_manager):
+		push_warning("Road manager not assigned for terrain flattening")
+		has_error = true
+	if not is_instance_valid(terrain):
+		push_warning("Terrain not assigned for terrain flattening")
+		has_error = true
+	return not has_error
+
+
+func configure_road_update_signal() -> void:
+	if not is_instance_valid(road_manager):
+		return
+	# TODO: Primary road generator project to expose this on the manager level, to bubble up from
+	# individual containers
+	for _cont in road_manager.get_containers():
+		_cont = _cont as RoadContainer
+		if auto_refresh and not _cont.on_road_updated.is_connected(_schedule_refresh):
+			_cont.on_road_updated.connect(_schedule_refresh)
+		elif not auto_refresh and _cont.on_road_updated.is_connected(_schedule_refresh):
+			_cont.on_road_updated.disconnect(_schedule_refresh)
+
+
+func do_full_refresh():
+	print("do_full_refresh")
+	if not is_configured():
+		return
+	for _container in road_manager.get_containers():
+		_container = _container as RoadContainer
+		var segs:Array = _container.get_segments()
+		refresh_roadsegments(segs)
+
+
+func _schedule_refresh(segments: Array) -> void:
+	print("_schedule_refresh")
+	_mutex.lock()
+	_pending_updates += segments
+	if not is_instance_valid(_timer):
+		print("\tCreated timer")
+		_timer = get_tree().create_timer(0.2)
+	else:
+		print("\tTime left: ", _timer.get_time_left())
+	if not _timer.timeout.is_connected(_refresh_scheduled_segments):
+		print("\tConnecting timer")
+		_timer.timeout.connect(_refresh_scheduled_segments)
+	_mutex.unlock()
+
+
+func _refresh_scheduled_segments() -> void:
+	print("_refresh_scheduled_segments")
+	_mutex.lock()
+	var _segs := _pending_updates.duplicate()
+	_pending_updates.clear()
+	_timer = null
+	_mutex.unlock()
+	refresh_roadsegments(_segs)
+	
+
+func refresh_roadsegments(segments: Array) -> void:
+	print("refresh_roadsegments")
+	if not is_configured():
+		push_warning("Terrain-Road configuration invalid")
+		return
+	if not terrain.data:
+		push_warning("No terrain data available (yet)")
+		return
+	for _seg in segments:
+		_seg = _seg as RoadSegment
+		print("Refreshing %s/%s" % [_seg.get_parent().name, _seg.name])
+		flatten_terrain_via_roadsegment(_seg)
+	terrain.data.force_update_maps()
+
+
+
+# TODO: Move this utility into the RoadSegment (with offset) or RoadPoint class (no offset)
+func get_road_width(point: RoadPoint) -> float:
+	return (point.gutter_profile.x*2
+		+ point.shoulder_width_l
+		+ point.shoulder_width_r
+		+ point.lane_width * point.lanes.size()
+	)
+
+
+func flatten_terrain_via_roadsegment(segment:RoadSegment):
+	var curve:Curve3D = segment.curve
+	var points = curve.get_baked_points()
+	
+	if not is_instance_valid(segment.start_point) or not is_instance_valid(segment.end_point):
+		return
+	
+	# Get the starting/ending widths to interpolate between
+	var start_width:float = get_road_width(segment.start_point)
+	#var end_width:float = get_road_width(segment.end_point)
+	
+	var _prev = segment.global_transform.origin + segment.global_transform.basis * points[0]
+	for pidx in range(1, points.size()):
+		var point = segment.global_transform.origin + segment.global_transform.basis * points[pidx]
+		var road_height = point.y + offset # Subtract some to avoid z-fighting
+		terrain.data.set_height(point, road_height)
+		var fwd = (point - _prev).normalized()
+		var side = Vector3.UP.cross(fwd)
+		var width = start_width / 2 # todo, interpolate betwen start/end widths
+		# Start at 1 since we already hit 0
+		for i in range(1, width):
+			terrain.data.set_height(point + (side*i), road_height)
+			terrain.data.set_height(point - (side*i), road_height)
+		#print("\t\tFlattening %s:%s offset %s to %s" % [pidx, point, side, road_height])
+		_prev = point
+	

--- a/addons/road-generator/connectors/terrain3d_road_connector.gd
+++ b/addons/road-generator/connectors/terrain3d_road_connector.gd
@@ -26,7 +26,7 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 ## Immediately level the terrain to match roads
 @export_tool_button("Refresh", "Callable") var refresh_action = do_full_refresh
 
-var _pending_updates:Array = [] # TODO: type as RoadSegments, need to update internal typing
+var _pending_updates:Dictionary = {} # TODO: type as RoadSegments, need to update internal typing
 var _timer:SceneTreeTimer
 var _mutex:Mutex
 
@@ -72,7 +72,9 @@ func do_full_refresh():
 func _schedule_refresh(segments: Array) -> void:
 	print("_schedule_refresh")
 	_mutex.lock()
-	_pending_updates += segments
+	for _seg in segments:
+		# Using a dictionary to accumulate updates to process
+		_pending_updates[_seg] = true
 	if not is_instance_valid(_timer):
 		print("\tCreated timer")
 		_timer = get_tree().create_timer(0.2)
@@ -91,7 +93,7 @@ func _refresh_scheduled_segments() -> void:
 	_pending_updates.clear()
 	_timer = null
 	_mutex.unlock()
-	refresh_roadsegments(_segs)
+	refresh_roadsegments(_segs.keys())
 	
 
 func refresh_roadsegments(segments: Array) -> void:
@@ -106,7 +108,7 @@ func refresh_roadsegments(segments: Array) -> void:
 		_seg = _seg as RoadSegment
 		print("Refreshing %s/%s" % [_seg.get_parent().name, _seg.name])
 		flatten_terrain_via_roadsegment(_seg)
-	terrain.data.force_update_maps()
+	terrain.data.update_maps(Terrain3DRegion.MapType.TYPE_HEIGHT)
 
 
 


### PR DESCRIPTION
This PR adds a lightweight integration between the Road Generator and Terrain3D plugins. It simply requires on public signals or class function methods in order to 

We are actively looking for feedback, but regardless this will be included in the next Road Generator release

- Test it by adding the simple Node into your scene with the script this PR adds, and connect the export var to the corresponding nodes (you should already have a terrain3d and RoadManager object in your scene)
- Play around with the other export like edge margin and edge falloff
- Works when drawing new roads, changing lane counts, and moving roads around
- Made to work with the latest v1.0 version of Terrain3D, older versions of Terrain3D won't work due to a slight API change
- Currently no way to mark sections of the road to be ignored, which can be problematic for holes
- Some known issues to improve upon (now, or in the future):
  - If you have high angles or slants on your roads, or twists, it will not perfectly match up
  - You can get some "creasing" around RoadPoints, though it should be fairly quick to manually smooth out using Terrain3D tools
  - While road updates themselves can be undone/redone, the changes to terrain via this connection do not respect undo/redo
  - Does not respect the "alignment" feature recently added to RoadPoints other than the default "geometric"
  - Doesn't fully work with prefab intersections at the moment

Latest demo showcase:

https://github.com/user-attachments/assets/a76969fc-049e-497a-9ea6-3dda6070380e

---

The majority of the discussion so far is held in https://github.com/TheDuckCow/godot-road-generator/issues/215 so see there for details and contributions - thanks once again to @aclave1 to your code sample, and the others for weighing in.

Outdated demo video:

https://github.com/user-attachments/assets/3c31f2dc-c8c5-4d43-ae82-78612334582f

Closes #215