### PR TITLE
Proposal: make reversed lanes continuous

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -902,10 +902,13 @@ func update_lane_seg_connections():
 			# prior lane be set to track to a next lane
 			for next_ln in next_seg_lanes:
 				if prior_ln.lane_next_tag == next_ln.lane_prior_tag:
-					if prior_ln.reverse_direction:
+					# TODO: When directionality is made consistent, we should no longer
+					# need to invert the direction assignment here.
+					if prior_ln.lane_next_tag[0] == "F":
 						prior_ln.lane_prior = prior_ln.get_path_to(next_ln)
 						next_ln.lane_next = next_ln.get_path_to(prior_ln)
 					else:
+						assert(prior_ln.lane_next_tag[0] == "R")
 						prior_ln.lane_next = prior_ln.get_path_to(next_ln)
 						next_ln.lane_prior = next_ln.get_path_to(prior_ln)
 

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -898,25 +898,16 @@ func update_lane_seg_connections():
 		var next_seg_lanes = pt.next_seg.get_lanes()
 
 		# Check lanes attributed to the *prior* segment
-		for ln in prior_seg_lanes:
+		for prior_ln in prior_seg_lanes:
 			# prior lane be set to track to a next lane
 			for next_ln in next_seg_lanes:
-				if next_ln.lane_prior_tag == ln.lane_next_tag:
-					if ln.reverse_direction:
-						# if reverse, then a "next" lane becomes the "prior"
-						ln.lane_prior = ln.get_path_to(next_ln)
+				if prior_ln.lane_next_tag == next_ln.lane_prior_tag:
+					if prior_ln.reverse_direction:
+						prior_ln.lane_prior = prior_ln.get_path_to(next_ln)
+						next_ln.lane_next = next_ln.get_path_to(prior_ln)
 					else:
-						ln.lane_next = ln.get_path_to(next_ln)
-		# Check lanes attributed to the *next* segment
-		for ln in next_seg_lanes:
-			# next lane be set to track to a prior lane
-			for prior_ln in prior_seg_lanes:
-				if prior_ln.lane_next_tag == ln.lane_prior_tag:
-					if ln.reverse_direction:
-						# if reverse, then a "prior" lane becomes the "next"
-						ln.lane_next = ln.get_path_to(prior_ln)
-					else:
-						ln.lane_prior = ln.get_path_to(prior_ln)
+						prior_ln.lane_next = prior_ln.get_path_to(next_ln)
+						next_ln.lane_prior = next_ln.get_path_to(prior_ln)
 
 
 # Triggered by adjusting RoadPoint transform in editor via signal connection.

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -74,33 +74,30 @@ func _ready():
 	rebuild_geom()
 	#_instantiate_geom()
 
-
-func _set_direction(value):
+func _set_direction(value: bool) -> void:
+	if value == reverse_direction:
+		return
+	var reversed_curve = Curve3D.new()
+	for i in range(self.curve.point_count - 1, -1, -1):
+		var pos = self.curve.get_point_position(i)
+		var in_tangent = self.curve.get_point_in(i)
+		var out_tangent = self.curve.get_point_out(i)
+		reversed_curve.add_point(pos, out_tangent, in_tangent)
+	self.curve = reversed_curve
 	reverse_direction = value
 	refresh_geom = true
 	rebuild_geom()
 
-
-func _get_direction():
+func _get_direction() -> bool:
 	return reverse_direction
 
 
 func get_lane_start() -> Vector3:
-	var pos
-	if reverse_direction:
-		pos = curve.get_point_position(curve.get_point_count()-1)
-	else:
-		pos = curve.get_point_position(0)
-	return to_global(pos)
+	return to_global(curve.get_point_position(0))
 
 
 func get_lane_end() -> Vector3:
-	var pos
-	if reverse_direction:
-		pos = curve.get_point_position(0)
-	else:
-		pos = curve.get_point_position(curve.get_point_count()-1)
-	return to_global(pos)
+	return to_global(curve.get_point_position(curve.get_point_count()-1))
 
 
 ## Register a car to be connected to (on, following) this lane.
