### PR TITLE
Added roadpoint flip tool to assist with normalization

### DIFF
--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -937,6 +937,11 @@ func disconnect_container(this_direction: int, target_direction: int) -> bool:
 	return true
 
 
+func set_internal_updating(state: bool) -> void:
+	self._is_internal_updating = state
+	container._auto_refresh = not state
+	
+
 func _exit_tree():
 	# Proactively disconnected any connected road segments, no longer valid.
 	if is_instance_valid(prior_seg):

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -28,6 +28,7 @@ func _parse_begin(object):
 	panel_instance.on_add_connected_rp.connect(_handle_add_connected_rp)
 	panel_instance.assign_copy_target.connect(_assign_copy_target)
 	panel_instance.apply_settings_target.connect(_apply_settings_target)
+	panel_instance.flip_roadpoint.connect(_flip_roadpoint)
 
 	if is_instance_valid(_editor_plugin): 
 		panel_instance.has_copy_ref = true and _editor_plugin.copy_attributes 
@@ -129,3 +130,11 @@ func _apply_settings_target(target, all:bool) -> void:
 		undo_redo.add_do_method(target, "emit_transform")
 		undo_redo.add_undo_method(target, "emit_transform")
 	undo_redo.commit_action()
+
+
+func _flip_roadpoint(rp:RoadPoint) -> void:
+	var undo_redo = _editor_plugin.get_undo_redo()
+	undo_redo.create_action("Flip RoadPoint")
+	_editor_plugin.subaction_flip_roadpoint(rp, undo_redo)
+	undo_redo.commit_action()
+	

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -6,6 +6,7 @@ signal on_lane_change_pressed(selection, direction, change_type)
 signal on_add_connected_rp(selection, point_init_type)
 signal assign_copy_target(selection)
 signal apply_settings_target(selection, all)
+signal flip_roadpoint(selection)
 
 # EditorInterface, don't use as type:
 # https://github.com/godotengine/godot/issues/85079
@@ -31,14 +32,14 @@ var has_copy_ref: bool
 
 
 func _ready():
-	btn_add_lane_fwd.connect("pressed", Callable(self, "add_lane_fwd_pressed"))
-	btn_add_lane_rev.connect("pressed", Callable(self, "add_lane_rev_pressed"))
-	btn_rem_lane_fwd.connect("pressed", Callable(self, "rem_lane_fwd_pressed"))
-	btn_rem_lane_rev.connect("pressed", Callable(self, "rem_lane_rev_pressed"))
-	btn_sel_rp_next.connect("pressed", Callable(self, "sel_rp_next_pressed"))
-	btn_sel_rp_prior.connect("pressed", Callable(self, "sel_rp_prior_pressed"))
-	btn_add_rp_next.connect("pressed", Callable(self, "add_rp_next_pressed"))
-	btn_add_rp_prior.connect("pressed", Callable(self, "add_rp_prior_pressed"))
+	btn_add_lane_fwd.pressed.connect(add_lane_fwd_pressed)
+	btn_add_lane_rev.pressed.connect(add_lane_rev_pressed)
+	btn_rem_lane_fwd.pressed.connect(rem_lane_fwd_pressed)
+	btn_rem_lane_rev.pressed.connect(rem_lane_rev_pressed)
+	btn_sel_rp_next.pressed.connect(sel_rp_next_pressed)
+	btn_sel_rp_prior.pressed.connect(sel_rp_prior_pressed)
+	btn_add_rp_next.pressed.connect(add_rp_next_pressed)
+	btn_add_rp_prior.pressed.connect(add_rp_prior_pressed)
 	update_labels(Input.is_key_pressed(KEY_SHIFT))
 
 func _unhandled_key_input(event: InputEvent) -> void:
@@ -97,35 +98,30 @@ func update_road_point_panel():
 
 
 func add_lane_fwd_pressed():
-	#gd4, nice to have
-	# Here and below, change to:
-	#on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD)
 	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD, bulk)
+	on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.ADD_FORWARD, bulk)
 	update_road_point_panel()
 
 
 func add_lane_rev_pressed():
 	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.ADD_REVERSE, bulk)
+	on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.ADD_REVERSE, bulk)
 	update_road_point_panel()
 
 
 func rem_lane_fwd_pressed():
 	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.REM_FORWARD, bulk)
+	on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.REM_FORWARD, bulk)
 	update_road_point_panel()
 
 
 func rem_lane_rev_pressed():
 	var bulk:bool = Input.is_key_pressed(KEY_SHIFT)
