### PR TITLE
Fixing overlapping shoulder geo on the right side

### DIFF
--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -1033,13 +1033,35 @@ func _insert_geo_loop(
 		if lr == LeftRight.RIGHT:
 			quad( st, uv_square(0, uv_m, uv_y),
 				pts_square(nf_loop, nf_basis,
-					[pos_l[NearFar.FAR] + gutr_x[NearFar.FAR] * dir, pos_r[NearFar.FAR], pos_r[NearFar.NEAR], pos_l[NearFar.NEAR] + gutr_x[NearFar.NEAR] * dir],
-					[gutr_y[NearFar.FAR], 0, 0, gutr_y[NearFar.NEAR]]) )
+					[
+						pos_l[NearFar.FAR] + gutr_x[NearFar.FAR] * dir,
+						pos_l[NearFar.FAR],
+						pos_l[NearFar.NEAR],
+						pos_l[NearFar.NEAR] + gutr_x[NearFar.NEAR] * dir
+					],
+					[
+						gutr_y[NearFar.FAR],
+						0,
+						0,
+						gutr_y[NearFar.NEAR]
+					])
+				)
 		else:
 			quad( st, uv_square(uv_m, 0, uv_y),
 				pts_square(nf_loop, nf_basis,
-					[pos_r[NearFar.FAR], pos_r[NearFar.FAR] + gutr_x[NearFar.FAR] * dir, pos_r[NearFar.NEAR] + gutr_x[NearFar.NEAR] * dir, pos_r[NearFar.NEAR]],
-					[0, gutr_y[NearFar.FAR], gutr_y[NearFar.NEAR], 0]) )
+					[
+						pos_r[NearFar.FAR],
+						pos_r[NearFar.FAR] + gutr_x[NearFar.FAR] * dir,
+						pos_r[NearFar.NEAR] + gutr_x[NearFar.NEAR] * dir,
+						pos_r[NearFar.NEAR]
+					],
+					[
+						0,
+						gutr_y[NearFar.FAR],
+						gutr_y[NearFar.NEAR],
+						0
+					])
+				)
 
 static func uv_square(uv_lmr1:float, uv_lmr2:float, uv_y: Array) -> Array:
 	assert( len(uv_y) == 2 )


### PR DESCRIPTION
Made formatting more verbose to make it easier to see what needed changes.

Before this change, we were seeing an issue like you see here, something I discovered while working on the gLTF exporter. Not sure when it was introduced, but definitely an important one to fix!

<img width="719" alt="Screen Shot 2025-05-16 at 10 15 32 PM" src="https://github.com/user-attachments/assets/20d891b2-97b5-4d44-83ae-13ab7dc97e7a" />
