### PR TITLE
Add manager road updated signal and ready signal

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -461,6 +461,8 @@ func get_segments() -> Array:
 		for pt_ch in ch.get_children():
 			if not pt_ch is RoadSegment:
 				continue
+			if pt_ch.is_queued_for_deletion():
+				continue
 			segs.append(pt_ch)
 	return segs
 

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -17,9 +17,8 @@ extends Node3D
 
 
 ## Emitted when a road segment has been (re)generated, returning the list
-## of updated segments of type Array. Will also trigger on segments deleted,
-## which will contain a list of nothing.
-signal on_road_updated(updated_segments)
+## of updated segments of type Array.
+signal on_road_updated(updated_segments: Array)
 
 ## For internal purposes, to handle drag events in the editor.
 signal on_transform(node)
@@ -873,7 +872,7 @@ func rebuild_segments(clear_existing := false):
 		print_debug("Road segs rebuilt: ", rebuilt)
 
 	if signal_rebuilt.size() > 0:
-		emit_signal("on_road_updated", signal_rebuilt)
+		_emit_road_updated(signal_rebuilt)
 
 
 ## Removes a single RoadSegment, ensuring no leftovers and signal is emitted.
@@ -1080,9 +1079,7 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 				needs_update = true
 
 	if needs_update and len(segs_updated) > 0:
-		if self.debug:
-			print_debug("Road segs rebuilt: ", len(segs_updated))
-		emit_signal("on_road_updated", segs_updated)
+		_emit_road_updated(segs_updated)
 
 
 # Callback from a modification of a RoadSegment object.
@@ -1108,6 +1105,15 @@ func setup_road_container():
 	if not is_instance_valid(get_manager()):
 		# Assign a road material by default if there's no parent RoadManager
 		material_resource = RoadMaterial
+
+
+## Signals the segments whichhave been just (re)built
+func _emit_road_updated(segments: Array) -> void:
+	if self.debug:
+		print_debug("Road segs rebuilt: ", len(segments))
+	on_road_updated.emit(segments)
+	if is_instance_valid(_manager):
+		_manager.on_container_update(segments)
 
 
 ## Detect and move legacy node hierharcy layout.

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -13,6 +13,10 @@ extends Node3D
 ## @tutorial(Custom Materials Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/Creating-custom-materials
 ## @tutorial(Custom Mesh Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/User-guide:-Custom-road-meshes
 
+## Emitted when a road segment has been (re)generated, returning the list
+## of updated segments of type Array.
+signal on_road_updated(updated_segments: Array)
+
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
 
 # ------------------------------------------------------------------------------
@@ -123,11 +127,12 @@ var auto_refresh: bool = true: set = _ui_refresh_set
 
 
 # ------------------------------------------------------------------------------
-# Internal flags
+# Internal flags and setup
 # ------------------------------------------------------------------------------
 
 
 var _skip_warn_found_rc_child := false
+var _initial_ready_done := false
 
 
 # ------------------------------------------------------------------------------
@@ -143,6 +148,7 @@ func _ready():
 	# setup_road_container won't work in _ready unless call_deferred is used
 	assign_default_material.call_deferred()
 
+	_initial_ready_done = true
 
 func assign_default_material() -> void:
 	if not material_resource:
@@ -202,3 +208,9 @@ func rebuild_all_containers_deferred() -> void:
 	for ch in get_containers():
 		ch._dirty = true
 		ch._dirty_rebuild_deferred()
+
+
+## Propogates upwards signals emitted by child RoadContainers
+## Note: this function is connected to each RoadContainer's own on_road_updated signal
+func on_container_update(updated_segments: Array) -> void:
+	on_road_updated.emit(updated_segments)

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -189,7 +189,7 @@ func _ready():
 			push_warning("Parent of RoadPoint %s is not a RoadContainer" % self.name)
 		container = par
 
-	connect("on_transform", Callable(container, "on_point_update"))
+	on_transform.connect(container.on_point_update)
 
 	# TODO: If a new roadpoint is just added, we need to trigger this. But,
 	# if this is just a scene startup, would be better to call it once only

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -17,6 +17,7 @@ const RAD_NINETY_DEG = PI/2 ## aka 1.5707963267949, used for offset_curve algori
 const EDGE_R_NAME = "edge_R" ## Name of reverse lane edge curve
 const EDGE_F_NAME = "edge_F" ## Name of forward lane edge curve
 const EDGE_C_NAME = "edge_C" ## Name of road center (direction divider) edge curve
