### PR TITLE
Fix bad .dot call when placing new RoadPoints

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1371,7 +1371,7 @@ func _connect_rp_on_click(rp_a, rp_b):
 		target_dir = RoadPoint.PointInit.PRIOR # only prior open
 	else:
 		var rel_vec = rp_a.global_transform.origin - rp_b.global_transform.origin
-		if rp_b.global_transform.basis.z.dor(rel_vec) > 0:
+		if rp_b.global_transform.basis.z.dot(rel_vec) > 0:
 			target_dir = RoadPoint.PointInit.NEXT
 		else:
 			target_dir = RoadPoint.PointInit.PRIOR


### PR DESCRIPTION
Prevented placing RoadPoints facing away from you in the camera for some reason