### PR TITLE
Collision layers and physics slot

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -912,7 +912,11 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 		else:
 			new_seg._end_flip = false
 		segid_map[sid] = new_seg
-		new_seg.material = material_resource
+		
+		if material_resource:
+			new_seg.material = material_resource
+		elif is_instance_valid(_manager) and _manager.material_resource:
+			new_seg.material = _manager.material_resource
 		new_seg.check_rebuild()
 
 		return [true, new_seg]

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -13,49 +13,92 @@ signal on_transform(node)  # for internal purposes, to handle drags
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
-## Material applied to the generated meshes, expects specific trimsheet UV layout
-@export var material_resource: Material: set = _set_material
 
-## Mesh density of generated segments. -1 implies to use the parent RoadManager's value, higher
-## values like 10 mean higher spacing between loop cuts (ie a lower density; this terminology and
-## meaning is unintuitive, but matches the term used within the built in 3D curve property name)
-@export var density: float = -1.0: set = _set_density
+# ------------------------------------------------------------------------------
+## How road meshes are generated
+@export_group("Road Generation")
+# ------------------------------------------------------------------------------
+
 
 ## Generate procedural road geometry
 ## If off, it indicates the developer will load in their own custom mesh + collision.
 @export var create_geo := true: set = _set_create_geo
+
+## Material applied to the generated meshes, expects specific trimsheet UV layout
+##
+## If cleared, will utilize the default specificed by the RoadManager
+@export var material_resource: Material: set = _set_material
+
+## Defines the distnace in meters between road loop cuts. This mirrors the
+## same term used in native Curve3D objects where a higher density means a larger
+## spacing between loops and fewer overall verticies.
+##
+## A value of -1 indicates the density of the RoadManager will be used, or the
+## internal default of 4.0 if no manager is presetn
+@export var density: float = -1.0: set = _set_density
+
 # If create_geo is true, then whether to reduce geo mid transform.
 @export var use_lowpoly_preview: bool = false
-## Whether to create approximated curves to fit along the forward, reverse, and center of the road.
-## Visible in the editor, useful for adding procedural generation along road edges or center lane.
-@export var create_edge_curves := false: set = _set_create_edge_curves
+
+## The PhysicsMaterial to apply to static bodies. An override of any present on
+## the parent RoadManager's physics_material
+@export var physics_material: PhysicsMaterial:
+	set(value):
+		physics_material = value
+		_defer_refresh_on_change()
+
+## Group name to assign to the staic bodies created within a RoadSegment
+@export var collider_group_name := "": set = _set_collider_group
+## Meta property name to assign to the static bodies created within a RoadSegment
+@export var collider_meta_name := "": set = _set_collider_meta
+
+
+# ------------------------------------------------------------------------------
+## Properties relating to how RoadLanes and AI tooling is set up
+@export_group("Lanes and AI")
+# ------------------------------------------------------------------------------
+
 
 ## Whether to auto create RoadLanes for AI agents to follow, which are extensions of the native
 ## 3D Curve, added to the runtime game as a child of RoadPoints when connections exist.
 @export var generate_ai_lanes := false: set = _set_gen_ai_lanes
-## Group name to assign to generated RoadLane nodes
-@export var ai_lane_group := "road_lanes": set = _set_ai_lane_group
+
+## The group name to assign to any procedurally generated RoadLanes
+@export var ai_lane_group := "": set = _set_ai_lane_group
+
 ## Pass through to each RoadLane on whether to auto free all registered vehicles on _exit_tree.
 ## Useful to let the raod generator handle any vehicles on a road segment to be cleaned up but
 ## is not a direct child (which would require re-parenting as vehicles travel between segments)
 @export var auto_free_vehicles := true: set = _set_auto_free_vehicles
-## Group name to assign to the staic bodies created within a RoadSegment
-@export var collider_group_name := "": set = _set_collider_group
-## Meta property name to assign to the static bodies created within a RoadSegment, value will always be true
-@export var collider_meta_name := "": set = _set_collider_meta
 
-@export var debug := false
 @export var draw_lanes_editor := false: get = _get_draw_lanes_editor, set = _set_draw_lanes_editor
 @export var draw_lanes_game := false: get = _get_draw_lanes_game, set = _set_draw_lanes_game
 