+const DEFAULT_DENSITY := 4.0
 
 ## Lookup for lane texture multiplier - corresponds to RoadPoint.LaneType enum
 const uv_mul = [7, 0, 1, 2, 3, 4, 5, 6, 7, 7]
@@ -32,7 +33,7 @@ var end_point:RoadPoint
 var curve:Curve3D
 var road_mesh:MeshInstance3D
 var material:Material
-var density := 4.00 ## Distance between loops, bake_interval in m applied to curve for geo creation.
+var density := DEFAULT_DENSITY ## Distance between loops, bake_interval in m applied to curve for geo creation.
 var container:RoadContainer ## The managing container node for this road segment (grandparent).
 
 var is_dirty := true
@@ -77,7 +78,6 @@ func _init(_container):
 		return
 	container = _container
 	curve = Curve3D.new()
-
 
 
 func _ready():
@@ -626,11 +626,12 @@ func _rebuild():
 		return
 
 	get_id()
+	var manager:RoadManager = container.get_manager()
 	if not container or not is_instance_valid(container):
 		pass
-	elif container.density > 0:
+	elif container.density > 0.0:
 		density = container.density
-	elif is_instance_valid(container.get_manager()):
+	elif is_instance_valid(manager) and manager.density > 0.0:
 		density = container.get_manager().density
 	else:
 		pass

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -3,18 +3,25 @@ extends "res://addons/gut/test.gd"
 ## Utility to create a single segment container (2 points)
 func create_oneseg_container(container):
 	container.setup_road_container()
-	var points = container.get_node(container.points)
-	var segments = container.get_node(container.segments)
-
-	assert_eq(points.get_child_count(), 0, "No initial point children")
-	assert_eq(segments.get_child_count(), 0, "No initial segment children")
+	
+	assert_eq(container.get_child_count(), 0, "No initial point children")
 
 	var p1 = autoqfree(RoadPoint.new())
 	var p2 = autoqfree(RoadPoint.new())
 
-	points.add_child(p1)
-	points.add_child(p2)
-	assert_eq(points.get_child_count(), 2, "Both RPs added")
+	container.add_child(p1)
+	container.add_child(p2)
+	assert_eq(container.get_child_count(), 2, "Both RPs added")
 
 	p1.next_pt_init = p1.get_path_to(p2)
 	p2.prior_pt_init = p2.get_path_to(p1)
+
+
+func create_two_containers(container_a, container_b):
+	create_oneseg_container(container_a)
+	create_oneseg_container(container_b)
+
+	assert_eq(len(container_a.edge_containers), 2, "Cont A should have 2 empty edge container slots")
+	assert_eq(len(container_b.edge_containers), 2, "Cont B should have 2 empty edge container slots")
+	#container_a.update_edges() # should be auto-called
+	#container_b.update_edges() # should be auto-called

--- a/test/unit/test_road_container.gd
+++ b/test/unit/test_road_container.gd
@@ -2,11 +2,14 @@ extends "res://addons/gut/test.gd"
 
 const RoadUtils = preload("res://test/unit/road_utils.gd")
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
-@onready var road_util := RoadUtils.new()
+
+var road_util: RoadUtils
 
 
 func before_each():
 	gut.p("ran setup", 2)
+	road_util = RoadUtils.new()
+	road_util.gut = gut
 
 func after_each():
 	gut.p("ran teardown", 2)
@@ -19,33 +22,6 @@ func after_all():
 
 
 # ------------------------------------------------------------------------------
-
-
-## Utility to create a single segment container (2 points)
-func create_oneseg_container(container):
-	container.setup_road_container()
-
-	assert_eq(container.get_child_count(), 0, "No initial point children")
-
-	var p1 = autoqfree(RoadPoint.new())
-	var p2 = autoqfree(RoadPoint.new())
-
-	container.add_child(p1)
-	container.add_child(p2)
-	assert_eq(container.get_child_count(), 2, "Both RPs added")
-
-	p1.next_pt_init = p1.get_path_to(p2)
-	p2.prior_pt_init = p2.get_path_to(p1)
-
-
-func create_two_containers(container_a, container_b):
-	create_oneseg_container(container_a)
-	create_oneseg_container(container_b)
-
-	assert_eq(len(container_a.edge_containers), 2, "Cont A should have 2 empty edge container slots")
-	assert_eq(len(container_b.edge_containers), 2, "Cont B should have 2 empty edge container slots")
-	#container_a.update_edges() # should be auto-called
-	#container_b.update_edges() # should be auto-called
 
 
 func validate_edges_equal_size(container):
