### PR TITLE
Use region and endregion throughout core code

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -1,6 +1,5 @@
 @tool
 @icon("res://addons/road-generator/resources/road_container.png")
-
 class_name RoadContainer
 extends Node3D
 ## The parent node for [RoadPoint]'s and controller of actual geo creation.
@@ -14,6 +13,11 @@ extends Node3D
 ## @tutorial(Getting started): https://github.com/TheDuckCow/godot-road-generator/wiki/A-getting-started-tutorial
 ## @tutorial(Custom Materials Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/Creating-custom-materials
 ## @tutorial(Custom Mesh Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/User-guide:-Custom-road-meshes
+
+
+# ------------------------------------------------------------------------------
+#region Signals/Enums/Const
+# ------------------------------------------------------------------------------
 
 
 ## Emitted when a road segment has been (re)generated, returning the list
@@ -184,7 +188,8 @@ const RoadMaterial = preload("res://addons/road-generator/resources/road_texture
 
 
 # ------------------------------------------------------------------------------
-# Runtime variables
+#endregion
+#region Runtime variables
 # ------------------------------------------------------------------------------
 
 
@@ -226,7 +231,8 @@ var _is_ready := false
 
 
 # ------------------------------------------------------------------------------
-# Setup and export setter/getters
+#endregion
+#region Setup and export setter/getters
 # ------------------------------------------------------------------------------
 
 
@@ -418,7 +424,8 @@ func _set_create_edge_curves(value: bool) -> void:
 
 
 # ------------------------------------------------------------------------------
-# Editor interactions
+#endregion
+#region Editor interactions
 # ------------------------------------------------------------------------------
 
 
@@ -433,7 +440,8 @@ func _notification(what):
 
 
 # ------------------------------------------------------------------------------
-# Container methods
+#endregion
+#region Functions
 # ------------------------------------------------------------------------------
 
 
@@ -562,7 +570,7 @@ func get_closest_edge_road_point(g_search_pos: Vector3)->RoadPoint:
 	return closest_rp
 
 
-# Get Edge RoadPoints that are open and available for connections
+## Get Edge RoadPoints that are open and available for connections
 func get_open_edges()->Array:
 	var rp_edges: Array = []
 	for idx in len(edge_rp_locals):
@@ -583,8 +591,8 @@ func get_open_edges()->Array:
 	return rp_edges
 
 
-# Get Edge RoadPoints that are unavailable for connections. Returns
-# local Edges, target Edges, and target containers.
+## Get Edge RoadPoints that are unavailable for connections. Returns
+## local Edges, target Edges, and target containers.
 func get_connected_edges()->Array:
 	var rp_edges: Array = []
 	for idx in len(edge_rp_locals):
@@ -1011,10 +1019,10 @@ func _process_seg(pt1:RoadPoint, pt2:RoadPoint, low_poly:bool=false) -> Array:
 		return [true, new_seg]
 
 
-# Update the lane_next and lane_prior connections based on tags assigned.
-#
-# Process over each end of "connecting" Lanes, therefore best to iterate
-# over RoadPoints.
+## Update the lane_next and lane_prior connections based on tags assigned.
+##
+## Process over each end of "connecting" Lanes, therefore best to iterate
+## over RoadPoints.
 func update_lane_seg_connections():
 	for obj in get_children():
 		if not obj is RoadPoint:
@@ -1055,7 +1063,7 @@ func update_lane_seg_connections():
 						next_ln.lane_prior = next_ln.get_path_to(prior_ln)
 
 
-# Triggered by adjusting RoadPoint transform in editor via signal connection.
+## Triggered by adjusting RoadPoint transform in editor via signal connection.
 func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 	if not _auto_refresh:
 		_needs_refresh = true
@@ -1120,7 +1128,7 @@ func on_point_update(point:RoadPoint, low_poly:bool) -> void:
 		emit_signal("on_road_updated", segs_updated)
 
 
-# Callback from a modification of a RoadSegment object.
+## Callback from a modification of a RoadSegment object.
 func segment_rebuild(road_segment:RoadSegment):
 	road_segment.check_rebuild()
 
@@ -1184,3 +1192,6 @@ func _exit_tree():
 	#	return
 	#for seg in get_node(segments).get_children():
 	#	seg.queue_free()
+
+#endregion
+# ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -1,12 +1,11 @@
 @tool
 @icon("res://addons/road-generator/resources/road_intersection.png")
-
 ## Center point of an intersection.
 ##
 ## Should be contained within a [RoadContainer] and a sibling to 1+ [RoadPoints].
 ##
 ## @experimental: Currently unused and may change.
-class_name RoadIntersection
+#class_name RoadIntersection # TODO: Re-enable once in actual use
 extends Node3D
 
 

--- a/addons/road-generator/nodes/road_lane.gd
+++ b/addons/road-generator/nodes/road_lane.gd
@@ -1,6 +1,5 @@
 @tool
 @icon("res://addons/road-generator/resources/road_lane.png")
-
 class_name RoadLane
 extends Path3D
 ## Defines a directional lane of traffic for AI with references to adjacent lanes.
@@ -11,15 +10,26 @@ extends Path3D
 ## @tutorial(Using RoadLanes with custom meshes): https://github.com/TheDuckCow/godot-road-generator/wiki/User-guide:-Custom-road-meshes
 ## @tutorial(Procedural demo with agents): https://github.com/TheDuckCow/godot-road-generator/tree/main/demo/procedural_generator
 
-const COLOR_PRIMARY := Color(0.6, 0.3, 0,3)
-const COLOR_START := Color(0.7, 0.7, 0,7)
+# ------------------------------------------------------------------------------
+#region Signals/Enums/Const
+# ------------------------------------------------------------------------------
+
 
 signal on_transform
 
+const COLOR_PRIMARY := Color(0.6, 0.3, 0,3)
+const COLOR_START := Color(0.7, 0.7, 0,7)
+
 
 # ------------------------------------------------------------------------------
-@export_group("Connections")
+#endregion
+#region Export vars
 # ------------------------------------------------------------------------------
+
+
+# -------------------------------------
+@export_group("Connections")
+# -------------------------------------
 
 
 ## Reference to the next left-side [RoadLane] if any, for allowed lane transitions.
@@ -53,9 +63,9 @@ signal on_transform
 @export var lane_prior_tag:String
 
 
-# ------------------------------------------------------------------------------
+# -------------------------------------
 @export_group("Behavior")
-# ------------------------------------------------------------------------------
+# -------------------------------------
 
 ## Visualize this [RoadLane] and its direction in the editor directly.
 @export var draw_in_game = false: get = _get_draw_in_game, set = _set_draw_in_game
@@ -66,9 +76,9 @@ signal on_transform
 @export var auto_free_vehicles: bool = true
 
 
-# ------------------------------------------------------------------------------
+# -------------------------------------
 @export_group("Editor tools")
-# ------------------------------------------------------------------------------
+# -------------------------------------
 
 
 # TODO: remove when moved to Godot 4.4 and changed to simple button
@@ -95,7 +105,8 @@ var _display_fins: bool = false
 
 
 # ------------------------------------------------------------------------------
-# Setup and export setter/getters
+#endregion
+#region Setup and builtin overrides
 # ------------------------------------------------------------------------------
 
 
@@ -110,6 +121,19 @@ func _ready():
 	connect("curve_changed", Callable(self, "curve_changed"))
 	rebuild_geom()
 	#_instantiate_geom()
+
+
+func _exit_tree() -> void:
+	if auto_free_vehicles:
+		for _vehicle in _vehicles_in_lane:
+			if is_instance_valid(_vehicle):
+				_vehicle.call_deferred("queue_free")
+
+
+# ------------------------------------------------------------------------------
+#endregion
+#region Functions
+# ------------------------------------------------------------------------------
 
 
 #TODO: remove when moved to Godot 4.4 and changed to simple button
@@ -257,8 +281,5 @@ func show_fins(value: bool) -> void:
 	rebuild_geom()
 
 
-func _exit_tree() -> void:
-	if auto_free_vehicles:
-		for _vehicle in _vehicles_in_lane:
-			if is_instance_valid(_vehicle):
-				_vehicle.call_deferred("queue_free")
+#endregion
+# ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_lane_agent.gd
+++ b/addons/road-generator/nodes/road_lane_agent.gd
@@ -1,5 +1,6 @@
 @icon("res://addons/road-generator/resources/road_lane_agent.png")
-
+class_name RoadLaneAgent
+extends Node
 ## An agent helper for navigation on [RoadLane]'s.
 ##
 ## Inspired, but does not inherit from, NavigationAgent since this does not rely
@@ -16,8 +17,12 @@
 ##
 ## @tutorial(Intersection demo with agents): https://github.com/TheDuckCow/godot-road-generator/tree/main/demo/intersections
 ## @tutorial(Procedural demo with agents): https://github.com/TheDuckCow/godot-road-generator/tree/main/demo/procedural_generator
-class_name RoadLaneAgent
-extends Node
+
+
+# ------------------------------------------------------------------------------
+#region Signals/Enums/Const/Export/Vars
+# ------------------------------------------------------------------------------
+
 
 signal on_lane_changed(old_lane)
 
@@ -61,6 +66,13 @@ var _did_make_lane_visible := false
 
 const DEBUG_OUT: bool = false
 
+
+# ------------------------------------------------------------------------------
+#endregion
+#region Setup and builtin overrides
+# ------------------------------------------------------------------------------
+
+
 func _ready() -> void:
 	var res = assign_actor()
 	assert(res == OK)
@@ -68,6 +80,13 @@ func _ready() -> void:
 	assert(res == OK)
 	if DEBUG_OUT:
 		print("Finished setup for road lane agent with: ", road_manager, " and ", current_lane)
+
+
+
+# ------------------------------------------------------------------------------
+#endregion
+#region Functions
+# ------------------------------------------------------------------------------
 
 
 func assign_lane(new_lane:RoadLane) -> void:
@@ -331,3 +350,7 @@ func cars_in_lane(lane_change_dir: LaneChangeDir) -> int:
 ## Returns the expect target position based on the closest target pos
 #func get_fwd_tangent_for_position(position: Vector3) -> Vector3:
 #	return Vector3.ZERO
+
+
+#endregion
+# ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_lane_agent.gd
+++ b/addons/road-generator/nodes/road_lane_agent.gd
@@ -317,7 +317,7 @@ func close_to_lane_end(proximity: float, move_dir: MoveDir) -> bool:
 ## the road continues forward (move_dir == 1) or backward (move_dir == -1)
 ## Used for decision to change lanes from transition lanes (as there are no direct connection)
 func find_continued_lane(lane_change_dir: LaneChangeDir, move_dir: MoveDir) -> int:
-	assert ( move_dir != MoveDir.STOP && (lane_change_dir == LaneChangeDir.LEFT || lane_change_dir == LaneChangeDir.RIGHT) )
+	assert(move_dir != MoveDir.STOP && (lane_change_dir == LaneChangeDir.LEFT || lane_change_dir == LaneChangeDir.RIGHT))
 	var _new_lane = current_lane
 	var count:int = 0
 	while true:

--- a/addons/road-generator/nodes/road_manager.gd
+++ b/addons/road-generator/nodes/road_manager.gd
@@ -1,6 +1,5 @@
 @tool
 @icon("res://addons/road-generator/resources/road_manager.png")
-
 class_name RoadManager
 extends Node3D
 ## Manager for all child [RoadContainer]'s.
@@ -13,7 +12,13 @@ extends Node3D
 ## @tutorial(Custom Materials Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/Creating-custom-materials
 ## @tutorial(Custom Mesh Tutorial): https://github.com/TheDuckCow/godot-road-generator/wiki/User-guide:-Custom-road-meshes
 
+
+# ------------------------------------------------------------------------------
+#region Signals/Enums/Const/Exports
+# ------------------------------------------------------------------------------
+
 const RoadMaterial = preload("res://addons/road-generator/resources/road_texture.material")
+
 
 # ------------------------------------------------------------------------------
 # How road meshes are generated
@@ -149,8 +154,10 @@ var _skip_warn_found_rc_child := false
 
 
 # ------------------------------------------------------------------------------
-# Setup and export setter/getters
+#endregion
+#region Setup and builtin overrides
 # ------------------------------------------------------------------------------
+
 
 func _ready():
 	# Without this line, child RoadContainers initialize after
@@ -160,11 +167,6 @@ func _ready():
 
 	# setup_road_container won't work in _ready unless call_deferred is used
 	assign_default_material.call_deferred()
-
-
-func assign_default_material() -> void:
-	if not material_resource:
-		material_resource = RoadMaterial
 
 
 func _get_configuration_warnings() -> PackedStringArray:
@@ -187,17 +189,9 @@ func is_road_manager() -> bool:
 	return true
 
 
-func _ui_refresh_set(value: bool) -> void:
-	if value:
-		call_deferred("rebuild_all_containers")
-	auto_refresh = value
-	for ch in get_containers():
-		# Not an exposed setting on child.
-		ch._auto_refresh = value
-
-
 # ------------------------------------------------------------------------------
-# Setup and export setter/getters
+#endregion
+#region Functions
 # ------------------------------------------------------------------------------
 
 
@@ -220,3 +214,27 @@ func rebuild_all_containers_deferred() -> void:
 	for ch in get_containers():
 		ch._dirty = true
 		ch._dirty_rebuild_deferred()
+
+
+# ------------------------------------------------------------------------------
+#endregion
+#region Internal functions
+# ------------------------------------------------------------------------------
+
+
+func assign_default_material() -> void:
+	if not material_resource:
+		material_resource = RoadMaterial
+
+
+func _ui_refresh_set(value: bool) -> void:
+	if value:
+		call_deferred("rebuild_all_containers")
+	auto_refresh = value
+	for ch in get_containers():
+		# Not an exposed setting on child.
+		ch._auto_refresh = value
+
+
+#endregion
+# ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -1,6 +1,5 @@
 @tool
 @icon("res://addons/road-generator/resources/road_point.png")
-
 class_name RoadPoint
 extends Node3D
 ## Definition for a single point handle, which 2+ road segments connect to.
@@ -8,9 +7,12 @@ extends Node3D
 ## Functionally equivalent to a point along a curve, it defines the cross section
 ## of the road at a particular slice.
 
-signal on_transform(node, low_poly)
+# ------------------------------------------------------------------------------
+#region Signals/Enums/Const
+# ------------------------------------------------------------------------------
 
-const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
+
+signal on_transform(node, low_poly)
 
 enum LaneType {
 	NO_MARKING, # Default no marking placed first, but is last texture UV column.
@@ -52,15 +54,20 @@ enum Alignment {
 	DIVIDER,  ## Ensures the lane direction dividing line is aligned to the RoadPoint
 }
 
+const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
 const UI_TIMEOUT = 50 # Time in ms to delay further refresh updates.
 const COLOR_YELLOW = Color(0.7, 0.7, 0,7)
 const COLOR_RED = Color(0.7, 0.3, 0.3)
 const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPoint.
 
+# ------------------------------------------------------------------------------
+#endregion
+#region Export vars
+# ------------------------------------------------------------------------------
 
-# ------------------------------------------------------------------------------
+# -------------------------------------
 @export_group("Lanes")
-# ------------------------------------------------------------------------------
+# -------------------------------------
 
 
 # TODO: decide whether to do this
@@ -96,9 +103,9 @@ const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPo
 @export var terminated := false: set = _set_terminated
 
 
-# ------------------------------------------------------------------------------
+# -------------------------------------
 @export_group("Road Generation")
-# ------------------------------------------------------------------------------
+# -------------------------------------
 
 
 ## Defines size of the bezier output leading to the prior [RoadPoint].
@@ -139,9 +146,9 @@ const SEG_DIST_MULT: float = 8.0 # How many road widths apart to add next RoadPo
 ## underside will not be generated at all.
 @export var underside_thickness: float = -1.0: set = _set_thickness
 
-# ------------------------------------------------------------------------------
+# -------------------------------------
 @export_group("Internal data")
-# ------------------------------------------------------------------------------
+# -------------------------------------
 
 # TODO: convert these into direct node reference export vars instead of nodepaths
 ## Considered private, not meant for editor or script interaction.[br][br]
@@ -170,7 +177,8 @@ var _is_internal_updating: bool = false # Very special cases to bypass autofix c
 
 
 # ------------------------------------------------------------------------------
-# Setup and export setter/getters
+#endregion
+#region Setup and builtin overrides
 # ------------------------------------------------------------------------------
 
 
@@ -234,7 +242,8 @@ func is_road_point() -> bool:
 
 
 # ------------------------------------------------------------------------------
-# Editor visualizing
+#endregion
+#region Export var callbacks
 # ------------------------------------------------------------------------------
 
 
@@ -392,9 +401,12 @@ func _set_thickness(value: float) -> void:
 		return  # Might not be initialized yet.
 	emit_transform()
 
+
 # ------------------------------------------------------------------------------
-# Editor interactions
+#endregion
+#region Editor interactions
 # ------------------------------------------------------------------------------
+
 
 func _notification(what):
 	if not is_instance_valid(container):
@@ -419,8 +431,10 @@ func emit_transform(low_poly=false):
 
 
 # ------------------------------------------------------------------------------
-# Utilities
+#endregion
+#region Utilities
 # ------------------------------------------------------------------------------
+
 
 ## Checks if this RoadPoint is an open edge connection for its parent container.
 func is_on_edge() -> bool:
@@ -1197,3 +1211,7 @@ func get_thickness():
 	if is_instance_valid(container.get_manager()) and container.get_manager().underside_thickness != -1.0:
 		return container.get_manager().underside_thickness
 	return -1.0
+
+
+#endregion
+# ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -922,7 +922,6 @@ func _build_geo():
 		# Enable shadows. If it has underside then its probably in air and casting some
 		road_mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 
-
 	_create_collisions()
 
 
@@ -1053,7 +1052,7 @@ class GeoLoopInfo:
 
 	## Fills out other parameters based on the ones passed in the constructor
 	func _generate_geo_loop_info():
-		assert (loop < loops)
+		assert(loop < loops)
 
 		# One loop = row of quads left to right across the road, spanning lanes.
 		offset = [float(loop) / float(loops), float(loop + 1) / float(loops)]
@@ -1075,7 +1074,7 @@ class GeoLoopInfo:
 						nf_reverse[NearFar.NEAR] += 1
 						nf_reverse[NearFar.FAR] += 1
 				else:
-					assert (l[1] == RoadPoint.LaneDir.FORWARD)
+					assert(l[1] == RoadPoint.LaneDir.FORWARD)
 			for nf in NearFar.values():
 				if point[nf].alignment == RoadPoint.Alignment.DIVIDER:
 					lane_offset[nf] = nf_reverse[nf]
@@ -1150,7 +1149,7 @@ class GeoLoopInfo:
 			# Assume the start and end lanes are the same for now.
 			var uv_l:float # the left edge of the uv for this lane.
 			var uv_r:float
-			assert (len(uv_mul) == len(RoadPoint.LaneType.values()))
+			assert(len(uv_mul) == len(RoadPoint.LaneType.values()))
 			uv_l = uv_width * uv_mul[lanes[i][0]]
 			uv_r = uv_l + uv_width
 			if lanes[i][0] == RoadPoint.LaneType.TRANSITION_ADD || lanes[i][0] == RoadPoint.LaneType.TRANSITION_REM:
@@ -1377,6 +1376,7 @@ class GeoLoopInfo:
 #region Geo utilities
 # ------------------------------------------------------------------------------
 
+
 static func uv_square(uv_lmr1:float, uv_lmr2:float, uv_y: Array) -> Array:
 	assert( len(uv_y) == 2 )
 	return	[
@@ -1385,6 +1385,7 @@ static func uv_square(uv_lmr1:float, uv_lmr2:float, uv_y: Array) -> Array:
 			Vector2(uv_lmr2, uv_y[NearFar.NEAR]),
 			Vector2(uv_lmr1, uv_y[NearFar.NEAR]),
 			]
+
 
 static func pts_square(nf_loop:Array, nf_basis:Array, width_offset: Array, y_offset: Array = [], nf_y_dir = [Vector3.UP, Vector3.UP]) -> Array:
 	assert( len(nf_loop) == 2 && len(nf_basis) == 2 )
@@ -1401,6 +1402,7 @@ static func pts_square(nf_loop:Array, nf_basis:Array, width_offset: Array, y_off
 		ret[3] += nf_y_dir[NearFar.NEAR] * y_offset[3]
 
 	return ret
+
 
 # Generate a quad with two triangles for a list of 4 points/uvs in a row.
 # For convention, do cloclwise from top-left vert, where the diagonal
@@ -1428,6 +1430,7 @@ static func quad(st:SurfaceTool, uvs:Array, pts:Array, smoothing_group: int = 0)
 	st.set_uv(uvs[3])
 	st.add_vertex(pts[3])
 
+
 static func inverse_quad(st:SurfaceTool, uvs:Array, pts:Array, smoothing_group: int = 0) -> void:
 	# Triangle 1.
 	st.set_smooth_group(smoothing_group)
@@ -1449,6 +1452,7 @@ static func inverse_quad(st:SurfaceTool, uvs:Array, pts:Array, smoothing_group: 
 	st.set_smooth_group(smoothing_group)
 	st.set_uv(uvs[1])
 	st.add_vertex(pts[1])
+
 
 func _flip_traffic_dir(lanes: Array) -> Array:
 	var _spdir:Array = []
@@ -1658,6 +1662,7 @@ func _match_lanes() -> Array:
 				last_same_i = (i - start_flip_offset)
 
 	return lanes
+
 
 ## Evaluate the lanes of a RoadPoint and return the index of the direction flip
 ## from REVERSE to FORWARD. Return -1 if no flip was found. Also, return the

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1,6 +1,10 @@
 @tool
-## Road and Highway generator addon.
 extends EditorPlugin
+## Road and Highway generator addon.
+
+# ------------------------------------------------------------------------------
+#region Signals/Enums/Const/Vars
+# ------------------------------------------------------------------------------
 
 enum SnapState {
 	IDLE,
@@ -57,6 +61,12 @@ var _edi_debug := false
 var copy_attributes:Dictionary = {}
 
 
+# ------------------------------------------------------------------------------
+#endregion
+#region Setup and builtin overrides
+# ------------------------------------------------------------------------------
+
+
 func _enter_tree():
 	add_node_3d_gizmo_plugin(road_point_gizmo)
 	add_inspector_plugin(road_point_editor)
@@ -102,7 +112,8 @@ func _exit_tree():
 
 
 # ------------------------------------------------------------------------------
-# EditorPlugin overriden methods
+#endregion
+#region EditorPlugin overriden methods
 # ------------------------------------------------------------------------------
 
 
@@ -285,7 +296,8 @@ func _forward_3d_gui_input(camera: Camera3D, event: InputEvent) -> int:
 
 
 # ------------------------------------------------------------------------------
-# Utilities
+#endregion
+#region GUI utilities
 # ------------------------------------------------------------------------------
 
 
@@ -678,7 +690,8 @@ func refresh() -> void:
 
 
 # ------------------------------------------------------------------------------
-# Selection utilities
+#endregion
+#region Selection utilities
 # ------------------------------------------------------------------------------
 
 
@@ -917,7 +930,8 @@ func _handles(object: Object):
 
 
 # ------------------------------------------------------------------------------
-# Create menu handling
+#endregion
+#region Create menu handling
 # ------------------------------------------------------------------------------
 
 
@@ -978,6 +992,12 @@ func _on_regenerate_pressed() -> void:
 	if t_container:
 		t_container.rebuild_segments(true)
 		return
+
+
+# ------------------------------------------------------------------------------
+#endregion
+#region Operations
+# ------------------------------------------------------------------------------
 
 
 func _instance_custom_roadcontainer(path: String) -> void:
@@ -2058,3 +2078,6 @@ func _create_lane_agent_pressed() -> void:
 	undo_redo.add_undo_method(target_parent, "remove_child", agent)
 	undo_redo.add_undo_method(self, "set_selection_list", editor_selected)
 	undo_redo.commit_action()
+
+#endregion
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
For consistency with the recent PR merged on underside geo, this PR adds further regions across the codebase to collapse major sections easily. This also includes some cleanup to ensure more consistent ordering.

There are some cases where we have some "private" functions in ordinarily public places, but to avoid making the diff too large and increasing complexity of other in progress PRs, I only did this in limited places.

End result:

<img width="504" height="410" alt="Screen Shot 2025-09-07 at 9 22 09 PM" src="https://github.com/user-attachments/assets/0606097c-a9ae-4a42-a0d2-1be6a86296ac" />

Thanks to @Visssarion for tipping me off inadvertently to the feature