+
+# ------------------------------------------------------------------------------
+## Properties which assist with further decorating of roads, such as sidewalks
+## and railings
+@export_group("Decoration")
+# ------------------------------------------------------------------------------
+
+
+## Whether to create approximated curves to fit along the forward, reverse, and center of the road.
+## Visible in the editor, useful for adding procedural generation along road edges or center lane.
+@export var create_edge_curves := false: set = _set_create_edge_curves
+
+
+# ------------------------------------------------------------------------------
 ## Auto generated exposed variables used to connect this RoadContainer to
 ## another RoadContainer.
 ## These should *never* be manually adjusted, they are only export vars to
 ## facilitate the connection of RoadContainers needing to connect to points in
 ## different scenes, where said connection needs to be established in the editor
-##
+@export_group("Internal data")
 # TODO: In Godot 4.3ish, these should be @export_storage, hidden to users
 # https://github.com/godotengine/godot/pull/82122
+# ------------------------------------------------------------------------------
+
+@export var debug := false
 
 # Paths to other containers, relative to this container (self)
 @export var edge_containers: Array[NodePath]
@@ -68,6 +111,12 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 @export var edge_rp_locals: Array[NodePath]
 # Local RP directions, enum value of RoadPoint.PointInit
 @export var edge_rp_local_dirs: Array[int]
+
+
+# ------------------------------------------------------------------------------
+# Runtime variables
+# ------------------------------------------------------------------------------
+
 
 # Mapping maintained of individual segments and their corresponding resources.
 var segid_map = {}

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -10,7 +10,6 @@ extends Node3D
 signal on_road_updated(updated_segments)
 signal on_transform(node)  # for internal purposes, to handle drags
 
-const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
 
@@ -182,7 +181,7 @@ var _is_ready := false
 
 func _ready():
 	# setup_road_container won't work in _ready unless call_deferred is used
-	call_deferred("setup_road_container")
+	setup_road_container.call_deferred()
 
 	set_notify_transform(true) # TOOD: check if both of these are necessary
 	set_notify_local_transform(true)
@@ -1061,10 +1060,6 @@ func setup_road_container():
 		own = owner
 	else:
 		own = self
-
-	if not material_resource:
-		material_resource = RoadMaterial
-		print("Added material to ", name)
 
 	_check_migrate_points()
 

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -40,6 +40,13 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 # If create_geo is true, then whether to reduce geo mid transform.
 @export var use_lowpoly_preview: bool = false
 
+
+# ------------------------------------------------------------------------------
+## Properties defining how to set up the road's StaticBody3D
+@export_group("Collision")
+# ------------------------------------------------------------------------------
+
+
 ## The PhysicsMaterial to apply to static bodies. An override of any present on
 ## the parent RoadManager's physics_material
 @export var physics_material: PhysicsMaterial:
@@ -51,6 +58,19 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 @export var collider_group_name := "": set = _set_collider_group
 ## Meta property name to assign to the static bodies created within a RoadSegment
 @export var collider_meta_name := "": set = _set_collider_meta
+
+## If enabled, use collision_layer and collision_mask defined on this RoadContainer instead of the RoadManager
+@export var override_collision_layers:bool = false
+## Collision layer to assign to the StaticBody3D's own collision_layer
+@export_flags_3d_physics var collision_layer: int = 1:
+	set(value):
+		collision_layer = value
+		_defer_refresh_on_change()
+## Collision mask to assign to the StaticBody3D's own collision_mask
+@export_flags_3d_physics var collision_mask: int = 1:
+	set(value):
+		collision_mask = value
+		_defer_refresh_on_change()
 
 
 # ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -35,6 +35,12 @@ var density: float = 4.0:
 		density = value
 		rebuild_all_containers()
 
+# ------------------------------------------------------------------------------
+## Properties defining how to set up the road's StaticBody3D
+@export_group("Collision")
+# ------------------------------------------------------------------------------
+
+
 ## The PhysicsMaterial to apply to genrated static bodies
 ##
 ## Can be overridden by individual RoadContainers
@@ -62,6 +68,21 @@ var collider_meta_name := "":
 		collider_meta_name = value
 		rebuild_all_containers()
 
+## Collision layer to assign to the StaticBody3D's own collision_layer
+##
+## Can be overridden by individual RoadContainers if override_collision_layers enabled
+@export_flags_3d_physics var collision_layer: int = 1:
+	set(value):
+		collision_layer = value
+		rebuild_all_containers()
+
+## Collision mask to assign to the StaticBody3D's own collision_mask
+##
+## Can be overridden by individual RoadContainers if override_collision_layers enabled
+@export_flags_3d_physics var collision_mask: int = 1:
+	set(value):
+		collision_mask = value
+		rebuild_all_containers()
 
 # ------------------------------------------------------------------------------
 ## Properties relating to how RoadLanes and AI tooling is set up

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -1,27 +1,94 @@
 @tool
 @icon("res://addons/road-generator/resources/road_manager.png")
