### PR TITLE
Astar3D pathfinding demo scene

### DIFF
--- a/demo/navigation/astar_lane_graph.gd
+++ b/demo/navigation/astar_lane_graph.gd
@@ -1,11 +1,11 @@
+## Demo scene showing pathfinding over RoadLanes using an AStar3D graph. Left-click to set path start, right-click to set path end.
 extends Node3D
 
-@export var path_marker_mesh: Mesh
-@export var path_highlight_material: Material
+@export var path_marker_mesh: Mesh ## Mesh used to mark AStar points along RoadLanes
+@export var path_highlight_material: Material ## Material used for markers along the current path
 
-const search_radius_squared := 100.0 ## Pathfinding will find the nearest graph point, and then try out other points within this radius (squared)
+const search_radius_squared := 100.0 ## Pathfinding will find the nearest graph point, and then try out other points within the square root of this radius
 const astar_point_interval := 10.0 ## Distance between astar points along road lanes
-var lanes_by_id: Dictionary
 var endpoints_dict: Dictionary = {} ## Used to track the astar indices of the start & end points of each RoadLane
 var id_path: PackedInt64Array ## AStar point IDs for the most recently plotted route
 
@@ -13,6 +13,7 @@ var id_path: PackedInt64Array ## AStar point IDs for the most recently plotted r
 @onready var path_start_marker: MeshInstance3D = $PathStartMarker
 @onready var path_end_marker: MeshInstance3D = $PathEndMarker
 @onready var astar := AStar3D.new()
+
 
 func _ready() -> void:
 	var _road_lanes: Array[Node] = find_children("*", "RoadLane", true, false)
@@ -30,21 +31,18 @@ func _ready() -> void:
 
 			var _marker := MeshInstance3D.new()
 			_marker.mesh = path_marker_mesh
-			_marker.add_to_group("AStarPathDot")
 			marker_container.add_child(_marker)
 			_marker.global_position = _road_lane.to_global(_lane_points[_index])
 			_marker.set_meta("point_id", _new_id)
 
-			lanes_by_id[_new_id] = _road_lane
-
 			if _index == 0: # If this is the first point on this lane, store its index
 				endpoints_dict[_new_id] = _road_lane
-			elif _index > 0: # Make a one-way connection from the previous point to this one
+			else: # Make a one-way connection from the previous point to this one
 				astar.connect_points(_previous_point_id, _new_id, false)
 			_previous_point_id = _new_id
 			_index += _increment_amount
 
-		# Add astar point for end of lane's curve
+		# Add an astar point at the end of the lane's curve
 		var _endpoint_id := astar.get_available_point_id()
 		astar.add_point(_endpoint_id, _road_lane.to_global(_lane_points[len(_lane_points) - 1]))
 		astar.connect_points(_previous_point_id, _endpoint_id, false)
@@ -53,15 +51,13 @@ func _ready() -> void:
 		_end_marker.mesh = path_marker_mesh
 		marker_container.add_child(_end_marker)
 		_end_marker.global_position = _road_lane.to_global(_lane_points[len(_lane_points) - 1])
-		_end_marker.add_to_group("AStarPathDot")
 		_end_marker.set_meta("point_id", _endpoint_id)
-		lanes_by_id[_endpoint_id] = _road_lane
 
-	for _point_idx: int in endpoints_dict.keys():
+	for _point_idx: int in endpoints_dict.keys(): # Loop over endpoints and connect lanes to each other
 		var _point_position := astar.get_point_position(_point_idx)
 		var _lane: RoadLane = endpoints_dict[_point_idx]
 		if _point_position == _lane.to_global(_lane.curve.get_point_position(0)):