@@ -169,7 +166,6 @@ func _draw_shark_fins() -> void:
 	var draw_dist = 3 # draw a new triangle at this interval in m
 	var tri_count = floor(curve_length / draw_dist)
 
-	var rev = -1 if reverse_direction else 1
 	geom.clear_surfaces()
 	for i in range (0, tri_count):
 		var f = i * curve_length / tri_count
@@ -177,7 +173,7 @@ func _draw_shark_fins() -> void:
 
 		xf.origin = curve.sample_baked(f)
 		var lookat = (
-			curve.sample_baked(f + 0.1*rev) - xf.origin
+			curve.sample_baked(f + 0.1) - xf.origin
 		).normalized()
 
 		geom.surface_begin(Mesh.PRIMITIVE_TRIANGLES)

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -11,7 +11,6 @@ const COLOR_START = Color(0.7, 0.7, 0,7)
 
 signal on_transform
 
-@export var reverse_direction:bool = false: get = _get_direction, set = _set_direction
 @export var lane_left:NodePath # Used to indicate allowed lane changes
 @export var lane_right:NodePath # Used to indicate allowed lane changes
 @export var lane_next:NodePath # RoadLane or intersection
@@ -43,6 +42,10 @@ signal on_transform
 ## Auto queue-free any vehicles registered to this lane with the road lane exits
 @export var auto_free_vehicles: bool = true
 
+# TODO: remove when moved to Godot 4.4 and changed to simple button
+# the variable is not used - only to provide GUI element
+@export var reverse_direction = false: set = _set_reverse_direction
+
 var this_road_segment = null # RoadSegment
 var refresh_geom = true
 var geom:ImmediateMesh # For tool usage, drawing lane directions and end points
@@ -55,7 +58,6 @@ var _draw_in_game: bool = false
 var _draw_in_editor: bool = false
 var _draw_override: bool = false
 var _display_fins: bool = false
-
 
 # ------------------------------------------------------------------------------
 # Setup and export setter/getters
@@ -74,9 +76,14 @@ func _ready():
 	rebuild_geom()
 	#_instantiate_geom()
 
-func _set_direction(value: bool) -> void:
-	if value == reverse_direction:
-		return
+
+#TODO: remove when moved to Godot 4.4 and changed to simple button
+func _set_reverse_direction(value: bool) -> void:
+	on_reverse_lane()
+
+
+## Reverse geometry of lane curve
+func on_reverse_lane() -> void:
 	var reversed_curve = Curve3D.new()
 	for i in range(self.curve.point_count - 1, -1, -1):
 		var pos = self.curve.get_point_position(i)
@@ -84,12 +91,8 @@ func _set_direction(value: bool) -> void:
 		var out_tangent = self.curve.get_point_out(i)
 		reversed_curve.add_point(pos, out_tangent, in_tangent)
 	self.curve = reversed_curve
-	reverse_direction = value
 	refresh_geom = true
 	rebuild_geom()
-
-func _get_direction() -> bool:
-	return reverse_direction
 
 
 func get_lane_start() -> Vector3:


### PR DESCRIPTION
This code is my first attempt of a small refactoring in the project, so please consider it as a proposal and invitation to discussion based on the working code :)
In my mind it make sense just from abstraction point of view when working with lanes - so you wouldn't have to think about segment order/direction. instead you're having "natural" order where bigger lane offsets and next means forward, lower lane offset and prior Road lane means backward. Also left/right lane links already in "natural" order for the road lanes so I think this proposal makes it more consistent
"reverse flag" still left to ease connection search and GUI purposes, but not for moving along the RoadLane list
Essentially  this proposal moves complexity from agent, which doesn't have to consider whether it moves on reverse lane or not - to (ideally) less frequently used functions (like lane reverse)

Change road lanes directions from being segment direction centric to lane direction centric
For reversed lanes:
Reverse RoadLane's Path3D curve to make start point and lane offset intuitive
Change connection with next/prior RoadLane to be in direction of the lane
I think it already makes RoadAgent's logic a little simpler