### PR TITLE
Add ability to skip specific segments when flattening Terrain3D

### DIFF
--- a/addons/road-generator/connectors/terrain3d_road_connector.gd
+++ b/addons/road-generator/connectors/terrain3d_road_connector.gd
@@ -30,19 +30,6 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 		auto_refresh = value
 		configure_road_update_signal()
 
-# TODO this can be switched to a Dictionary[RoadPoint, RoadPoint]
-# once https://github.com/godotengine/godot/issues/103082 is fixed
-## Can be used to ignore specific segments of road when performing
-## terrain flattening. Array should look like:
-## [
-##  start of segnment 1,
-##  end of segment 1,
-##  start of segment 2,
-##  end of segment 2,
-##  ...
-## ]
-@export var ignored_road_segments: Array[RoadPoint] = []
-
 ## Immediately level the terrain to match roads
 @export_tool_button("Refresh", "Callable") var refresh_action = do_full_refresh
 
@@ -135,20 +122,10 @@ func refresh_roadsegments(segments: Array) -> void:
 		_seg = _seg as RoadSegment
 
 		# check if this segment should be ignored
-		var should_ignore := false
-		for i in range(0, ignored_road_segments.size(), 2):
-			if i + 1 < ignored_road_segments.size():
-				var ignored_start := ignored_road_segments[i]
-				var ignored_end := ignored_road_segments[i + 1]
-
-				var ignore_from_start = _seg.start_point == ignored_start and _seg.end_point == ignored_end
-				var ignore_from_end = _seg.start_point == ignored_end and _seg.end_point == ignored_start
-
-				if ignore_from_start or ignore_from_end:
-					should_ignore = true
-					break
-
-		if should_ignore:
+		if (
+			not _seg.container.flatten_terrain
+			or (not _seg.start_point.flatten_terrain and not _seg.end_point.flatten_terrain)
+		):
 			print("Skipping ignored segment %s/%s" % [_seg.get_parent().name, _seg.name])
 			continue
 

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -26,6 +26,9 @@ const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 @export var create_geo := true: set = _set_create_geo
 # If create_geo is true, then whether to reduce geo mid transform.
 @export var use_lowpoly_preview: bool = false
+## If enabled, then road points that are children of this container will
+## flatten terrain underneath them if a terrain connector is used.
+@export var flatten_terrain: bool = true
 ## Whether to create approximated curves to fit along the forward, reverse, and center of the road.
 ## Visible in the editor, useful for adding procedural generation along road edges or center lane.
 @export var create_edge_curves := false: set = _set_create_edge_curves

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -86,6 +86,12 @@ const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPo
 # If off, it indicates the developer will load in their own custom mesh + collision.
 @export var create_geo := true: set = _set_create_geo
 
+## If enabled, then this road point will flatten terrain underneath it.
+##
+## NOTE: For this to be disabled, it must be disabled on at least two connected points
+## that are in the same segment.
+@export var flatten_terrain: bool = true
+
 var rev_width_mag := -8.0
 var fwd_width_mag := 8.0
 # Ultimate assignment if any export path specified


### PR DESCRIPTION
The reason I need this is because I have a few scenarios where roads go over / into holes in the terrain:

<img width="787" height="426" alt="Screenshot 2025-07-30 at 1 14 07 AM" src="https://github.com/user-attachments/assets/af1ad138-291b-4a1c-aae1-fc2702650b2c" />

Currently, the terrain flattening stomps on these holes and messes them up pretty bad. So I figured just skipping those segments would be easiest for now (idk if it would be feasible to check for holes and not flatten over them 🤔 sounds hard)

---

I originally tried using a `Dictionary[NodePoint, NodePoint]` which worked! ...for one point.

<img width="395" height="441" alt="Screenshot 2025-07-30 at 1 12 53 AM" src="https://github.com/user-attachments/assets/27e8e34b-dbfe-44c6-a43f-94e8a7d02bb9" />

As soon as you try to add a second set there, Godot freezes and then eventually crashes. I think because https://github.com/godotengine/godot/issues/103082

Pretty unfortunate bug because I thought I was being _soooo_ clever.

---

<img width="385" height="666" alt="Screenshot 2025-07-30 at 1 43 38 AM" src="https://github.com/user-attachments/assets/be5bf3b4-1ca5-4a79-a1f5-402c5a0cd6ba" />

I ended up just using an array that's expected to be groups of two `RoadPoint` nodes.

I tried using a custom `Resource` here, but then you lose the type safety of only allowing selecting `RoadPoint`s.