### PR TITLE
Support in-app documentation and improved export grouping for addon nodes

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -1,71 +1,88 @@
 @tool
 @icon("res://addons/road-generator/resources/road_container.png")
-## Manager used to generate the actual road segments when needed.
+
 class_name RoadContainer
 extends Node3D
+## The parent node for [RoadPoint]'s and controller of actual geo creation.
+##
+## A Road is defined by a [RoadContainer] with two or more [RoadPoint] children
+## who are connected together.
+##
+## Can be saved as the root of a scene for reuse, otherwise should be placed as
+## the child of a [RoadManager] node.
+##
+## @tutorial(Getting started): https://github.com/TheDuckCow/godot-road-generator/wiki/A-getting-started-tutorial
+## @tutorial(Custom Materials Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/Creating-custom-materials
+## @tutorial(Custom Mesh Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/User-guide:-Custom-road-meshes
+
 
 ## Emitted when a road segment has been (re)generated, returning the list
 ## of updated segments of type Array. Will also trigger on segments deleted,
 ## which will contain a list of nothing.
 signal on_road_updated(updated_segments)
-signal on_transform(node)  # for internal purposes, to handle drags
+
+## For internal purposes, to handle drag events in the editor.
+signal on_transform(node)
 
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
 
 # ------------------------------------------------------------------------------
-## How road meshes are generated
+# How road meshes are generated
 @export_group("Road Generation")
 # ------------------------------------------------------------------------------
 
 
-## Generate procedural road geometry
+## Generate procedural road geometry.[br][br]
+##
 ## If off, it indicates the developer will load in their own custom mesh + collision.
 @export var create_geo := true: set = _set_create_geo
 
-## Material applied to the generated meshes, expects specific trimsheet UV layout
+## Material applied to the generated meshes, expects specific trimsheet UV layout[br][br]
 ##
-## If cleared, will utilize the default specificed by the RoadManager
+## If cleared, will utilize the default specificed by the [RoadManager].
 @export var material_resource: Material: set = _set_material
 
-## Defines the distnace in meters between road loop cuts. This mirrors the
-## same term used in native Curve3D objects where a higher density means a larger
-## spacing between loops and fewer overall verticies.
+## Defines the distance in meters between road loop cuts.[br][br]
+##
+## This mirrors the same term used in native Curve3D objects where a higher
+## density means a larger spacing between loops and fewer overall verticies.[br][br]
 ##
 ## A value of -1 indicates the density of the RoadManager will be used, or the
-## internal default of 4.0 if no manager is presetn
+## internal default of 4.0 if no manager is present.
 @export var density: float = -1.0: set = _set_density
 
-# If create_geo is true, then whether to reduce geo mid transform.
+## Use fewer loop cuts for performance during transform.
 @export var use_lowpoly_preview: bool = false
 
 
 # ------------------------------------------------------------------------------
-## Properties defining how to set up the road's StaticBody3D
+# Properties defining how to set up the road's StaticBody3D
 @export_group("Collision")
 # ------------------------------------------------------------------------------
 
 
-## The PhysicsMaterial to apply to static bodies. An override of any present on
-## the parent RoadManager's physics_material
+## The PhysicsMaterial to apply to static bodies.[br][br]
+##
+## An override for any present on the parent [member RoadManager.physics_material] .
 @export var physics_material: PhysicsMaterial:
 	set(value):
 		physics_material = value
 		_defer_refresh_on_change()
 
-## Group name to assign to the staic bodies created within a RoadSegment
+## Group name to assign to the staic bodies created within a RoadSegment.
 @export var collider_group_name := "": set = _set_collider_group
-## Meta property name to assign to the static bodies created within a RoadSegment
+## Meta property name to assign to the static bodies created within a RoadSegment.
 @export var collider_meta_name := "": set = _set_collider_meta
 
-## If enabled, use collision_layer and collision_mask defined on this RoadContainer instead of the RoadManager
+## If enabled, use collision_layer and collision_mask defined on this RoadContainer instead of the [RoadManager].
 @export var override_collision_layers:bool = false
-## Collision layer to assign to the StaticBody3D's own collision_layer
+## Collision layer to assign to the generated [StaticBody3D]'s own collision_layer.
 @export_flags_3d_physics var collision_layer: int = 1:
 	set(value):
 		collision_layer = value
 		_defer_refresh_on_change()