-	emit_signal("on_lane_change_pressed", sel_road_point, RoadPoint.TrafficUpdate.REM_REVERSE, bulk)
+	on_lane_change_pressed.emit(sel_road_point, RoadPoint.TrafficUpdate.REM_REVERSE, bulk)
 	update_road_point_panel()
 
 
 func sel_rp_next_pressed():
-	#gd4, not needed?
-	# not is empty
 	if not sel_road_point.next_pt_init:
 		return
 
@@ -138,8 +134,6 @@ func sel_rp_next_pressed():
 
 
 func sel_rp_prior_pressed():
-	#gd4, not needed?
-	# not is empty
 	if not sel_road_point.prior_pt_init:
 		return
 
@@ -152,11 +146,11 @@ func sel_rp_prior_pressed():
 
 
 func add_rp_next_pressed():
-	emit_signal("on_add_connected_rp", sel_road_point, RoadPoint.PointInit.NEXT)
+	on_add_connected_rp.emit(sel_road_point, RoadPoint.PointInit.NEXT)
 
 
 func add_rp_prior_pressed():
-	emit_signal("on_add_connected_rp", sel_road_point, RoadPoint.PointInit.PRIOR)
+	on_add_connected_rp.emit(sel_road_point, RoadPoint.PointInit.PRIOR)
 
 
 ## Adds a numeric sequence to the end of a RoadPoint name
@@ -180,16 +174,20 @@ func _on_cp_settings_pressed() -> void:
 	has_copy_ref = true
 	apply_setting.disabled = false
 	cp_to_all.disabled = false
-	emit_signal("assign_copy_target", sel_road_point)
+	assign_copy_target.emit(sel_road_point)
 
 
 func _on_cp_to_all_pressed() -> void:
 	if not has_copy_ref:
 		return
-	emit_signal("apply_settings_target", sel_road_point, true)
+	apply_settings_target.emit(sel_road_point, true)
 
 
 func _on_apply_setting_pressed() -> void:
 	if not has_copy_ref:
 		return
-	emit_signal("apply_settings_target", sel_road_point, false)
+	apply_settings_target.emit(sel_road_point, false)
+
+
+func _on_btn_flip_pressed() -> void:
+	flip_roadpoint.emit(sel_road_point)

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -13,34 +13,27 @@ signal flip_roadpoint(selection)
 var _edi : set = set_edi
 var sel_road_point: RoadPoint
 var has_copy_ref: bool
-@onready var top_label = $SectionLabel
-@onready var btn_add_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_add
-@onready var btn_add_lane_rev = $HBoxLanes/HBoxSubLanes/rev_add
-@onready var btn_rem_lane_fwd = $HBoxLanes/HBoxSubLanes/fwd_minus
-@onready var btn_rem_lane_rev = $HBoxLanes/HBoxSubLanes/rev_minus
-@onready var btn_sel_rp_next = $HBoxSelNextRP/sel_rp_front
-@onready var btn_sel_rp_prior = $HBoxSelPriorRP/sel_rp_back
-@onready var btn_add_rp_next = $HBoxAddNextRP/add_rp_front
-@onready var btn_add_rp_prior = $HBoxAddPriorRP/add_rp_back
-@onready var hbox_add_rp_next = $HBoxAddNextRP
-@onready var hbox_add_rp_prior = $HBoxAddPriorRP
-@onready var hbox_sel_rp_next = $HBoxSelNextRP
-@onready var hbox_sel_rp_prior = $HBoxSelPriorRP
-@onready var cp_settings: Button = $HBoxContainer/cp_settings
-@onready var apply_setting: Button = $HBoxContainer/apply_setting
-@onready var cp_to_all: Button = $HBoxContainer/cp_to_all
+@onready var top_label := %SectionLabel
+@onready var btn_add_lane_fwd = %fwd_add
+@onready var btn_add_lane_rev = %rev_add
+@onready var btn_rem_lane_fwd = %fwd_minus
+@onready var btn_rem_lane_rev = %rev_minus
+@onready var btn_sel_rp_next = %sel_rp_front
+@onready var btn_sel_rp_prior = %sel_rp_back
+@onready var btn_add_rp_next = %add_rp_front
+@onready var btn_add_rp_prior = %add_rp_back
+#@onready var hbox_add_rp_next = $HBoxAddNextRP
+#@onready var hbox_add_rp_prior = $HBoxAddPriorRP
+#@onready var hbox_sel_rp_next = $HBoxSelNextRP
+#@onready var hbox_sel_rp_prior = $HBoxSelPriorRP
+@onready var cp_settings: Button = %cp_settings
+@onready var apply_setting: Button = %apply_setting
+@onready var cp_to_all: Button = %cp_to_all
 
 
 func _ready():