-## Manager for all children RoadContainers
+
 class_name RoadManager
 extends Node3D
+## Manager for all children RoadContainers
+##
+## This node should be added as the parent of all RoadContainers which are
+## meant to be managed by these settings. The exception is where a RoadContainer
+## is saved as the root of a tscn saved file.
 
 
 # ------------------------------------------------------------------------------
-# Inherited default settings used by RoadContainers
+## How road meshes are generated
+@export_group("Road Generation")
+# ------------------------------------------------------------------------------
+
+## The default material applied to generated meshes, expects specific trimsheet UV layout
+## 
+## Can be overridden by individual RoadContainers
+@export
+var material_resource: Material:
+	set(value):
+		material_resource = value
+		rebuild_all_containers()
+
+## Defines the distnace in meters between road loop cuts. This mirrors the
+## same term used in native Curve3D objects where a higher density means a larger
+## spacing between loops and fewer overall verticies.
+##
+## Can be overridden by individual RoadContainers
+@export
+var density: float = 4.0:
+	set(value):
+		density = value
+		rebuild_all_containers()
+
+## The PhysicsMaterial to apply to genrated static bodies
+##
+## Can be overridden by individual RoadContainers
+@export
+var physics_material: PhysicsMaterial:
+	set(value):
+		physics_material = value
+		rebuild_all_containers()
+
+## Group name to assign to the staic bodies created within a RoadSegment
+##
+## Can be overridden by individual RoadContainers
+@export
+var collider_group_name := "":
+	set(value):
+		collider_group_name = value
+		rebuild_all_containers()
+
+## Meta property name to assign to the static bodies created within RoadSegments
+##
+## Can be overridden by individual RoadContainers
+@export
+var collider_meta_name := "":
+	set(value):
+		collider_meta_name = value
+		rebuild_all_containers()
+
+
+# ------------------------------------------------------------------------------
+## Properties relating to how RoadLanes and AI tooling is set up
+@export_group("Lanes and AI")
 # ------------------------------------------------------------------------------
 
 
-@export var density: float = 4.0: set = _set_density
+## The group name to assign to any procedurally generated RoadLanes
+##
+## Can be overridden by individual RoadContainers
+@export
+var ai_lane_group := "road_lanes":
+	set(value):
+		ai_lane_group = value
+		rebuild_all_containers()
 
 
 # ------------------------------------------------------------------------------
-# Editor settings
+@export_group("Editor settings")
 # ------------------------------------------------------------------------------
 
 
 # Auto refresh on transforms or other actions on roads. Good to disable if
 # you modify roads during runtime and want to manually trigger refreshes on
 # specific RoadContainers/RoadPoints at a time.
-@export var auto_refresh: bool = true: set = _ui_refresh_set
+@export
+var auto_refresh: bool = true: set = _ui_refresh_set
 
 
 # ------------------------------------------------------------------------------
@@ -61,11 +128,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 # Workaround for cyclic typing
 func is_road_manager() -> bool:
 	return true
-
-
-func _set_density(value: float) -> void:
-	density = value
-	rebuild_all_containers()
 
 
 func _ui_refresh_set(value: bool) -> void:

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -9,6 +9,7 @@ extends Node3D
 ## meant to be managed by these settings. The exception is where a RoadContainer
 ## is saved as the root of a tscn saved file.
 
+const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
 
 # ------------------------------------------------------------------------------
 ## How road meshes are generated
@@ -129,6 +130,14 @@ func _ready():
 	# the manager initializes (different from _ready), meaning
 	# it would default to true even if auto refresh is false here.
 	_ui_refresh_set(auto_refresh)
+	
+	# setup_road_container won't work in _ready unless call_deferred is used
+	assign_default_material.call_deferred()
+	
+
+func assign_default_material() -> void:
+	if not material_resource:
+		material_resource = RoadMaterial
 
 
 func _get_configuration_warnings() -> PackedStringArray:

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -820,8 +820,16 @@ func _create_collisions() -> void:
 		
 		if container.physics_material != null:
 			sbody.physics_material_override = container.physics_material
-		elif manager.physics_material != null:
+		elif is_instance_valid(manager) and manager.physics_material != null:
 			sbody.physics_material_override = manager.physics_material