@@ -134,7 +110,7 @@ func test_on_road_updated_single_segment():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
 
-	create_oneseg_container(container)
+	road_util.create_oneseg_container(container)
 
 	# Now trigger the update, to see that a single segment was made
 	watch_signals(container)
@@ -150,7 +126,7 @@ func test_RoadContainer_validations_with_autorefresh():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = true  # Will kick in validation
 
-	create_oneseg_container(container)
+	road_util.create_oneseg_container(container)
 
 	# Now trigger the update, to see that a single segment was made
 	watch_signals(container)
@@ -204,7 +180,7 @@ func test_update_edges():
 	validate_edges_equal_size(container)
 
 	# Second case: 2 edges over 2 points
-	create_oneseg_container(container)
+	road_util.create_oneseg_container(container)
 	assert_eq(len(container.edge_rp_locals), 2, "Should have two edges")
 	validate_edges_equal_size(container)
 
@@ -241,7 +217,7 @@ func test_container_connection():
 	cont_a._auto_refresh = false
 	cont_b._auto_refresh = false
 
-	create_two_containers(cont_a, cont_b)
+	road_util.create_two_containers(cont_a, cont_b)
 	var pt1 = cont_a.get_roadpoints()[0]
 	var pt2 = cont_b.get_roadpoints()[1]
 
@@ -284,7 +260,7 @@ func test_container_disconnection():
 	cont_a._auto_refresh = false
 	cont_b._auto_refresh = false
 
-	create_two_containers(cont_a, cont_b)
+	road_util.create_two_containers(cont_a, cont_b)
 	var pt1 = cont_a.get_roadpoints()[0]
 	var pt2 = cont_b.get_roadpoints()[1]
 
@@ -336,7 +312,7 @@ func test_container_snap_unsnap():
 	cont_a._auto_refresh = false
 	cont_b._auto_refresh = false
 
-	create_two_containers(cont_a, cont_b)
+	road_util.create_two_containers(cont_a, cont_b)
 	var pt1:RoadPoint = cont_a.get_roadpoints()[0]
 	var pt2:RoadPoint = cont_b.get_roadpoints()[1]
 
@@ -349,7 +325,7 @@ func test_collider_assignmens():
 	var container = add_child_autofree(RoadContainer.new())
 	container.collider_group_name = "test_collider_group"
 	container.collider_meta_name = "test_meta_name"
-	create_oneseg_container(container)
+	road_util.create_oneseg_container(container)
 
 	var _members = get_tree().get_nodes_in_group(container.collider_group_name)
 	assert_true(len(_members)>0, "Should have 1+ segmetns in test group name")

--- a/test/unit/test_road_manager.gd
+++ b/test/unit/test_road_manager.gd
@@ -1,23 +1,13 @@
 extends "res://addons/gut/test.gd"
 
+const RoadUtils = preload("res://test/unit/road_utils.gd")
 
-func create_segment_with_manager():
-	var manager = add_child_autofree(RoadManager.new())
-	var container = autoqfree(RoadContainer.new())
-	var p1 = autoqfree(RoadPoint.new())
-	var p2 = autoqfree(RoadPoint.new())
-	var road_points = [p1, p2]
+var road_util: RoadUtils
 
-	p1.next_pt_init = p1.get_path_to(p2)
-	p2.prior_pt_init = p2.get_path_to(p1)
-
-	assert_eq(container.get_child_count(), 2, "Both RPs added")
-	assert_eq(p1.get_child_count(), 1, "One RoadSegment created")
-	container.rebuild_segments()
-	var segment = p1.get_child(0)
-	assert_true(segment.has_method("is_road_segment"))
-
-	return [manager, container, road_points, segment]
+func before_each():
+	gut.p("ran setup", 2)
+	road_util = RoadUtils.new()
+	road_util.gut = gut
 
 
 func test_create_road_manager():