-## Collision mask to assign to the StaticBody3D's own collision_mask
+## Collision mask to assign to the generated [StaticBody3D]'s own collision_mask.
 @export_flags_3d_physics var collision_mask: int = 1:
 	set(value):
 		collision_mask = value
@@ -73,62 +90,81 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 
 
 # ------------------------------------------------------------------------------
-## Properties relating to how RoadLanes and AI tooling is set up
+# Properties relating to how RoadLanes and AI tooling is set up
 @export_group("Lanes and AI")
 # ------------------------------------------------------------------------------
 
 
-## Whether to auto create RoadLanes for AI agents to follow, which are extensions of the native
-## 3D Curve, added to the runtime game as a child of RoadPoints when connections exist.
+## Whether to auto-generate [RoadLane]'s for AI agents to follow.[br][br]
+##
+## These are extensions of the native 3D Curve, added to the runtime game as a
+## child of RoadPoints when connections exist.
 @export var generate_ai_lanes := false: set = _set_gen_ai_lanes
 
-## The group name to assign to any procedurally generated RoadLanes
+## The group name to assign to any procedurally generated [RoadLane]'s.
 @export var ai_lane_group := "": set = _set_ai_lane_group
 
-## Pass through to each RoadLane on whether to auto free all registered vehicles on _exit_tree.
-## Useful to let the raod generator handle any vehicles on a road segment to be cleaned up but
-## is not a direct child (which would require re-parenting as vehicles travel between segments)
+## Setter applied to [RoadLane] on whether to auto-free registered vehicles on _exit_tree.[br][br]
+##
+## This lets the road generator handle the cleanup of any vehicles listed as
+## following a road segment about to be deleted anyways, even when the vehicle
+## is not a direct child of the segments being removed.
 @export var auto_free_vehicles := true: set = _set_auto_free_vehicles
 
+## Visualize [RoadLane]'s and their directions in the editor directly.
 @export var draw_lanes_editor := false: get = _get_draw_lanes_editor, set = _set_draw_lanes_editor
+## Visualize [RoadLane]'s and their directions during the game runtime.
 @export var draw_lanes_game := false: get = _get_draw_lanes_game, set = _set_draw_lanes_game
 
 
 # ------------------------------------------------------------------------------
-## Properties which assist with further decorating of roads, such as sidewalks
-## and railings
+# Properties which assist with further decorating of roads, such as sidewalks
+# and railings
 @export_group("Decoration")
 # ------------------------------------------------------------------------------
 
 
-## Whether to create approximated curves to fit along the forward, reverse, and center of the road.
-## Visible in the editor, useful for adding procedural generation along road edges or center lane.
+## Create approximated curves along the left, right, and center of the road.[br][br]
+##
+## Exposed in the editor, useful for adding procedural generation along road
+## edges or center lane.
 @export var create_edge_curves := false: set = _set_create_edge_curves
 
 
 # ------------------------------------------------------------------------------
-## Auto generated exposed variables used to connect this RoadContainer to
-## another RoadContainer.
-## These should *never* be manually adjusted, they are only export vars to
-## facilitate the connection of RoadContainers needing to connect to points in
-## different scenes, where said connection needs to be established in the editor
-@export_group("Internal data")
+# Auto generated exposed variables used to connect this RoadContainer to
+# another RoadContainer.
+# These should *never* be manually adjusted, they are only export vars to
+# facilitate the connection of RoadContainers needing to connect to points in
+# different scenes, where said connection needs to be established in the editor.
 # TODO: In Godot 4.3ish, these should be @export_storage, hidden to users
 # https://github.com/godotengine/godot/pull/82122
+@export_group("Internal data")
 # ------------------------------------------------------------------------------
 
+## Output additional debug information, does not change functionality.
 @export var debug := false
 
-# Paths to other containers, relative to this container (self)
+## Considered private, not meant for editor or script interaction.[br][br]
+##
+## Paths to other containers, relative to this container (self)
 @export var edge_containers: Array[NodePath]
-# Node paths within other containers, relative to the *target* container (not self here)
+## Considered private, not meant for editor or script interaction.[br][br]
+##
+## Node paths within other containers, relative to the *target* container (not self here)
 @export var edge_rp_targets: Array[NodePath]
-# Direction of which RP we are connecting to, used to make unique key along with
-# the edge_rp_targets path above. Enum value of RoadPoint.PointInit
+## Considered private, not meant for editor or script interaction.[br][br]
+##
+## Direction of which RP we are connecting to, used to make unique key along with
+## the edge_rp_targets path above. Enum value of RoadPoint.PointInit
 @export var edge_rp_target_dirs: Array[int]