-			var _overlapping_indices := endpoints_dict.keys().filter(func(i):
+			var _overlapping_indices := endpoints_dict.keys().filter(func(i): # Find other endpoints close to this endpoint
 				var _other_point_position := astar.get_point_position(i)
 				var _other_lane: RoadLane = endpoints_dict[i]
 				if _other_point_position != _other_lane.to_global(_other_lane.curve.get_point_position(_other_lane.curve.point_count - 1)):
@@ -83,7 +79,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		_ray_params.to = _ray_params.from + $Camera3D.project_ray_normal(get_viewport().get_mouse_position()) * $Camera3D.far
 
 		var _result = _space_state.intersect_ray(_ray_params)
-		if _result.size() > 0:
+		if _result.size() > 0: # Move our "start marker" to the clicked location, and plot a route to the end marker
 			path_start_marker.visible = true
 			path_start_marker.position = _result.position
 			path_start_marker.position.y += 2
@@ -96,14 +92,14 @@ func _unhandled_input(event: InputEvent) -> void:
 		_ray_params.to = _ray_params.from + $Camera3D.project_ray_normal(get_viewport().get_mouse_position()) * $Camera3D.far
 
 		var _result = _space_state.intersect_ray(_ray_params)
-		if _result.size() > 0:
+		if _result.size() > 0: # Move our "end marker" to the clicked location, and plot a route from the start marker
 			path_end_marker.visible = true
 			path_end_marker.position = _result.position
 			path_end_marker.position.y += 2
 			id_path = plot_route()
 	return
 
-
+## Get an array of astar point ids, representing a path through our astar graph
 func plot_route() -> PackedInt64Array:
 	var _possible_starts: PackedInt64Array
 	var _possible_ends: PackedInt64Array
@@ -139,12 +135,7 @@ func plot_route() -> PackedInt64Array:
 	prints("Path cost:", str(roundi(_lowest_cost)))
 	return _id_path
 
-
-func clear_route() -> void:
-	id_path.clear()
-	return
-
-
+## Calculate the cost of a given astar path
 func get_path_cost(_id_path: PackedInt64Array) -> float:
 	var _path_cost := 0.0
 	var i: int = 0

--- a/demo/navigation/astar_lane_graph.gd
+++ b/demo/navigation/astar_lane_graph.gd
@@ -1,0 +1,154 @@
+extends Node3D
+
+@export var path_marker_mesh: Mesh
+@export var path_highlight_material: Material
+
+const search_radius_squared := 100.0 ## Pathfinding will find the nearest graph point, and then try out other points within this radius (squared)
+const astar_point_interval := 10.0 ## Distance between astar points along road lanes
+var lanes_by_id: Dictionary
+var endpoints_dict: Dictionary = {} ## Used to track the astar indices of the start & end points of each RoadLane
+var id_path: PackedInt64Array ## AStar point IDs for the most recently plotted route
+
+@onready var marker_container: Node3D = $AStarMarkers
+@onready var path_start_marker: MeshInstance3D = $PathStartMarker
+@onready var path_end_marker: MeshInstance3D = $PathEndMarker
+@onready var astar := AStar3D.new()
+
+func _ready() -> void:
+	var _road_lanes: Array[Node] = find_children("*", "RoadLane", true, false)
+	prints(str(len(_road_lanes)), "RoadLane nodes in scene")
+
+	for _road_lane: RoadLane in _road_lanes:
+		var _lane_points := _road_lane.curve.get_baked_points()
+		var _increment_amount := ceili(astar_point_interval / _road_lane.curve.bake_interval)
+		var _index: int = 0
+		var _previous_point_id: int
+
+		while _index < len(_lane_points) - 1: # Add astar points at intervals along the lane's curve
+			var _new_id := astar.get_available_point_id()
+			astar.add_point(_new_id, _road_lane.to_global(_lane_points[_index]))
+
+			var _marker := MeshInstance3D.new()
+			_marker.mesh = path_marker_mesh
+			_marker.add_to_group("AStarPathDot")
+			marker_container.add_child(_marker)
+			_marker.global_position = _road_lane.to_global(_lane_points[_index])
+			_marker.set_meta("point_id", _new_id)
+
+			lanes_by_id[_new_id] = _road_lane
+
+			if _index == 0: # If this is the first point on this lane, store its index
+				endpoints_dict[_new_id] = _road_lane
+			elif _index > 0: # Make a one-way connection from the previous point to this one
+				astar.connect_points(_previous_point_id, _new_id, false)
+			_previous_point_id = _new_id
+			_index += _increment_amount
+
+		# Add astar point for end of lane's curve
+		var _endpoint_id := astar.get_available_point_id()
+		astar.add_point(_endpoint_id, _road_lane.to_global(_lane_points[len(_lane_points) - 1]))
+		astar.connect_points(_previous_point_id, _endpoint_id, false)
+		endpoints_dict[_endpoint_id] = _road_lane
+		var _end_marker := MeshInstance3D.new()
+		_end_marker.mesh = path_marker_mesh
+		marker_container.add_child(_end_marker)
+		_end_marker.global_position = _road_lane.to_global(_lane_points[len(_lane_points) - 1])
+		_end_marker.add_to_group("AStarPathDot")
+		_end_marker.set_meta("point_id", _endpoint_id)
+		lanes_by_id[_endpoint_id] = _road_lane
+
+	for _point_idx: int in endpoints_dict.keys():
+		var _point_position := astar.get_point_position(_point_idx)
+		var _lane: RoadLane = endpoints_dict[_point_idx]
+		if _point_position == _lane.to_global(_lane.curve.get_point_position(0)):
+			var _overlapping_indices := endpoints_dict.keys().filter(func(i):
+				var _other_point_position := astar.get_point_position(i)
+				var _other_lane: RoadLane = endpoints_dict[i]
+				if _other_point_position != _other_lane.to_global(_other_lane.curve.get_point_position(_other_lane.curve.point_count - 1)):
+					return false
+				return _other_point_position.distance_squared_to(_point_position) < 1
+			)
+			for _overlapping_index in _overlapping_indices:
+				astar.connect_points(_overlapping_index, _point_idx, false)
+
+	prints(str(astar.get_point_count()), "points in AStar3D graph")
+	return
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and not event.is_echo() and event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed():
+		var _space_state = get_world_3d().direct_space_state
+		var _ray_params := PhysicsRayQueryParameters3D.new()
+		_ray_params.from = $Camera3D.project_ray_origin(DisplayServer.mouse_get_position())
+		_ray_params.to = _ray_params.from + $Camera3D.project_ray_normal(get_viewport().get_mouse_position()) * $Camera3D.far
+
+		var _result = _space_state.intersect_ray(_ray_params)
+		if _result.size() > 0:
+			path_start_marker.visible = true
+			path_start_marker.position = _result.position
+			path_start_marker.position.y += 2
+			id_path = plot_route()
+
+	if event is InputEventMouseButton and not event.is_echo() and event.button_index == MOUSE_BUTTON_RIGHT and event.is_pressed():
+		var _space_state = get_world_3d().direct_space_state
+		var _ray_params := PhysicsRayQueryParameters3D.new()
+		_ray_params.from = $Camera3D.project_ray_origin(DisplayServer.mouse_get_position())
+		_ray_params.to = _ray_params.from + $Camera3D.project_ray_normal(get_viewport().get_mouse_position()) * $Camera3D.far
+
+		var _result = _space_state.intersect_ray(_ray_params)
+		if _result.size() > 0:
+			path_end_marker.visible = true
+			path_end_marker.position = _result.position
+			path_end_marker.position.y += 2
+			id_path = plot_route()
+	return
+
+
+func plot_route() -> PackedInt64Array:
+	var _possible_starts: PackedInt64Array
+	var _possible_ends: PackedInt64Array
+	var _nearest_start := astar.get_point_position(astar.get_closest_point(path_start_marker.position))
+	var _nearest_end := astar.get_point_position(astar.get_closest_point(path_end_marker.position))
+
+	for _id in astar.get_point_ids():
+		if astar.get_point_position(_id).distance_squared_to(_nearest_start) < search_radius_squared:
+			_possible_starts.push_back(_id)
+		if astar.get_point_position(_id).distance_squared_to(_nearest_end) < search_radius_squared:
+			_possible_ends.push_back(_id)
+	
+	var _lowest_cost := INF
+	var _id_path: PackedInt64Array
+	for _possible_start in _possible_starts:
+		for _possible_end in _possible_ends:
+			var _test_id_path := astar.get_id_path(_possible_start, _possible_end)
+			if len(_test_id_path) == 0: continue
+			var _cost := get_path_cost(_test_id_path)
+			if _cost < _lowest_cost:
+				_lowest_cost = _cost
+				_id_path = _test_id_path
+
+	var _markers := marker_container.get_children()
+	for _marker: MeshInstance3D in _markers:
+		if _marker.get_meta("point_id") in _id_path:
+			_marker.set_surface_override_material(0, path_highlight_material)
+			_marker.scale = Vector3(2, 2, 2)
+		else:
+			_marker.set_surface_override_material(0, null)
+			_marker.scale = Vector3.ONE
+
+	prints("Path cost:", str(roundi(_lowest_cost)))
+	return _id_path
+
+
+func clear_route() -> void:
+	id_path.clear()
+	return
+
+
+func get_path_cost(_id_path: PackedInt64Array) -> float:
+	var _path_cost := 0.0
+	var i: int = 0
+	while i < len(_id_path) - 2:
+		_path_cost += astar.get_point_position(_id_path[i]).distance_to(astar.get_point_position(_id_path[i + 1])) * astar.get_point_weight_scale(_id_path[i + 1])
+		i += 1
+	return _path_cost

--- a/demo/navigation/astar_lane_graph.gd
+++ b/demo/navigation/astar_lane_graph.gd
@@ -106,7 +106,7 @@ func plot_route() -> PackedInt64Array:
 	var _nearest_start := astar.get_point_position(astar.get_closest_point(path_start_marker.position))
 	var _nearest_end := astar.get_point_position(astar.get_closest_point(path_end_marker.position))
 
-	for _id in astar.get_point_ids():
+	for _id in astar.get_point_ids(): # Get alternate start and end points
 		if astar.get_point_position(_id).distance_squared_to(_nearest_start) < search_radius_squared:
 			_possible_starts.push_back(_id)
 		if astar.get_point_position(_id).distance_squared_to(_nearest_end) < search_radius_squared:
@@ -114,7 +114,7 @@ func plot_route() -> PackedInt64Array:
 	
 	var _lowest_cost := INF
 	var _id_path: PackedInt64Array
-	for _possible_start in _possible_starts:
+	for _possible_start in _possible_starts: # Loop over possible start & end points to find shortest path
 		for _possible_end in _possible_ends:
 			var _test_id_path := astar.get_id_path(_possible_start, _possible_end)
 			if len(_test_id_path) == 0: continue
@@ -124,7 +124,7 @@ func plot_route() -> PackedInt64Array:
 				_id_path = _test_id_path
 
 	var _markers := marker_container.get_children()
-	for _marker: MeshInstance3D in _markers:
+	for _marker: MeshInstance3D in _markers: # Highlight markers along path, un-highlight others
 		if _marker.get_meta("point_id") in _id_path:
 			_marker.set_surface_override_material(0, path_highlight_material)
 			_marker.scale = Vector3(2, 2, 2)

--- a/demo/navigation/astar_lane_graph.tscn
+++ b/demo/navigation/astar_lane_graph.tscn
@@ -1,0 +1,353 @@
+[gd_scene load_steps=18 format=3 uid="uid://buus3nw81afbr"]
+
+[ext_resource type="Script" path="res://demo/navigation/astar_lane_graph.gd" id="1_g562n"]
+[ext_resource type="Script" path="res://addons/road-generator/nodes/road_manager.gd" id="1_o8koi"]
+[ext_resource type="Material" uid="uid://dpashsuk5lr4x" path="res://addons/road-generator/resources/road_texture.material" id="2_1qex7"]
+[ext_resource type="Script" path="res://addons/road-generator/nodes/road_container.gd" id="3_uojm1"]
+[ext_resource type="Script" path="res://addons/road-generator/nodes/road_point.gd" id="4_4lmnd"]
+[ext_resource type="PackedScene" uid="uid://d23s6bfnq6fex" path="res://addons/road-generator/custom_containers/4way_1x1.tscn" id="5_p8dyk"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1dpoc"]
+shading_mode = 0
+
+[sub_resource type="SphereMesh" id="SphereMesh_hbfo0"]
+material = SubResource("StandardMaterial3D_1dpoc")
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_0qrr4"]
+shading_mode = 0
+albedo_color = Color(0.757422, 0.869987, 3.85046e-07, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_evk4j"]
+albedo_color = Color(0.466667, 0.466667, 0.466667, 1)
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_nidkg"]
+material = SubResource("StandardMaterial3D_evk4j")
+size = Vector2(300, 200)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_ye8u6"]
+size = Vector3(300, 1, 200)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_rnb1w"]
+shading_mode = 0
+
+[sub_resource type="SphereMesh" id="SphereMesh_63c6c"]
+material = SubResource("StandardMaterial3D_rnb1w")
+radius = 2.0
+height = 4.0
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_10o7l"]
+shading_mode = 0
+albedo_color = Color(0.756863, 0.870588, 0, 1)
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_6beub"]
+material = SubResource("StandardMaterial3D_10o7l")
+top_radius = 1.0
+bottom_radius = 0.0
+height = 4.0
+
+[sub_resource type="Environment" id="Environment_av7ms"]
+
+[node name="AstarLaneGraph" type="Node3D"]
+script = ExtResource("1_g562n")
+path_marker_mesh = SubResource("SphereMesh_hbfo0")
+path_highlight_material = SubResource("StandardMaterial3D_0qrr4")
+
+[node name="Ground" type="StaticBody3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Ground"]
+mesh = SubResource("PlaneMesh_nidkg")
+skeleton = NodePath("../..")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Ground"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
+shape = SubResource("BoxShape3D_ye8u6")
+
+[node name="RoadManager" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+script = ExtResource("1_o8koi")
+material_resource = ExtResource("2_1qex7")
+collision_layer = 0
+collision_mask = 0
+
+[node name="4way_1x1_1" parent="RoadManager" instance=ExtResource("5_p8dyk")]
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath("../Road_001"), NodePath("../Road_007"), NodePath("../Road_003")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath("Node3D"), NodePath("Node3D2"), NodePath("Node3D2")])
+edge_rp_target_dirs = Array[int]([-1, 1, 0, 1])
+
+[node name="Road_001" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x1_1"), NodePath("../4way_1x1")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_002"), NodePath("RP_001")])
+edge_rp_target_dirs = Array[int]([0, 1])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D001")])
+edge_rp_local_dirs = Array[int]([1, 0])
+
+[node name="Node3D" type="Node3D" parent="RoadManager/Road_001"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 16)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 8.0
+next_pt_init = NodePath("../Node3D001")
+
+[node name="Node3D001" type="Node3D" parent="RoadManager/Road_001"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 61)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D")
+
+[node name="4way_1x1" parent="RoadManager" instance=ExtResource("5_p8dyk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 77)
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../Road_001"), NodePath(""), NodePath(""), NodePath("../Road_002")])
+edge_rp_targets = Array[NodePath]([NodePath("Node3D001"), NodePath(""), NodePath(""), NodePath("Node3D")])
+edge_rp_target_dirs = Array[int]([0, -1, -1, 1])
+
+[node name="Road_002" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x1"), NodePath("../4way_1x2")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_004"), NodePath("RP_002")])
+edge_rp_target_dirs = Array[int]([0, 0])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D003")])
+edge_rp_local_dirs = Array[int]([1, 0])
+
+[node name="Node3D" type="Node3D" parent="RoadManager/Road_002"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 16, 0, 77)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 24.8105
+next_pt_init = NodePath("../Node3D001")
+
+[node name="Node3D001" type="Node3D" parent="RoadManager/Road_002"]
+transform = Transform3D(-0.965926, 0, -0.258819, 0, 1, 0, 0.258819, 0, -0.965926, 32, 0, 49)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 24.9635
+prior_pt_init = NodePath("../Node3D")
+next_pt_init = NodePath("../Node3D002")
+
+[node name="Node3D002" type="Node3D" parent="RoadManager/Road_002"]
+transform = Transform3D(0.5, 0, 0.866025, 0, 1, 0, -0.866025, 0, 0.5, 93.7178, 0, 46.0904)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 37.7766
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D001")
+next_pt_init = NodePath("../Node3D003")
+
+[node name="Node3D003" type="Node3D" parent="RoadManager/Road_002"]
+transform = Transform3D(-0.965926, 0, -0.258819, 0, 1, 0, 0.258819, 0, -0.965926, 121.431, 0, 20.0904)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 27.2123
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D002")
+
+[node name="4way_1x2" parent="RoadManager" instance=ExtResource("5_p8dyk")]
+transform = Transform3D(0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, 0.965926, 117.289, 0, 4.63556)
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../Road_004"), NodePath("../Road_002"), NodePath("../Road_003"), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D003"), NodePath("Node3D"), NodePath("")])
+edge_rp_target_dirs = Array[int]([0, 0, 0, -1])
+
+[node name="Road_003" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x2"), NodePath("../4way_1x1_1")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_003"), NodePath("RP_004")])
+edge_rp_target_dirs = Array[int]([1, 0])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D2")])
+edge_rp_local_dirs = Array[int]([0, 1])
+
+[node name="Node3D" type="Node3D" parent="RoadManager/Road_003"]
+transform = Transform3D(-0.258819, 0, 0.965926, 0, 1, 0, -0.965926, 0, -0.258819, 101.835, 0, 8.77666)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 32.8612
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D2")
+
+[node name="Node3D2" type="Node3D" parent="RoadManager/Road_003"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 16, 0, 0)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 34.2091
+next_pt_init = NodePath("../Node3D")
+
+[node name="4way_1x3" parent="RoadManager" instance=ExtResource("5_p8dyk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -75)
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("../Road_005"), NodePath("../Road_004")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("Node3D002"), NodePath("Node3D2")])
+edge_rp_target_dirs = Array[int]([-1, -1, 0, 1])
+
+[node name="Road_004" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x2"), NodePath("../4way_1x3")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_001"), NodePath("RP_004")])
+edge_rp_target_dirs = Array[int]([1, 0])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D2")])
+edge_rp_local_dirs = Array[int]([0, 1])
+
+[node name="Node3D" type="Node3D" parent="RoadManager/Road_004"]
+transform = Transform3D(0.965926, 0, 0.258819, 0, 1, 0, -0.258819, 0, 0.965926, 113.148, 0, -10.8193)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 48.81
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D2")
+
+[node name="Node3D2" type="Node3D" parent="RoadManager/Road_004"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 16, 0, -75)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 66.0851
+next_pt_init = NodePath("../Node3D")
+
+[node name="Road_005" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x4"), NodePath("../4way_1x3")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_004"), NodePath("RP_003")])
+edge_rp_target_dirs = Array[int]([0, 1])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D001"), NodePath("Node3D002")])
+edge_rp_local_dirs = Array[int]([1, 0])
+
+[node name="Node3D001" type="Node3D" parent="RoadManager/Road_005"]
+transform = Transform3D(0.22325, 0, 0.974761, 0, 1, 0, -0.974761, 0, 0.22325, -90.3948, 0, -66.4329)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 37.4358
+next_mag = 37.4358
+next_pt_init = NodePath("../Node3D002")
+
+[node name="Node3D002" type="Node3D" parent="RoadManager/Road_005"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -16, 0, -75)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 32.1591
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D001")
+
+[node name="4way_1x4" parent="RoadManager" instance=ExtResource("5_p8dyk")]
+transform = Transform3D(0.974761, 0, -0.22325, 0, 1, 0, 0.22325, 0, 0.974761, -105.991, 0, -70.0049)
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath("../Road_006"), NodePath(""), NodePath("../Road_005")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath("Node3D"), NodePath(""), NodePath("Node3D001")])
+edge_rp_target_dirs = Array[int]([-1, 1, -1, 1])
+
+[node name="Road_006" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x4"), NodePath("../4way_1x5")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_002"), NodePath("RP_001")])
+edge_rp_target_dirs = Array[int]([0, 1])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D001")])
+edge_rp_local_dirs = Array[int]([1, 0])
+
+[node name="Node3D" type="Node3D" parent="RoadManager/Road_006"]
+transform = Transform3D(0.974761, 0, -0.22325, 0, 1, 0, 0.22325, 0, 0.974761, -109.563, 0, -54.4087)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 23.187
+next_pt_init = NodePath("../Node3D001")
+
+[node name="Node3D001" type="Node3D" parent="RoadManager/Road_006"]
+transform = Transform3D(0.993364, 0, 0.115016, 0, 1, 0, -0.115016, 0, 0.993364, -111.994, 0, -8.09916)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 23.187
+next_mag = 23.187
+prior_pt_init = NodePath("../Node3D")
+
+[node name="4way_1x5" parent="RoadManager" instance=ExtResource("5_p8dyk")]
+transform = Transform3D(0.993364, 0, 0.115016, 0, 1, 0, -0.115016, 0, 0.993364, -110.154, 0, 7.79466)
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../Road_006"), NodePath(""), NodePath(""), NodePath("../Road_007")])
+edge_rp_targets = Array[NodePath]([NodePath("Node3D001"), NodePath(""), NodePath(""), NodePath("Node3D")])
+edge_rp_target_dirs = Array[int]([0, -1, -1, 1])
+
+[node name="Road_007" type="Node3D" parent="RoadManager"]
+script = ExtResource("3_uojm1")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath("../4way_1x5"), NodePath("../4way_1x1_1")])
+edge_rp_targets = Array[NodePath]([NodePath("RP_004"), NodePath("RP_003")])
+edge_rp_target_dirs = Array[int]([0, 1])
+edge_rp_locals = Array[NodePath]([NodePath("Node3D"), NodePath("Node3D2")])
+edge_rp_local_dirs = Array[int]([1, 0])
+
+[node name="Node3D" type="Node3D" parent="RoadManager/Road_007"]
+transform = Transform3D(-0.115016, 0, 0.993364, 0, 1, 0, -0.993364, 0, -0.115016, -94.2604, 0, 5.95441)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 39.2454
+next_pt_init = NodePath("../Node3D2")
+
+[node name="Node3D2" type="Node3D" parent="RoadManager/Road_007"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, -16, 0, 0)
+script = ExtResource("4_4lmnd")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 8.0
+prior_pt_init = NodePath("../Node3D")
+
+[node name="AStarMarkers" type="Node3D" parent="."]
+
+[node name="PathStartMarker" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 2)
+mesh = SubResource("SphereMesh_63c6c")
+
+[node name="PathEndMarker" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -2)
+mesh = SubResource("CylinderMesh_6beub")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(0.876727, 0.475706, -0.0710943, 0, 0.147809, 0.989016, 0.480989, -0.867097, 0.129588, -9.93477, 138.206, 18.1087)
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_av7ms")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.258819, 0.965926, 0, -0.965926, 0.258819, 0, 250, 0)


### PR DESCRIPTION
This PR adds a simple demo scene showing on-road pathfinding between 2 points.

The start and end points of the path can be set by left & right clicking anywhere on the "Ground" plane. The calculated path should then be highlighted along the road, and the path should respect intersections and directional lanes.

Currently, the demo only features 2-lane roads connected by 4-way_1x1 intersections, and doesn't support lane-switching.

https://github.com/user-attachments/assets/f7fcb333-fe7a-463d-8add-7bad1a0139c3