@@ -25,19 +15,76 @@ func test_create_road_manager():
 	pass_test('nothing tested, passing')
 
 
+func test_manager_signals():
+	var manager:RoadManager = add_child_autofree(RoadManager.new())
+	manager.auto_refresh = false
+	watch_signals(manager)
+	assert_signal_emit_count(manager, "on_road_updated", 0, "Calling setup should not emit any signals")
+	
+	var container = RoadContainer.new()
+	manager.add_child(container)
+	container._auto_refresh = false
+	road_util.create_oneseg_container(container) # won't be built yet
+	
+	# Should have zero calls still, since not built yet
+	assert_signal_emit_count(manager, "on_road_updated", 0, "With refresh off should not have signalled yet")
+	assert_eq(container.get_segments().size(), 0, "Shouldn't have segments yet")
+	container.rebuild_segments()
+	assert_signal_emit_count(manager, "on_road_updated", 1, "Calling setup should emit a single update signal")
+	assert_eq(container.get_segments().size(), 1, "Should have a single segment")
+
+
+## Ensures that if auto refresh is off, segments aren't automatically created
+func test_auto_refresh():
+	var manager:RoadManager = add_child_autofree(RoadManager.new())
+	var container = RoadContainer.new()
+	manager.add_child(container)
+	manager.auto_refresh = false
+	watch_signals(manager)
+	watch_signals(container)
+	
+	road_util.create_oneseg_container(container)
+	
+	assert_signal_emit_count(manager, "on_road_updated", 0, "Should have no segment updates")
+	assert_signal_emit_count(container, "on_road_updated", 0, "Should have no segment updates")
+	
+	manager.density = 20.0
+	
+	assert_signal_emit_count(manager, "on_road_updated", 0, "Should have no segment updates")
+	assert_signal_emit_count(container, "on_road_updated", 0, "Should have no segment updates")
+	
+	# This will call updates in a deferred way, so we must make our own deferred call to run after.
+	manager.auto_refresh = true
+	
+	assert_signal_emit_count(manager, "on_road_updated", 1, "Should have no segment updates")
+	assert_signal_emit_count(container, "on_road_updated", 1, "Should have no segment updates")
+
+
 func test_set_density():
-	pass_test('Not ready')
-	return
-	# Need to setup full tree
-	var res = create_segment_with_manager()
-	var manager = res[0]
-	var container = res[1]
-	var segment = res[3]
-
-	assert_gt(manager.density, 0)
-	assert_eq(container.density, -1)
+	var manager:RoadManager = add_child_autofree(RoadManager.new())
+	manager.auto_refresh = true  # Simulating default editor, no explicit calls to rebuild
+	
+	var container = RoadContainer.new()
+	manager.add_child(container)
+	container.setup_road_container()
+	road_util.create_oneseg_container(container)
+	
+	# Check initial setup
+	var segs := container.get_segments()
+	assert_eq(segs.size(), 1)
+	var segment = segs[0]
+	assert_gt(manager.density, 0.0)
+	assert_eq(container.density, -1.0)
 	assert_eq(segment.density, manager.density)
-
-	manager.density = PI
-	assert_eq(manager.density, PI)
+	
+	# Update the setting
+	watch_signals(container)
+	manager.density = 1.23 # should auto trigger rebuilds
+	assert_signal_emit_count(container, "on_road_updated", 1, "Should have updated segments")
+	
+	segs = container.get_segments()
+	assert_eq(segs.size(), 1, "Should still only havea  single segment")
+	segment = segs[0]
+	assert_eq(manager.density, 1.23)
+	assert_eq(container.density, -1.0)
 	assert_eq(segment.density, manager.density)


### PR DESCRIPTION
This PR primarily adds a new signal to the RoadManager which is a parallel to the RoadContainer's `on_road_updated` signal, as well as an "is_ready" flag which I'm hoping to use in the terrain connector to differentiate between initial startup loading (which should not flatten terrain) and future edits (which should if auto flatten is on). At the moment, each time the terrain is opened it will continue to flatten the falloff range. By having the signal, there's less looping to also setup to respond to updates, although functionally the number of distinct calls is still the same (no grouping of the signals emitted at the RoadManager level).

This also more strictly types the manager's `get_containers()` to specify it only returns Array[RoadContainer], and adds some tests.

