### PR TITLE
Add double yellow alignment option

### DIFF
--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -46,8 +46,8 @@ enum PointInit {
 }
 
 enum Alignment {
-	CENTER,
-	CENTERLINE,
+	GEOMETRIC,  ## Aligns equal amount of road to the left and right of the RoadPoint
+	DIVIDER,  ## Ensures the lane direction dividing line is aligned to the RoadPoint
 }
 
 const UI_TIMEOUT = 50 # Time in ms to delay further refresh updates.
@@ -122,8 +122,7 @@ const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPo
 ## Use positive x-values to widen the road even further beyond the shoulder width.
 @export var gutter_profile := Vector2(2.0, -0.5): get = _get_profile, set = _set_profile
 
-# Generate procedural road geometry
-# If off, it indicates the developer will load in their own custom mesh + collision.
+## Determines how the geometry will center itself around the RoadPoint origin
 @export var alignment: Alignment: get = _get_alignment, set = _set_alignment
 
 # ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -45,6 +45,11 @@ enum PointInit {
 	PRIOR,
 }
 
+enum Alignment {
+	CENTER,
+	CENTERLINE,
+}
+
 const UI_TIMEOUT = 50 # Time in ms to delay further refresh updates.
 const COLOR_YELLOW = Color(0.7, 0.7, 0,7)
 const COLOR_RED = Color(0.7, 0.3, 0.3)
@@ -117,6 +122,9 @@ const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPo
 ## Use positive x-values to widen the road even further beyond the shoulder width.
 @export var gutter_profile := Vector2(2.0, -0.5): get = _get_profile, set = _set_profile
 
+# Generate procedural road geometry
+# If off, it indicates the developer will load in their own custom mesh + collision.
+@export var alignment: Alignment: get = _get_alignment, set = _set_alignment
 
 # ------------------------------------------------------------------------------
 @export_group("Internal data")
@@ -131,7 +139,6 @@ const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPo
 ##
 ## Path to next [RoadPoint], relative to this [RoadPoint] itself.
 @export var next_pt_init: NodePath: get = _get_next_pt_init, set = _set_next_pt_init
-
 
 var rev_width_mag := -8.0
 var fwd_width_mag := 8.0
@@ -353,6 +360,18 @@ func _set_create_geo(value: bool) -> void:
 	if value == true:
 		emit_transform()
 
+
+func _get_alignment() -> Alignment:
+	return alignment
+
+
+func _set_alignment(value: Alignment) -> void:
+	if value == alignment:
+		return
+	alignment = value
+	if not is_instance_valid(container):
+		return  # Might not be initialized yet.
+	emit_transform()
 
 # ------------------------------------------------------------------------------
 # Editor interactions
@@ -667,6 +686,7 @@ func copy_settings_from(ref_road_point: RoadPoint, copy_transform: bool = true) 
 	gutter_profile.y = ref_road_point.gutter_profile.y
 	create_geo = ref_road_point.create_geo
 	_last_update_ms = ref_road_point._last_update_ms
+	alignment = ref_road_point.alignment
 
 	if copy_transform:
 		prior_mag = ref_road_point.prior_mag

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -17,6 +17,9 @@ const EDGE_R_NAME = "edge_R" ## Name of reverse lane edge curve
 const EDGE_F_NAME = "edge_F" ## Name of forward lane edge curve
 const EDGE_C_NAME = "edge_C" ## Name of road center (direction divider) edge curve
 
+## Lookup for lane texture multiplier - corresponds to RoadPoint.LaneType enum
+const uv_mul = [7, 0, 1, 2, 3, 4, 5, 6, 7, 7]
+
 signal seg_ready(road_segment)
 
 @export var start_init: NodePath: get = _init_start_get, set = _init_start_set
@@ -48,6 +51,18 @@ var _end_flip: bool = false
 # For easier calculation, to account for flipped directions.
 var _start_flip_mult: int = 1
 var _end_flip_mult: int = 1