-	btn_add_lane_fwd.pressed.connect(add_lane_fwd_pressed)
-	btn_add_lane_rev.pressed.connect(add_lane_rev_pressed)
-	btn_rem_lane_fwd.pressed.connect(rem_lane_fwd_pressed)
-	btn_rem_lane_rev.pressed.connect(rem_lane_rev_pressed)
-	btn_sel_rp_next.pressed.connect(sel_rp_next_pressed)
-	btn_sel_rp_prior.pressed.connect(sel_rp_prior_pressed)
-	btn_add_rp_next.pressed.connect(add_rp_next_pressed)
-	btn_add_rp_prior.pressed.connect(add_rp_prior_pressed)
 	update_labels(Input.is_key_pressed(KEY_SHIFT))
+
 
 func _unhandled_key_input(event: InputEvent) -> void:
 	if not event.keycode == KEY_SHIFT:
@@ -81,18 +74,18 @@ func update_road_point_panel():
 		btn_rem_lane_rev.disabled = true
 
 	if sel_road_point.next_pt_init:
-		hbox_add_rp_next.visible = false
-		hbox_sel_rp_next.visible = true
+		btn_add_rp_next.visible = false
+		btn_sel_rp_next.visible = true
 	else:
-		hbox_add_rp_next.visible = true
-		hbox_sel_rp_next.visible = false
+		btn_add_rp_next.visible = true
+		btn_sel_rp_next.visible = false
 
 	if sel_road_point.prior_pt_init:
-		hbox_add_rp_prior.visible = false
-		hbox_sel_rp_prior.visible = true
+		btn_add_rp_prior.visible = false
+		btn_sel_rp_prior.visible = true
 	else:
-		hbox_add_rp_prior.visible = true
-		hbox_sel_rp_prior.visible = false
+		btn_add_rp_prior.visible = true
+		btn_sel_rp_prior.visible = false
 
 	notify_property_list_changed()
 

--- a/addons/road-generator/ui/road_point_panel.tscn
+++ b/addons/road-generator/ui/road_point_panel.tscn
@@ -14,19 +14,24 @@ theme = SubResource("1")
 script = ExtResource("1")
 
 [node name="SectionLabel" type="Label" parent="."]
+unique_name_in_owner = true
 layout_mode = 2
-text = "Edit RoadPoint"
+text = "RoadPoint Profile"
 
-[node name="HBoxAddNextRP" type="HBoxContainer" parent="."]
+[node name="HBoxNext" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="spacer" type="Label" parent="HBoxAddNextRP"]
-modulate = Color(1, 1, 1, 0)
-custom_minimum_size = Vector2(40, 0)
+[node name="sel_rp_front" type="Button" parent="HBoxNext"]
+unique_name_in_owner = true
+clip_contents = true
 layout_mode = 2
-text = "Lanes:"
+size_flags_horizontal = 3
+tooltip_text = "Select the next connected RoadPoint"
+text = "Select Next RoadPoint"
+clip_text = true
 