-# Node paths within this container, relative to this container
+## Considered private, not meant for editor or script interaction.[br][br]
+##
+## Node paths within this container, relative to this container
 @export var edge_rp_locals: Array[NodePath]
-# Local RP directions, enum value of RoadPoint.PointInit
+## Considered private, not meant for editor or script interaction.[br][br]
+##
+## Local RP directions, enum value of RoadPoint.PointInit
 @export var edge_rp_local_dirs: Array[int]
 
 

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -1,8 +1,11 @@
 @tool
 @icon("res://addons/road-generator/resources/road_intersection.png")
-## Center point of an intersection
+
+## Center point of an intersection.
 ##
-## Should be contained within a RoadContainer and a sibling to 1+ RoadPoints
+## Should be contained within a [RoadContainer] and a sibling to 1+ [RoadPoints].
+##
+## @experimental: Currently unused and may change.
 class_name RoadIntersection
 extends Node3D
 

--- a/addons/road-generator/nodes/road_lane_agent.gd
+++ b/addons/road-generator/nodes/road_lane_agent.gd
@@ -1,6 +1,9 @@
 @icon("res://addons/road-generator/resources/road_lane_agent.png")
-## An agent helper for navigation on RoadLanes, inspired but not inheriting
-## from NavigationAgent, as we are not using navigation meshes
+
+## An agent helper for navigation on [RoadLane]'s.
+##
+## Inspired, but does not inherit from, NavigationAgent since this does not rely
+## on navigation meshes, but instead on explicit path curves.
 ##
 ## Used to help calculate position updates, but currently does not directly
 ## perform these position updates directly.
@@ -10,32 +13,13 @@
 ## is specified. If it is a (grand)child of a RoadManager, then
 ## road_manager_path does not need to be specified. This node does not need to
 ## be a child of an actual RoadLane, but there is no harm in doing so.
+##
+## @tutorial(Intersection demo with agents): https://github.com/TheDuckCow/godot-road-generator/tree/main/demo/intersections
+## @tutorial(Procedural demo with agents): https://github.com/TheDuckCow/godot-road-generator/tree/main/demo/procedural_generator
 class_name RoadLaneAgent
 extends Node
 
 signal on_lane_changed(old_lane)
-
-## Directly assign the path to the RoadManager instance, otherwise will assume it
-## is in the parent hierarchy. Should refer to RoadManager nodes only.
-@export var road_manager_path: NodePath
-## Automatically register and unregiter this vehicle to RoadLanes as we travel.
-## Useful to let RoadLanes auto-queue free registered vehicles when the lane is
-## being removed, but likely should turn off for player agents to avoid freeing
-@export var auto_register: bool = true
-## Debug tool to make the current lane visible in the game. Can be slow, best
-## to turn it off for production use.
-@export var visualize_lane: bool = false
-
-## Reference spatial to assume where this agent's position is assumed to be at
-var actor: Node3D
-## The RoadManager instance that is containing all RoadContainers to consider,
-## primarily needed to fetch the initial nearest RoadLane
-var road_manager: RoadManager
-## The current RoadLane, used as the linking reference to all adjacent lanes
-var current_lane: RoadLane
-
-## Cache just to check whether the prior lane was made visible by visualize_lane
-var _did_make_lane_visible := false
 
 enum MoveDir
 {
@@ -49,6 +33,31 @@ enum LaneChangeDir
 	CURRENT = 0,
 	LEFT = -1
 }
+
+
+## Directly assign the path to the [RoadManager] instance, otherwise will assume it
+## is in the parent hierarchy. Should refer to [RoadManager] nodes only.
+@export var road_manager_path: NodePath
+## Automatically register and unregiter this vehicle to RoadLanes as we travel.[br][br]
+##
+## Useful to let RoadLanes auto-queue free registered vehicles when the lane is
+## being removed, but likely should turn off for player agents to avoid freeing.
+@export var auto_register: bool = true
+## Debug option to mark the current [RoadLane] visible ingame.[br][br]
+##
+## Can be slow, best to turn it off for production use.
+@export var visualize_lane: bool = false
+
+## Reference spatial to assume where this agent's position is assumed to be at
+var actor: Node3D
+## The RoadManager instance that is containing all RoadContainers to consider,
+## primarily needed to fetch the initial nearest RoadLane
+var road_manager: RoadManager
+## The current RoadLane, used as the linking reference to all adjacent lanes
+var current_lane: RoadLane
+
+## Cache just to check whether the prior lane was made visible by visualize_lane
+var _did_make_lane_visible := false
 
 
 func _ready() -> void:

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -3,33 +3,40 @@
 
 class_name RoadManager
 extends Node3D
