### PR TITLE
Add gLTF exporter for RoadContainers

### DIFF
--- a/addons/road-generator/ui/road_container_edit.gd
+++ b/addons/road-generator/ui/road_container_edit.gd
@@ -1,0 +1,30 @@
+extends EditorInspectorPlugin
+
+const RoadContainerPanel = preload("res://addons/road-generator/ui/road_container_panel.tscn")
+var panel_instance
+var _editor_plugin: EditorPlugin
+# EditorInterface, don't use as type:
+# https://github.com/godotengine/godot/issues/85079
+var _edi : set = set_edi
+
+
+func _init(editor_plugin: EditorPlugin):
+	_editor_plugin = editor_plugin
+
+
+func _can_handle(object):
+	return object is RoadContainer
+
+
+# Add controls to the beginning of the Inspector property list
+func _parse_category(object: Object, category: String) -> void:
+	if category != "road_container.gd":
+		return
+	panel_instance = RoadContainerPanel.instantiate()
+	panel_instance.call("set_edi", _edi)
+	add_custom_control(panel_instance)
+	panel_instance.export_gltf.connect(_editor_plugin._export_mesh_modal)
+
+
+func set_edi(value):
+	_edi = value

--- a/addons/road-generator/ui/road_container_panel.gd
+++ b/addons/road-generator/ui/road_container_panel.gd
@@ -1,0 +1,13 @@
+@tool
+# Panel which is added to UI and used to trigger callbacks to update RoadContainers
+extends VBoxContainer
+
+signal export_gltf
+
+var _edi : set = set_edi
+
+func set_edi(value):
+	_edi = value
+
+func _on_export_gltf_pressed() -> void:
+	export_gltf.emit()

--- a/addons/road-generator/ui/road_container_panel.tscn
+++ b/addons/road-generator/ui/road_container_panel.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=2 format=3 uid="uid://cc8w0puk44el3"]
+
+[ext_resource type="Script" path="res://addons/road-generator/ui/road_container_panel.gd" id="1_1iim1"]
+
+[node name="RoadContainerPanel" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_1iim1")
+
+[node name="spacer1" type="Control" parent="."]
+custom_minimum_size = Vector2(0, 5)
+layout_mode = 2
+
+[node name="export_gltf" type="Button" parent="."]
+layout_mode = 2
+tooltip_text = "Export all children to a .gltf / .glb file"
+text = "Export to gLTF"
+
+[node name="spacer2" type="Control" parent="."]
+custom_minimum_size = Vector2(0, 5)
+layout_mode = 2
+
+[connection signal="pressed" from="export_gltf" to="." method="_on_export_gltf_pressed"]

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -15,6 +15,7 @@ signal create_roadpoint
 signal create_lane
 signal create_lane_agent
 signal create_2x2_road
+signal export_mesh
 
 # ripple up from children
 signal pressed_add_custom_roadcontainer(path)
@@ -28,6 +29,7 @@ enum CreateMenu {
 	LANE,
 	LANEAGENT,
 	TWO_X_TWO,
+	EXPORT_MESH
 }
 
 enum MenuMode {
@@ -71,9 +73,9 @@ func on_toolbar_show(primary_sel: Node) -> void:
 	pup.set_item_tooltip(idx, "Select this RoadPoint's parent RoadContainer")
 	idx += 1
 
-	if menu_mode == MenuMode.SAVED_SUBSCENE:
-		# Don't offer to modify subscenes
-		return
+	#if menu_mode == MenuMode.SAVED_SUBSCENE:
+	#	# Don't offer to modify subscenes
+	#	return
 
 	pup.add_separator()
 	idx += 1
@@ -100,6 +102,13 @@ func on_toolbar_show(primary_sel: Node) -> void:
 	rc_submenu.name = "rc_items"
 	pup.add_submenu_item("RoadContainer presets", "rc_items", idx)
 	idx += 1
+	
+	pup.add_separator()
+	pup.add_item("Export RoadContainer", CreateMenu.EXPORT_MESH)
+	idx += 1
+	if not primary_sel is RoadContainer:
+		pup.set_item_disabled(idx, true)
+		
 
 
 func _exit_tree() -> void:
@@ -122,6 +131,9 @@ func _create_menu_item_clicked(id: int) -> void:
 			emit_signal("create_lane_agent")
 		CreateMenu.TWO_X_TWO:
 			emit_signal("create_2x2_road")
+		CreateMenu.EXPORT_MESH:
+			emit_signal("export_mesh")
+
 
 func _on_pressed_add_custom_roadcontainer(path:String) -> void:
 	pressed_add_custom_roadcontainer.emit(path)


### PR DESCRIPTION
We now have an Export RoadContainer gLTF button in the editor, both in the road toolbar dropdown in the 3D editor, and in the inspector panel when a RoadContainer is selected. This allows users to export the given RoadContainer and all its children to a glb/gltf file on disk. Additionally, there is an option that allows for auto instancing the exported glb/gltf file into the scene while also turning off the "create geo" flag on the RoadContainer, making it one step easier to customize the geo for a given scene seutp.

Closes #207

Demo here, showing the "instance after export" option, showing that it'll bring the exported roads exactly into place:

https://github.com/user-attachments/assets/fbda1933-1e9a-45d6-a62a-18fca581fc58