-[node name="add_rp_front" type="Button" parent="HBoxAddNextRP"]
+[node name="add_rp_front" type="Button" parent="HBoxNext"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -34,91 +39,58 @@ tooltip_text = "Add RoadPoint to end of road"
 text = "+ Next RoadPoint"
 clip_text = true
 
-[node name="HBoxSelNextRP" type="HBoxContainer" parent="."]
-visible = false
-layout_mode = 2
-
-[node name="spacer" type="Label" parent="HBoxSelNextRP"]
-modulate = Color(1, 1, 1, 0)
-custom_minimum_size = Vector2(40, 0)
-layout_mode = 2
-text = "Lanes:"
-
-[node name="sel_rp_front" type="Button" parent="HBoxSelNextRP"]
-clip_contents = true
-layout_mode = 2
-size_flags_horizontal = 3
-text = "Select Next RoadPoint"
-clip_text = true
-
-[node name="HBoxLanes" type="HBoxContainer" parent="."]
-layout_mode = 2
-
-[node name="LanesLabel" type="Label" parent="HBoxLanes"]
-layout_mode = 2
-text = "Lanes:"
-
-[node name="HBoxSubLanes" type="HBoxContainer" parent="HBoxLanes"]
+[node name="HBoxSubLanes" type="HBoxContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3
 alignment = 1
 
-[node name="rev_add" type="Button" parent="HBoxLanes/HBoxSubLanes"]
+[node name="rev_add" type="Button" parent="HBoxSubLanes"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Add Reverse lane"
+tooltip_text = "Add Reverse lane. Hold shift to add another reverse lane to all RoadPoints in this container."
 text = "+"
 
-[node name="rev_minus" type="Button" parent="HBoxLanes/HBoxSubLanes"]
+[node name="rev_minus" type="Button" parent="HBoxSubLanes"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Remove Reverse lane"
+tooltip_text = "Remove Reverse lane. Hold shift to remove a reverse lane from all RoadPoints in this container."
 text = "-"
 
-[node name="diver_label" type="Label" parent="HBoxLanes/HBoxSubLanes"]
+[node name="diver_label" type="Label" parent="HBoxSubLanes"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.952941, 0.733333, 0.0666667, 1)
 text = "||"
 
-[node name="fwd_minus" type="Button" parent="HBoxLanes/HBoxSubLanes"]
+[node name="fwd_minus" type="Button" parent="HBoxSubLanes"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Remove Forward lane"
+tooltip_text = "Remove Forward lane. Hold shift to add another forward lane to all RoadPoints in this container."
 text = "-"
 
-[node name="fwd_add" type="Button" parent="HBoxLanes/HBoxSubLanes"]
+[node name="fwd_add" type="Button" parent="HBoxSubLanes"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Add Forward lane"
+tooltip_text = "Add Forward lane. Hold shift to remove a reverse lane from all RoadPoints in this container."
 text = "+"
 
-[node name="HBoxSelPriorRP" type="HBoxContainer" parent="."]
-visible = false
+[node name="HBoxPrior" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="spacer" type="Label" parent="HBoxSelPriorRP"]
-modulate = Color(1, 1, 1, 0)
-custom_minimum_size = Vector2(40, 0)
-layout_mode = 2
-text = "Lanes:"
-
-[node name="sel_rp_back" type="Button" parent="HBoxSelPriorRP"]
+[node name="sel_rp_back" type="Button" parent="HBoxPrior"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
+tooltip_text = "Select the previous connected RoadPoint"
 text = "Select Prior RoadPoint"
 clip_text = true
 
-[node name="HBoxAddPriorRP" type="HBoxContainer" parent="."]
-layout_mode = 2
-
-[node name="spacer" type="Label" parent="HBoxAddPriorRP"]
-modulate = Color(1, 1, 1, 0)
-custom_minimum_size = Vector2(40, 0)
-layout_mode = 2
-text = "Lanes:"
-
-[node name="add_rp_back" type="Button" parent="HBoxAddPriorRP"]
+[node name="add_rp_back" type="Button" parent="HBoxPrior"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -126,52 +98,72 @@ tooltip_text = "Add RoadPoint to beginning of road"
 text = "+ Prior RoadPoint"
 clip_text = true
 
-[node name="spacer" type="Control" parent="."]
-custom_minimum_size = Vector2(0, 5)
+[node name="debug_separator" type="HBoxContainer" parent="."]
 layout_mode = 2
+
+[node name="Label" type="Label" parent="debug_separator"]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Debug features "
+
+[node name="HSeparator" type="HSeparator" parent="debug_separator"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="spacer" type="Label" parent="HBoxContainer"]
-modulate = Color(1, 1, 1, 0)
-custom_minimum_size = Vector2(40, 0)
-layout_mode = 2
-text = "Lanes:"
-
 [node name="cp_settings" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
+tooltip_text = "Copies the attributes of this RoadPoint such as lane count shoulder size to easily apply to other RoadPoints.
+
+Hold shift to apply to all."
 text = "Copy Settings"
 clip_text = true
 
 [node name="apply_setting" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
+tooltip_text = "Applies copied attributes to this single RoadPoint, such as lane count and shoulder size."
 disabled = true
 text = "Apply"
 clip_text = true
 
 [node name="cp_to_all" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
 visible = false
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
+tooltip_text = "Applies copied attributes to all RoadPoints of this container, such as lane count and shoulder size."
 disabled = true
 text = "Apply All"
 clip_text = true
 
-[node name="flip" type="Button" parent="HBoxContainer"]
+[node name="flip" type="Button" parent="."]
 layout_mode = 2
+tooltip_text = "Flips this RoadPoint 180º while keeping all connections and attributes in place. Visually, it should appear nothing has changed - but is a way to fix roadpoints to point in a consistent direction without breaking connections."
 text = "Flip"
 
-[node name="spacer2" type="Control" parent="."]
+[node name="spacer3" type="Control" parent="."]
 custom_minimum_size = Vector2(0, 5)
 layout_mode = 2
 
+[connection signal="pressed" from="HBoxNext/sel_rp_front" to="." method="sel_rp_next_pressed"]
+[connection signal="pressed" from="HBoxNext/add_rp_front" to="." method="add_rp_next_pressed"]
+[connection signal="pressed" from="HBoxSubLanes/rev_add" to="." method="add_lane_rev_pressed"]
+[connection signal="pressed" from="HBoxSubLanes/rev_minus" to="." method="rem_lane_rev_pressed"]
+[connection signal="pressed" from="HBoxSubLanes/fwd_minus" to="." method="rem_lane_fwd_pressed"]
+[connection signal="pressed" from="HBoxSubLanes/fwd_add" to="." method="add_lane_fwd_pressed"]
+[connection signal="pressed" from="HBoxPrior/sel_rp_back" to="." method="sel_rp_prior_pressed"]
+[connection signal="pressed" from="HBoxPrior/add_rp_back" to="." method="add_rp_prior_pressed"]
 [connection signal="pressed" from="HBoxContainer/cp_settings" to="." method="_on_cp_settings_pressed"]
 [connection signal="pressed" from="HBoxContainer/apply_setting" to="." method="_on_apply_setting_pressed"]
 [connection signal="pressed" from="HBoxContainer/cp_to_all" to="." method="_on_cp_to_all_pressed"]
-[connection signal="pressed" from="HBoxContainer/flip" to="." method="_on_btn_flip_pressed"]
+[connection signal="pressed" from="flip" to="." method="_on_btn_flip_pressed"]

--- a/addons/road-generator/ui/road_point_panel.tscn
+++ b/addons/road-generator/ui/road_point_panel.tscn
@@ -163,6 +163,10 @@ disabled = true
 text = "Apply All"
 clip_text = true
 
+[node name="flip" type="Button" parent="HBoxContainer"]
+layout_mode = 2
+text = "Flip"
+
 [node name="spacer2" type="Control" parent="."]
 custom_minimum_size = Vector2(0, 5)
 layout_mode = 2
@@ -170,3 +174,4 @@ layout_mode = 2
 [connection signal="pressed" from="HBoxContainer/cp_settings" to="." method="_on_cp_settings_pressed"]
 [connection signal="pressed" from="HBoxContainer/apply_setting" to="." method="_on_apply_setting_pressed"]
 [connection signal="pressed" from="HBoxContainer/cp_to_all" to="." method="_on_cp_to_all_pressed"]
+[connection signal="pressed" from="HBoxContainer/flip" to="." method="_on_btn_flip_pressed"]

--- a/demo/intersections/intersection_demo.tscn
+++ b/demo/intersections/intersection_demo.tscn
@@ -68,33 +68,105 @@ script = ExtResource("5")
 [node name="vehicles" type="Node3D" parent="RoadManager"]
 
 [node name="Player" parent="RoadManager/vehicles" instance=ExtResource("11")]
-transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 217.617, 4.00543e-05, -9.31158)
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 216.412, 4.00543e-05, 13.0137)
 drive_state = 2
 acceleration = 3
-target_speed = 50
+target_speed = 77
 visualize_lane = true
 
 [node name="Camera3D" type="Camera3D" parent="RoadManager/vehicles/Player"]
 transform = Transform3D(0.993534, -0.0226309, 0.111254, 0, 0.979932, 0.199334, -0.113533, -0.198045, 0.973596, 3.12792, 9.95246, 16.1407)
 far = 400.0
 
+[node name="NOC1" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 154.55, 4.00543e-05, 1.93544)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC2" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 105.042, 3.62396e-05, -0.988855)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC3" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 78.966, 3.24249e-05, -47.9551)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC4" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 145.889, 3.24249e-05, -172.754)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC5" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 187.864, 3.24249e-05, -156.988)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC6" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 135.822, 3.24249e-05, -188.105)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC7" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 48.0486, 3.24249e-05, -208.259)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC8" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 74.2511, 3.24249e-05, -236.574)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC9" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 133.98, 4.76837e-05, -28.3214)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC10" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 120.174, 4.76837e-05, 33.9176)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC11" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 216.932, 4.76837e-05, 93.3602)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
+[node name="NOC12" parent="RoadManager/vehicles" instance=ExtResource("11")]
+transform = Transform3D(0.979375, 0, -0.202052, 0, 1, 0, 0.202052, 0, 0.979375, 153.564, 4.76837e-05, 162.363)
+acceleration = 3
+target_speed = 25
+visualize_lane = true
+
 [node name="4way_2x2" parent="RoadManager" instance=ExtResource("2")]
 transform = Transform3D(1, 0, 0, 0, 0.999999, 0, 0, 0, 0.999999, 101.62, 1.52588e-05, -182.767)
 edge_containers = Array[NodePath]([NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../LocalRoads")])
 edge_rp_targets = Array[NodePath]([NodePath("Spatial33"), NodePath("Spatial23"), NodePath("Spatial26"), NodePath("Spatial24")])
-edge_rp_target_dirs = Array[int]([0, 1, 0, 1])
+edge_rp_target_dirs = Array[int]([0, 0, 0, 1])
 
 [node name="4way_1x1" parent="RoadManager" instance=ExtResource("6")]
 transform = Transform3D(0.954376, 0, 0.298607, 0, 1, 0, -0.298608, 0, 0.954376, 45.2872, 1.52588e-05, -223.937)
 edge_containers = Array[NodePath]([NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../LocalRoads")])
 edge_rp_targets = Array[NodePath]([NodePath("Spatial32"), NodePath("Spatial27"), NodePath("Spatial30"), NodePath("Spatial28")])
-edge_rp_target_dirs = Array[int]([0, 1, 0, 1])
+edge_rp_target_dirs = Array[int]([1, 1, 0, 1])
 
 [node name="3way_2x2" parent="RoadManager" instance=ExtResource("7")]
 transform = Transform3D(1, 0, 1.74846e-07, 0, 1, 0, -1.74846e-07, 0, 1, 214.099, -3.05176e-05, -10.5339)
 edge_containers = Array[NodePath]([NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../splitter_2x2")])
 edge_rp_targets = Array[NodePath]([NodePath("Spatial25"), NodePath("Spatial17"), NodePath("cap")])
-edge_rp_target_dirs = Array[int]([0, 1, 0])
+edge_rp_target_dirs = Array[int]([0, 0, 0])
 
 [node name="highway_onramp" parent="RoadManager" instance=ExtResource("8")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 110.01, 7.62939e-06, -60.835)
@@ -125,14 +197,14 @@ edge_rp_target_dirs = Array[int]([0, 1, 0])
 transform = Transform3D(-2.18557e-07, 0, 1, 0, 1, 0, -1, 0, -2.18557e-07, 182.099, -3.05176e-05, -10.5339)
 edge_containers = Array[NodePath]([NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../3way_2x2")])
 edge_rp_targets = Array[NodePath]([NodePath("Spatial10"), NodePath("Spatial8"), NodePath("RP_003")])
-edge_rp_target_dirs = Array[int]([0, 0, 1])
+edge_rp_target_dirs = Array[int]([0, 1, 1])
 
 [node name="splitter_2x3" parent="RoadManager" instance=ExtResource("9")]
 transform = Transform3D(-0.999994, 0, -0.00338593, 0, 1, 0, 0.00338593, 0, -0.999994, 99.362, 0, -136.072)
 draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../LocalRoads")])
 edge_rp_targets = Array[NodePath]([NodePath("Spatial21"), NodePath("Spatial19"), NodePath("Spatial22")])
-edge_rp_target_dirs = Array[int]([0, 0, 1])
+edge_rp_target_dirs = Array[int]([0, 1, 1])
 
 [node name="LocalRoads" type="Node3D" parent="RoadManager"]
 script = ExtResource("1")
@@ -144,7 +216,7 @@ edge_containers = Array[NodePath]([NodePath("../highway_onramp1"), NodePath("../
 edge_rp_targets = Array[NodePath]([NodePath("HW_02"), NodePath("HW_01"), NodePath("RAMP_01"), NodePath("RAMP_02"), NodePath("HW_01"), NodePath("HW_02"), NodePath("RAMP_02"), NodePath("RP_003"), NodePath("RAMP_01"), NodePath("RP_001"), NodePath("RP_003"), NodePath("HW_01"), NodePath("RP_001"), NodePath("HW_02"), NodePath("cap"), NodePath("RP_002"), NodePath("HW_01"), NodePath("RP_003"), NodePath("HW_02"), NodePath("RP_001"), NodePath("cap"), NodePath("RP_002"), NodePath("RP_004"), NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_002"), NodePath("RP_004"), NodePath("RP_003"), NodePath("RP_001"), NodePath("RP_001")])
 edge_rp_target_dirs = Array[int]([0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1])
 edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Spatial2"), NodePath("Spatial3"), NodePath("Spatial4"), NodePath("Spatial5"), NodePath("Spatial6"), NodePath("Spatial7"), NodePath("Spatial8"), NodePath("Spatial9"), NodePath("Spatial10"), NodePath("Spatial11"), NodePath("Spatial12"), NodePath("Spatial13"), NodePath("Spatial14"), NodePath("Spatial15"), NodePath("Spatial17"), NodePath("Spatial18"), NodePath("Spatial19"), NodePath("Spatial20"), NodePath("Spatial21"), NodePath("Spatial22"), NodePath("Spatial23"), NodePath("Spatial24"), NodePath("Spatial25"), NodePath("Spatial26"), NodePath("Spatial27"), NodePath("Spatial28"), NodePath("Spatial30"), NodePath("Spatial33"), NodePath("Spatial32")])
-edge_rp_local_dirs = Array[int]([1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0])
+edge_rp_local_dirs = Array[int]([1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1])
 
 [node name="Node3D" type="Node3D" parent="RoadManager/LocalRoads"]
 transform = Transform3D(-0.999976, 0, -0.00692902, 0, 1, 0, 0.00692902, 0, -0.999976, 89.605, 7.62939e-06, 16.6758)
@@ -202,11 +274,12 @@ prior_mag = 12.9596
 next_mag = 12.9596
 
 [node name="Spatial8" type="Node3D" parent="RoadManager/LocalRoads"]
-transform = Transform3D(-2.18557e-07, 0, 1, 0, 1, 0, -1, 0, -2.18557e-07, 166.099, -3.05176e-05, -2.5339)
+transform = Transform3D(3.0598e-07, 0, -1, 0, 1, 0, 1, 0, 3.0598e-07, 166.099, -3.05176e-05, -2.5339)
 script = ExtResource("10")
-traffic_dir = Array[int]([2, 2])
-lanes = Array[int]([2, 0])
-prior_pt_init = NodePath("../Spatial7")
+traffic_dir = Array[int]([1, 1])
+lanes = Array[int]([0, 2])
+next_pt_init = NodePath("../Spatial7")
+next_mag = 5.59434
 
 [node name="Spatial9" type="Node3D" parent="RoadManager/LocalRoads"]
 transform = Transform3D(0.848769, 0, 0.528764, 0, 1, 0, -0.528764, 0, 0.848769, 126.911, 7.62939e-06, -36.835)
@@ -225,11 +298,11 @@ lanes = Array[int]([0, 2])
 prior_pt_init = NodePath("../Spatial9")
 
 [node name="Spatial11" type="Node3D" parent="RoadManager/LocalRoads"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 90.1187, 0, 86.944)
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 90.1187, 0, 86.944)
 script = ExtResource("10")
-traffic_dir = Array[int]([2, 2])
-lanes = Array[int]([2, 0])
-prior_pt_init = NodePath("../Spatial12")
+traffic_dir = Array[int]([1, 1])
+lanes = Array[int]([0, 2])
+next_pt_init = NodePath("../Spatial12")
 
 [node name="Spatial12" type="Node3D" parent="RoadManager/LocalRoads"]
 transform = Transform3D(-0.999976, 0, -0.00692902, 0, 1, 0, 0.00692902, 0, -0.999976, 89.8961, 7.62939e-06, 58.6748)
@@ -272,13 +345,13 @@ prior_mag = 40.8762
 next_mag = 40.8762
 
 [node name="Spatial17" type="Node3D" parent="RoadManager/LocalRoads"]
-transform = Transform3D(1, 0, 1.74846e-07, 0, 1, 0, -1.74846e-07, 0, 1, 214.099, -3.05176e-05, 5.4661)
+transform = Transform3D(-1, 0, -2.62269e-07, 0, 1, 0, 2.62269e-07, 0, -1, 214.099, -3.05176e-05, 5.4661)
 script = ExtResource("10")
 traffic_dir = Array[int]([2, 2, 1, 1])
 lanes = Array[int]([2, 4, 4, 2])
-next_pt_init = NodePath("../Spatial16")
-prior_mag = 6.27905
-next_mag = 109.905
+prior_pt_init = NodePath("../Spatial16")
+prior_mag = 109.905
+next_mag = 6.27905
 
 [node name="Spatial18" type="Node3D" parent="RoadManager/LocalRoads"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 110.01, 7.62939e-06, -76.835)
@@ -288,11 +361,11 @@ lanes = Array[int]([0, 3, 2])
 prior_pt_init = NodePath("../Spatial19")
 
 [node name="Spatial19" type="Node3D" parent="RoadManager/LocalRoads"]
-transform = Transform3D(-0.999994, 0, -0.00338593, 0, 1, 0, 0.00338593, 0, -0.999994, 107.416, 0, -120.099)
+transform = Transform3D(0.999994, 0, 0.00338602, 0, 1, 0, -0.00338602, 0, 0.999994, 107.416, 0, -120.099)
 script = ExtResource("10")
-traffic_dir = Array[int]([2, 2])
-lanes = Array[int]([2, 0])
-prior_pt_init = NodePath("../Spatial18")
+traffic_dir = Array[int]([1, 1])
+lanes = Array[int]([0, 2])
+next_pt_init = NodePath("../Spatial18")
 
 [node name="Spatial20" type="Node3D" parent="RoadManager/LocalRoads"]
 transform = Transform3D(-0.999976, 0, -0.00692902, 0, 1, 0, 0.00692902, 0, -0.999976, 89.0403, 7.62939e-06, -76.2673)
@@ -318,11 +391,11 @@ prior_mag = 3.90903
 next_mag = 3.90903
 
 [node name="Spatial23" type="Node3D" parent="RoadManager/LocalRoads"]
-transform = Transform3D(1, 0, 0, 0, 0.999999, 0, 0, 0, 0.999999, 101.62, 1.52588e-05, -166.767)
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 0.999999, 0, 8.74227e-08, 0, -0.999999, 101.62, 1.52588e-05, -166.767)
 script = ExtResource("10")
 traffic_dir = Array[int]([2, 2, 1, 1])
 lanes = Array[int]([2, 4, 4, 2])
-next_pt_init = NodePath("../Spatial22")
+prior_pt_init = NodePath("../Spatial22")
 prior_mag = 3.65088
 next_mag = 3.65088
 
@@ -405,17 +478,17 @@ lanes = Array[int]([2, 4, 4, 2])
 prior_pt_init = NodePath("../Spatial29")
 
 [node name="Spatial32" type="Node3D" parent="RoadManager/LocalRoads"]
-transform = Transform3D(0.954376, 0, 0.298607, 0, 1, 0, -0.298608, 0, 0.954376, 40.5095, 1.52588e-05, -239.207)
+transform = Transform3D(-0.954376, 0, -0.298607, 0, 1, 0, 0.298608, 0, -0.954376, 40.5095, 1.52588e-05, -239.207)
 script = ExtResource("10")
 traffic_dir = Array[int]([2, 1])
 lanes = Array[int]([5, 5])
-prior_pt_init = NodePath("../Spatial31")
-prior_mag = 21.432
-next_mag = 8.0
+next_pt_init = NodePath("../Spatial31")
+prior_mag = 8.0
+next_mag = 21.432
 
 [node name="splitter_2x4" parent="RoadManager" instance=ExtResource("9")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 98.1187, 0, 102.944)
 draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath("../LocalRoads"), NodePath("../LocalRoads"), NodePath("../LocalRoads")])
 edge_rp_targets = Array[NodePath]([NodePath("Spatial13"), NodePath("Spatial11"), NodePath("Spatial15")])
-edge_rp_target_dirs = Array[int]([0, 0, 1])
+edge_rp_target_dirs = Array[int]([0, 1, 1])


### PR DESCRIPTION
There are some cases where it's helpful to rotate a RoadPoint 180º around its y-axis to get all RoadPoints to point along the same direction. In the future, this may be performed automatically or instead performed on an entire RoadContainer at once. However until then, this tool to manually flip individual RoadPoints will suffice. 

The goal of this operation is that visually for the user, the RoadPoint will appear entirely unchanged - meaning after the 180º rotation occurs, any asymmetries will be mirrored. For instance the forward bezier magnitude size is flipped with the reverse, the left-to-right lane directions will also be flipped around.

Demo of the flip tool can be seen here: notice how the Z-direction of the RoadPoint is flipped, but the mesh otherwise stays the same there (in reality, it is regenerated) - and most importantly, we can see that the errors in the RoadLane placement logic due to inconsistent directions is resolved and lanes flow smoothly now.

https://github.com/user-attachments/assets/968ec11b-d2f4-4355-9d03-84761a0d9067