+		
+		if container.override_collision_layers:
+			sbody.collision_layer = container.collision_layer
+			sbody.collision_mask = container.collision_mask
+		elif is_instance_valid(manager):
+			sbody.collision_layer = manager.collision_layer
+			sbody.collision_mask = manager.collision_mask
+		# else: will just be the godot default.
 		
 		sbody.set_meta("_edit_lock_", true)
 

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -28,7 +28,7 @@ var curve:Curve3D
 var road_mesh:MeshInstance3D
 var material:Material
 var density := 4.00 # Distance between loops, bake_interval in m applied to curve for geo creation.
-var container # The managing container node for this road segment (grandparent).
+var container:RoadContainer # The managing container node for this road segment (grandparent).
 
 var is_dirty := true
 var low_poly := false  # If true, then was (or will be) generated as low poly.
@@ -284,6 +284,7 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		return false
 
 	var any_generated = false
+	var manager:RoadManager = container.get_manager()
 
 	var start_offset = len(start_point.lanes) / 2.0 * start_point.lane_width - start_point.lane_width/2.0
 	var end_offset = len(end_point.lanes) / 2.0 * end_point.lane_width - end_point.lane_width/2.0
@@ -322,7 +323,11 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 			_par.add_child(ln_child)
 			if container.debug_scene_visible:
 				ln_child.owner = container.get_owner()
-			ln_child.add_to_group(container.ai_lane_group)
+			
+			if container.ai_lane_group != "":
+				ln_child.add_to_group(container.ai_lane_group)
+			elif is_instance_valid(manager) and manager.ai_lane_group != "":
+				ln_child.add_to_group(manager.ai_lane_group)
 			ln_child.set_meta("_edit_lock_", true)
 			ln_child.auto_free_vehicles = container.auto_free_vehicles
 		else:
@@ -792,18 +797,33 @@ func _build_geo():
 func _create_collisions() -> void:
 	for ch in road_mesh.get_children():
 		ch.queue_free()  # Prior collision meshes
+	
+	var manager:RoadManager = container.get_manager()
 
 	# Could also manually create with Mesh.create_trimesh_shape(),
 	# but this is still advertised as a non-cheap solution.
 	road_mesh.create_trimesh_collision()
 	for ch in road_mesh.get_children():
-		if not ch is StaticBody3D:
+		var sbody := ch as StaticBody3D # Set to null if casting fails
+		if not sbody:
 			continue
+		
 		if container.collider_group_name != "":
-			ch.add_to_group(container.collider_group_name)
+			sbody.add_to_group(container.collider_group_name)
+		elif is_instance_valid(manager) and manager.collider_group_name != "":
+			sbody.add_to_group(manager.collider_group_name)
+		
 		if container.collider_meta_name != "":
-			ch.set_meta(container.collider_meta_name, true)
-		ch.set_meta("_edit_lock_", true)
+			sbody.set_meta(container.collider_meta_name, true)
+		elif is_instance_valid(manager) and manager.collider_meta_name != "":
+			sbody.set_meta(manager.collider_meta_name, true)
+		
+		if container.physics_material != null:
+			sbody.physics_material_override = container.physics_material
+		elif manager.physics_material != null:
+			sbody.physics_material_override = manager.physics_material
+		
+		sbody.set_meta("_edit_lock_", true)
 
 
 func _insert_geo_loop(


### PR DESCRIPTION
Resolves #203 and #217 to create control over collision layers/masks and exposing physicals material. This change is backwards compatible as no pre-existing public variables have been renamed.

This PR also extends several export vars on the RoadContainer class into the RoadManager class. This way, a RoadContainer can be set up to override the RoadManager if something special is needed, but by default properties will extend from the RoadManager directly. For most users, this is ideal since they likely want to use the same settings for all RoadContainers. The settings that are newly available on the RoadManager include:

- material_resource
- physics_material
- collider_group_name
- collider_meta_name
- collision_layer
- collision_mask
- road_lanes

Also organizes the export vars for both into logical, parallel sections:

![Screen Shot 2025-05-04 at 10 02 44 AM](https://github.com/user-attachments/assets/d067d5f0-9f6d-48e8-88fa-12f89cb3acd3)


And for the RoadManager:
![Screen Shot 2025-05-04 at 10 03 10 AM](https://github.com/user-attachments/assets/d40ad32d-d48f-438c-9308-c46d380eab7e)