+
+## For iteration on values related to Near(start) or Far(end) points of a segment
+enum NearFar {
+	NEAR,
+	FAR
+}
+
+## For iteration on values related to Left or Right sides of a segment
+enum LeftRight {
+	LEFT,
+	RIGHT
+}
 
 
 # ------------------------------------------------------------------------------
@@ -859,17 +874,6 @@ func _create_collisions() -> void:
 		
 		sbody.set_meta("_edit_lock_", true)
 
-enum NearFar {
-	NEAR,
-	FAR
-}
-enum LeftRight {
-	LEFT,
-	RIGHT
-}
-
-#correspond to RoadPoint.LaneType enum - lookup for lane texture multiplier
-const uv_mul = [7, 0, 1, 2, 3, 4, 5, 6, 7, 7]
 
 func _insert_geo_loop(
 		st: SurfaceTool,

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -222,20 +222,20 @@ func generate_edge_curves():
 	var start_offset_F
 	var end_offset_R
 	var end_offset_F
-	if start_point.alignment == RoadPoint.Alignment.CENTER:
+	if start_point.alignment == RoadPoint.Alignment.GEOMETRIC:
 		var start_half_width: float = len(start_point.lanes) * start_point.lane_width * 0.5
 		start_offset_R = start_half_width
 		start_offset_F = start_half_width
 	else:
-		assert( start_point.alignment == RoadPoint.Alignment.CENTERLINE )
+		assert( start_point.alignment == RoadPoint.Alignment.DIVIDER )
 		start_offset_R = start_point.get_rev_lane_count() * start_point.lane_width
 		start_offset_F = start_point.get_fwd_lane_count() * start_point.lane_width
-	if end_point.alignment == RoadPoint.Alignment.CENTER:
+	if end_point.alignment == RoadPoint.Alignment.GEOMETRIC:
 		var end_half_width: float = len(end_point.lanes) * end_point.lane_width * 0.5
 		end_offset_R = end_half_width
 		end_offset_F = end_half_width
 	else:
-		assert( end_point.alignment == RoadPoint.Alignment.CENTERLINE )
+		assert( end_point.alignment == RoadPoint.Alignment.DIVIDER )
 		end_offset_R = end_point.get_rev_lane_count() * end_point.lane_width
 		end_offset_F = end_point.get_fwd_lane_count() * end_point.lane_width
 
@@ -300,17 +300,17 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 	
 	var start_lane_offset
 	var end_lane_offset
-	if start_point.alignment == RoadPoint.Alignment.CENTERLINE:
+	if start_point.alignment == RoadPoint.Alignment.DIVIDER:
 		start_lane_offset = start_point.get_rev_lane_count()
 	else:
-		assert( start_point.alignment == RoadPoint.Alignment.CENTER )
+		assert( start_point.alignment == RoadPoint.Alignment.GEOMETRIC )
 		start_lane_offset = len(start_point.lanes) / 2.0
 
 	var manager:RoadManager = container.get_manager()
-	if end_point.alignment == RoadPoint.Alignment.CENTERLINE:
+	if end_point.alignment == RoadPoint.Alignment.DIVIDER:
 		end_lane_offset = end_point.get_rev_lane_count()
 	else:
-		assert( end_point.alignment == RoadPoint.Alignment.CENTER )
+		assert( end_point.alignment == RoadPoint.Alignment.GEOMETRIC )
 		end_lane_offset = len(end_point.lanes) / 2.0
 
 	var start_offset = (start_lane_offset - 0.5) * start_point.lane_width
@@ -890,8 +890,8 @@ func _insert_geo_loop(
 	var lane_offset = []
 	for nf in NearFar.values():
 		lane_offset.append(len(point[nf].lanes) / 2.0)
-	if start_point.alignment == RoadPoint.Alignment.CENTERLINE || \
-		end_point.alignment == RoadPoint.Alignment.CENTERLINE:
+	if start_point.alignment == RoadPoint.Alignment.DIVIDER || \
+		end_point.alignment == RoadPoint.Alignment.DIVIDER:
 		var nf_reverse = [0, 0]
 		for l in lanes:
 			if l[1] == RoadPoint.LaneDir.REVERSE:
@@ -905,7 +905,7 @@ func _insert_geo_loop(
 			else:
 				assert (l[1] == RoadPoint.LaneDir.FORWARD)
 		for nf in NearFar.values():
-			if point[nf].alignment == RoadPoint.Alignment.CENTERLINE:
+			if point[nf].alignment == RoadPoint.Alignment.DIVIDER:
 				lane_offset[nf] = nf_reverse[nf]
 
 	var nf_loop = [null, null]

--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -103,8 +103,10 @@ func _assign_copy_target(target) -> void:
 		"shoulder_width_l": target.shoulder_width_l,
 		"shoulder_width_r": target.shoulder_width_r,
 		"gutter_profile": target.gutter_profile,
-		"create_geo": target.create_geo
+		"create_geo": target.create_geo,
+		"alignment": target.alignment
 	}
+
 
 func _apply_settings_target(target, all:bool) -> void:
 	var undo_redo = _editor_plugin.get_undo_redo()

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -213,7 +213,7 @@ func _get_handle_value(gizmo: EditorNode3DGizmo, index: int, secondary: bool) ->
 	var lane_width = point.lane_width
 	var lane_count = len(point.traffic_dir)
 	var width_mag: float = lane_count * lane_width / 2
-	if point.alignment == RoadPoint.Alignment.CENTERLINE:
+	if point.alignment == RoadPoint.Alignment.DIVIDER:
 		if index == HandleType.REV_WIDTH_MAG:
 			width_mag = point.get_rev_lane_count() * lane_width
 		elif index == HandleType.FWD_WIDTH_MAG:
@@ -318,7 +318,7 @@ func set_width_handle(gizmo: EditorNode3DGizmo, index: int, camera: Camera3D, po
 		var lane_count = len(roadpoint.traffic_dir)
 
 		var road_divider = 0
-		if roadpoint.alignment == RoadPoint.Alignment.CENTER:
+		if roadpoint.alignment == RoadPoint.Alignment.GEOMETRIC:
 			road_divider = (roadpoint.get_rev_lane_count() - lane_count / 2.0) * lane_width
 		var road_div_rev_limit = road_divider - (lane_width * LaneOffset)
 		var road_div_fwd_limit = road_divider + (lane_width * LaneOffset)

--- a/addons/road-generator/ui/road_point_gizmo.gd
+++ b/addons/road-generator/ui/road_point_gizmo.gd
@@ -125,8 +125,8 @@ func _redraw(gizmo) -> void:
 		collider.size = BaseColliderSize * width_scale
 
 	var lines = PackedVector3Array()
-	lines.push_back(Vector3(0, 1, 0))
-	lines.push_back(Vector3(0, 1, 0))
+	lines.push_back(Vector3.UP)
+	lines.push_back(Vector3.UP)
 	gizmo.add_lines(lines, get_material("main", gizmo), false)
 
 	gizmo.add_collision_triangles(collider_tri_mesh)
@@ -186,7 +186,7 @@ func _redraw(gizmo) -> void:
 		if i < lane_count:
 			div.visible = true
 			div.position = Vector3(x_pos, 0, 0)
-			div.scale = Vector3(width_scale, width_scale, width_scale)
+			div.scale = width_scale_v
 			x_pos += lane_width
 		else:
 			div.visible = false
@@ -213,6 +213,11 @@ func _get_handle_value(gizmo: EditorNode3DGizmo, index: int, secondary: bool) ->
 	var lane_width = point.lane_width
 	var lane_count = len(point.traffic_dir)
 	var width_mag: float = lane_count * lane_width / 2
+	if point.alignment == RoadPoint.Alignment.CENTERLINE:
+		if index == HandleType.REV_WIDTH_MAG:
+			width_mag = point.get_rev_lane_count() * lane_width
+		elif index == HandleType.FWD_WIDTH_MAG:
+			width_mag = point.get_fwd_lane_count() * lane_width
 
 	match index:
 		HandleType.PRIOR_MAG:
@@ -311,9 +316,10 @@ func set_width_handle(gizmo: EditorNode3DGizmo, index: int, camera: Camera3D, po
 		# Prevent handles from crossing over road divider
 		var lane_width = roadpoint.lane_width
 		var lane_count = len(roadpoint.traffic_dir)
-		var half_road_width = lane_count * lane_width / 2
-		var rev_lane_width = roadpoint.get_rev_lane_count() * lane_width
-		var road_divider = -half_road_width + rev_lane_width
+
+		var road_divider = 0
+		if roadpoint.alignment == RoadPoint.Alignment.CENTER:
+			road_divider = (roadpoint.get_rev_lane_count() - lane_count / 2.0) * lane_width
 		var road_div_rev_limit = road_divider - (lane_width * LaneOffset)
 		var road_div_fwd_limit = road_divider + (lane_width * LaneOffset)
 		if index == HandleType.REV_WIDTH_MAG and new_mag > road_div_rev_limit:

--- a/demo/procedural_generator/ProceduralGenerator.tscn
+++ b/demo/procedural_generator/ProceduralGenerator.tscn
@@ -48,18 +48,20 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 21.9997)
 script = ExtResource("4")
 traffic_dir = Array[int]([2, 2, 1, 1])
 lanes = Array[int]([2, 4, 4, 2])
-prior_pt_init = NodePath("../RP_002")
 prior_mag = 15.0
 next_mag = 15.0
+alignment = 1
+prior_pt_init = NodePath("../RP_002")
 
 [node name="RP_002" type="Node3D" parent="RoadManager/Road_001"]
 transform = Transform3D(0.999842, -0.000116941, 0.0178009, 0, 0.999978, 0.00656924, -0.0178013, -0.0065682, 0.99982, -0.677433, 0.25, -16.0496)
 script = ExtResource("4")
 traffic_dir = Array[int]([2, 2, 1, 1])
 lanes = Array[int]([2, 4, 4, 2])
-next_pt_init = NodePath("../RP_001")
 prior_mag = 15.0
 next_mag = 15.0
+alignment = 1
+next_pt_init = NodePath("../RP_001")
 
 [node name="UI" type="Control" parent="."]
 layout_mode = 3


### PR DESCRIPTION
Create Road Point alignment property

Modes supported:
1. road point is in the center of the road (original)
2. road point is on double yellow line. for one-way roads new alignment is on the leftmost lane

make alignment attribute visible and registered for copy (either in plugin GUI and RoadPoint copy method)
update lanes, edges and geometry to use offsets, according to the alignment property (including mixed alignment in segment's road points)
update custom gui handles for lanes to show arrows with respect to alignment attribute

related to https://github.com/TheDuckCow/godot-road-generator/issues/229

From my work, I see that it has to be a road-point centered feature, as it makes no sense if there are no FORWARD or no REVERSE lanes, makes the road left or right aligned and demanding that all such roads should be in different containers is probably not great in general
I think it also could be useful in some edge cases and there won't be problems with connections. so I'll try if it will work with road points of different alignments first, doesn't look like it should be too complicated

here is how it looks
[Kooha-2025-05-04-01-19-30.webm](https://github.com/user-attachments/assets/59494f27-1f71-4334-aa2f-d4384ee8ee4d)

and here are some issues with the intersection demo (fixed with support for mixed alignment)
![Screenshot From 2025-05-04 01-36-47](https://github.com/user-attachments/assets/acd5da5d-77ee-4588-8882-9f75ccb12c6f)

