### PR TITLE
Disable Add Next/Previous RP to avoid crashing, panel re-organization

### DIFF
--- a/addons/road-generator/ui/road_point_edit.gd
+++ b/addons/road-generator/ui/road_point_edit.gd
@@ -19,7 +19,9 @@ func _can_handle(object):
 
 
 # Add controls to the beginning of the Inspector property list
-func _parse_begin(object):
+func _parse_category(object: Object, category: String) -> void:
+	if category != "road_point.gd":
+		return
 	panel_instance = RoadPointPanel.instantiate()
 	panel_instance.call("set_edi", _edi)
 	panel_instance.call_deferred("update_selected_road_point", object)

--- a/addons/road-generator/ui/road_point_panel.gd
+++ b/addons/road-generator/ui/road_point_panel.gd
@@ -72,20 +72,26 @@ func update_road_point_panel():
 		btn_rem_lane_rev.disabled = false
 	else:
 		btn_rem_lane_rev.disabled = true
-
+	
+	# TODO(#234): Resolve crashing when using next button, using disable for now.
 	if sel_road_point.next_pt_init:
-		btn_add_rp_next.visible = false
-		btn_sel_rp_next.visible = true
+		btn_sel_rp_next.disabled = false
+		#btn_add_rp_next.visible = false
+		#btn_sel_rp_next.visible = true
 	else:
-		btn_add_rp_next.visible = true
-		btn_sel_rp_next.visible = false
-
+		btn_sel_rp_next.disabled = true
+		#btn_add_rp_next.visible = true
+		#btn_sel_rp_next.visible = false
+	
+	# TODO(#234): Resolve crashing when using next button, using disable for now.
 	if sel_road_point.prior_pt_init:
-		btn_add_rp_prior.visible = false
-		btn_sel_rp_prior.visible = true
+		btn_sel_rp_prior.disabled = false
+		#btn_add_rp_prior.visible = false
+		#btn_sel_rp_prior.visible = true
 	else:
-		btn_add_rp_prior.visible = true
-		btn_sel_rp_prior.visible = false
+		btn_sel_rp_prior.disabled = true
+		#btn_add_rp_prior.visible = true
+		#btn_sel_rp_prior.visible = false
 
 	notify_property_list_changed()
 

--- a/addons/road-generator/ui/road_point_panel.tscn
+++ b/addons/road-generator/ui/road_point_panel.tscn
@@ -16,7 +16,7 @@ script = ExtResource("1")
 [node name="SectionLabel" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-text = "RoadPoint Profile"
+text = "Edit RoadPoint"
 
 [node name="HBoxNext" type="HBoxContainer" parent="."]
 layout_mode = 2
@@ -49,14 +49,16 @@ alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Add Reverse lane. Hold shift to add another reverse lane to all RoadPoints in this container."
+tooltip_text = "Add Reverse lane.
+Hold shift to add another reverse lane to all RoadPoints in this container."
 text = "+"
 
 [node name="rev_minus" type="Button" parent="HBoxSubLanes"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Remove Reverse lane. Hold shift to remove a reverse lane from all RoadPoints in this container."
+tooltip_text = "Remove Reverse lane.
+Hold shift to remove a reverse lane from all RoadPoints in this container."
 text = "-"
 
 [node name="diver_label" type="Label" parent="HBoxSubLanes"]
@@ -68,14 +70,16 @@ text = "||"
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Remove Forward lane. Hold shift to add another forward lane to all RoadPoints in this container."
+tooltip_text = "Remove Forward lane.
+Hold shift to add another forward lane to all RoadPoints in this container."
 text = "-"
 
 [node name="fwd_add" type="Button" parent="HBoxSubLanes"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Add Forward lane. Hold shift to remove a reverse lane from all RoadPoints in this container."
+tooltip_text = "Add Forward lane.
+Hold shift to remove a reverse lane from all RoadPoints in this container."
 text = "+"
 
 [node name="HBoxPrior" type="HBoxContainer" parent="."]
@@ -106,7 +110,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="debug_separator"]
 layout_mode = 2
 size_flags_horizontal = 0
-text = "Debug features "
+text = "Settings"
 
 [node name="HSeparator" type="HSeparator" parent="debug_separator"]
 visible = false
@@ -121,9 +125,7 @@ unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
-tooltip_text = "Copies the attributes of this RoadPoint such as lane count shoulder size to easily apply to other RoadPoints.
-
-Hold shift to apply to all."
+tooltip_text = "Copies the attributes of this RoadPoint such as lane count shoulder size to easily apply to other RoadPoints."
 text = "Copy Settings"
 clip_text = true
 
@@ -150,7 +152,9 @@ clip_text = true
 
 [node name="flip" type="Button" parent="."]
 layout_mode = 2
-tooltip_text = "Flips this RoadPoint 180º while keeping all connections and attributes in place. Visually, it should appear nothing has changed - but is a way to fix roadpoints to point in a consistent direction without breaking connections."
+tooltip_text = "Flips this RoadPoint 180º while keeping all connections and attributes in place. Visually,
+it should appear nothing has changed - but is a way to fix roadpoints to point in a
+consistent direction without breaking connections."
 text = "Flip"
 
 [node name="spacer3" type="Control" parent="."]

--- a/addons/road-generator/ui/road_point_panel.tscn
+++ b/addons/road-generator/ui/road_point_panel.tscn
@@ -32,6 +32,7 @@ clip_text = true
 
 [node name="add_rp_front" type="Button" parent="HBoxNext"]
 unique_name_in_owner = true
+visible = false
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -91,6 +92,7 @@ clip_text = true
 
 [node name="add_rp_back" type="Button" parent="HBoxPrior"]
 unique_name_in_owner = true
+visible = false
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3


### PR DESCRIPTION
Resolves #234 by disabling the add previous/next button from the RoadPoint inspector panel custom drawing, which was causing potential crashing issues.

This also updates some tooltips and labels to be a bit more natural and improved spacing/wrapping. This additionally puts the panel squarely underneath the RoadPoint panel section itself, instead of at the top of the inspector panel.

<img width="363" alt="Screen Shot 2025-05-15 at 10 27 35 PM" src="https://github.com/user-attachments/assets/ca84b93e-7c46-446a-9ea9-87213bff3522" />