-## Manager for all children RoadContainers
+## Manager for all child [RoadContainer]'s.
 ##
 ## This node should be added as the parent of all RoadContainers which are
 ## meant to be managed by these settings. The exception is where a RoadContainer
 ## is saved as the root of a tscn saved file.
+##
+## @tutorial(Getting started): https://github.com/TheDuckCow/godot-road-generator/wiki/A-getting-started-tutorial
+## @tutorial(Custom Materials Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/Creating-custom-materials
+## @tutorial(Custom Mesh Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/User-guide:-Custom-road-meshes
 
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
 
 # ------------------------------------------------------------------------------
-## How road meshes are generated
+# How road meshes are generated
 @export_group("Road Generation")
 # ------------------------------------------------------------------------------
 
-## The default material applied to generated meshes, expects specific trimsheet UV layout
+## The material applied to generated meshes.[br][br]
 ## 
-## Can be overridden by individual RoadContainers
+## This mateiral is expected to use a specific trimsheet UV layout.[br][br]
+##
+## Can be overridden by each [RoadContainer].
 @export
 var material_resource: Material:
 	set(value):
 		material_resource = value
 		rebuild_all_containers()
 
-## Defines the distnace in meters between road loop cuts. This mirrors the
-## same term used in native Curve3D objects where a higher density means a larger
-## spacing between loops and fewer overall verticies.
+## Defines the distance in meters between road loop cuts.[br][br]
 ##
-## Can be overridden by individual RoadContainers
+## This mirrors the same term used in native Curve3D objects where a higher
+## density means a larger spacing between loops and fewer overall verticies.[br][br]
+##
+## Can be overridden by each [RoadContainer].
 @export
 var density: float = 4.0:
 	set(value):
@@ -37,63 +44,65 @@ var density: float = 4.0:
 		rebuild_all_containers()
 
 # ------------------------------------------------------------------------------
-## Properties defining how to set up the road's StaticBody3D
+# Properties defining how to set up the road's StaticBody3D
 @export_group("Collision")
 # ------------------------------------------------------------------------------
 
 
-## The PhysicsMaterial to apply to genrated static bodies
+## The PhysicsMaterial to apply to genrated static bodies.[br][br]
 ##
-## Can be overridden by individual RoadContainers
+## Can be overridden by each [RoadContainer].
 @export
 var physics_material: PhysicsMaterial:
 	set(value):
 		physics_material = value
 		rebuild_all_containers()
 
-## Group name to assign to the staic bodies created within a RoadSegment
+## Group name to assign to the staic bodies created by a RoadSegment.[br][br]
 ##
-## Can be overridden by individual RoadContainers
+## Can be overridden by each [RoadContainer].
 @export
 var collider_group_name := "":
 	set(value):
 		collider_group_name = value
 		rebuild_all_containers()
 
-## Meta property name to assign to the static bodies created within RoadSegments
+## Meta name to assign to the static bodies created by a RoadSegment.[br][br]
 ##
-## Can be overridden by individual RoadContainers
+## Can be overridden by each [RoadContainer].
 @export
 var collider_meta_name := "":
 	set(value):
 		collider_meta_name = value
 		rebuild_all_containers()
 
-## Collision layer to assign to the StaticBody3D's own collision_layer
+## Collision layer to assign to the StaticBody3D's own collision_layer.[br][br]
 ##
-## Can be overridden by individual RoadContainers if override_collision_layers enabled
+## Can be overridden by each [RoadContainer] if
+## [member RoadContainer.override_collision_layers] is enabled.
 @export_flags_3d_physics var collision_layer: int = 1:
 	set(value):
 		collision_layer = value
 		rebuild_all_containers()
 
-## Collision mask to assign to the StaticBody3D's own collision_mask
+## Collision mask to assign to the StaticBody3D's own collision_mask.[br][br]
 ##
-## Can be overridden by individual RoadContainers if override_collision_layers enabled
+## Can be overridden by each [RoadContainer] if
+## [member RoadContainer.override_collision_layers] is enabled.
 @export_flags_3d_physics var collision_mask: int = 1:
 	set(value):
 		collision_mask = value
 		rebuild_all_containers()
 
 # ------------------------------------------------------------------------------
-## Properties relating to how RoadLanes and AI tooling is set up
+# Properties relating to how RoadLanes and AI tooling is set up
 @export_group("Lanes and AI")
 # ------------------------------------------------------------------------------
 
 
-## The group name to assign to any procedurally generated RoadLanes
+## The group name assigned to any procedurally generated [RoadLane].[br][br]
 ##
-## Can be overridden by individual RoadContainers
+## Can be overridden by each [RoadContainer].
 @export
 var ai_lane_group := "road_lanes":
 	set(value):

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -1,20 +1,21 @@
+extends Node3D
 ## Create and hold the geometry of a segment of road, including its curve.
 ##
 ## Assume lazy evaluation, only adding nodes when explicitly requested, so that
 ## the structure stays light only until needed.
-extends Node3D
-
-# Disabled, since we don't want users to manually via the UI to add this class.
+##
+## Not defined with a ClassName, since this should be treated as internal
+## functionality of how the road generation works, and may change.
+##
+## If necessary to reference like a class, place this in any script:
+## const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
 #class_name RoadSegment, "road_segment.png"
-#
-# To be able to reference as if a class, place this in any script:
-# const RoadSegment = preload("res://addons/road-generator/road_segment.gd")
 
 const LOWPOLY_FACTOR = 3.0
-const RAD_NINETY_DEG = PI/2 # aka 1.5707963267949, used for offset_curve algorithm
-const EDGE_R_NAME = "edge_R" # Name of reverse lane edge curve
-const EDGE_F_NAME = "edge_F" # Name of forward lane edge curve
-const EDGE_C_NAME = "edge_C" # Name of road center (direction divider) edge curve
+const RAD_NINETY_DEG = PI/2 ## aka 1.5707963267949, used for offset_curve algorithm
+const EDGE_R_NAME = "edge_R" ## Name of reverse lane edge curve
+const EDGE_F_NAME = "edge_F" ## Name of forward lane edge curve
+const EDGE_C_NAME = "edge_C" ## Name of road center (direction divider) edge curve
 
 signal seg_ready(road_segment)
 
@@ -27,8 +28,8 @@ var end_point:RoadPoint
 var curve:Curve3D
 var road_mesh:MeshInstance3D
 var material:Material
-var density := 4.00 # Distance between loops, bake_interval in m applied to curve for geo creation.
-var container:RoadContainer # The managing container node for this road segment (grandparent).
+var density := 4.00 ## Distance between loops, bake_interval in m applied to curve for geo creation.
+var container:RoadContainer ## The managing container node for this road segment (grandparent).
 
 var is_dirty := true
 var low_poly := false  # If true, then was (or will be) generated as low poly.
@@ -47,6 +48,7 @@ var _end_flip: bool = false
 # For easier calculation, to account for flipped directions.
 var _start_flip_mult: int = 1
 var _end_flip_mult: int = 1
+
 
 # ------------------------------------------------------------------------------
 # Setup and export setter/getters

--- a/demo/intersections/intersection_demo.tscn
+++ b/demo/intersections/intersection_demo.tscn
@@ -64,6 +64,7 @@ surface_material_override/0 = SubResource("StandardMaterial3D_gomn4")
 [node name="RoadManager" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -110.138, -3.05176e-05, 47.3471)
 script = ExtResource("5")
+material_resource = ExtResource("4")
 
 [node name="vehicles" type="Node3D" parent="RoadManager"]
 


### PR DESCRIPTION
Fixed spacing so that documentation actually appears in the inspector panel itself.

Where appropriate, re-ordered some classes to be more consistent with the official godot styleguide.

Sample of how it looks when opening the local documentation search in Godot 4.3:

<img width="1098" alt="Screen Shot 2025-05-04 at 8 17 02 PM" src="https://github.com/user-attachments/assets/1dccb55a-d77c-408a-a23e-c83056b9847c" />

And when hovering over tooltips in the inspector panel:

<img width="806" alt="Screen Shot 2025-05-04 at 8 19 54 PM" src="https://github.com/user-attachments/assets/6dc548ac-2b8a-4d85-920a-3eb54ce0f607" />
