### PR TITLE
Add ability to lock new road point rotations on x/y/z axes

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -47,6 +47,10 @@ var _nearest_edges: Array # [Selected RP, Target RP]
 var _edge_positions: Array # [edge_from_pos, edge_to_pos]
 var _export_file_dialog: FileDialog
 
+var _lock_x_rotation := false
+var _lock_y_rotation := false
+var _lock_z_rotation := false
+
 var _press_init_pos: Vector2
 
 var _new_selection: Node # RoadPoint or RoadContainer
@@ -923,7 +927,7 @@ func _handles(object: Object):
 
 func _show_road_toolbar() -> void:
 	_road_toolbar.mode = tool_mode
-	_road_toolbar.on_show(_eds.get_selected_nodes())
+	_road_toolbar.on_show(_eds.get_selected_nodes(), _lock_x_rotation, _lock_y_rotation, _lock_z_rotation)
 
 	if not _road_toolbar.get_parent():
 		add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, _road_toolbar)
@@ -941,9 +945,20 @@ func _show_road_toolbar() -> void:
 
 		# Specials / prefabs
 		_road_toolbar.create_menu.create_2x2_road.connect(_create_2x2_road_pressed)
-		
+
 		# Aditional tools
 		_road_toolbar.create_menu.export_mesh.connect(_export_mesh_modal)
+
+		# Locking rotations
+		_road_toolbar.create_menu.lock_rotation_x_toggled.connect(
+			func(value): _lock_x_rotation = value
+		)
+		_road_toolbar.create_menu.lock_rotation_y_toggled.connect(
+			func(value): _lock_y_rotation = value
+		)
+		_road_toolbar.create_menu.lock_rotation_z_toggled.connect(
+			func(value): _lock_z_rotation = value
+		)
 
 
 func _hide_road_toolbar() -> void:
@@ -1256,6 +1271,13 @@ func _add_next_rp_on_click_do(pos: Vector3, nrm: Vector3, selection: Node, paren
 			else:
 				look_pos += selection.global_transform.basis.z * selection.prior_mag
 			next_rp.look_at(look_pos, nrm)
+
+			if _lock_x_rotation:
+				next_rp.global_rotation.x = 0.0
+			if _lock_y_rotation:
+				next_rp.global_rotation.y = 0.0
+			if _lock_z_rotation:
+				next_rp.global_rotation.z = 0.0
 
 	set_selection(next_rp)
 
@@ -1621,7 +1643,7 @@ func _snap_to_road_point(selected:RoadContainer, sel_rp:RoadPoint, tgt_rp:RoadPo
 
 	# This just means we're cancelling the user's movement efforts, so put back without undo
 	if is_cancelling:
-		sel_rp.container = tgt_transform
+		sel_rp.container.transform = tgt_transform
 		return
 
 	undo_redo.create_action("Snap RoadContainer to RoadPoint")

--- a/addons/road-generator/ui/road_toolbar.gd
+++ b/addons/road-generator/ui/road_toolbar.gd
@@ -38,14 +38,19 @@ func update_refs():
 	create_menu = $CreateMenu
 
 
-func on_show(_selected_nodes: Array):
+func on_show(
+	_selected_nodes: Array,
+	x_rotation_locked: bool,
+	y_rotation_locked: bool,
+	z_rotation_locked: bool
+) -> void:
 	selected_nodes = _selected_nodes
 
 	var primary_sel = null
 	var is_subscene := false
 	if len(selected_nodes) > 0:
 		primary_sel = selected_nodes[0]
-	create_menu.on_toolbar_show(primary_sel)
+	create_menu.on_toolbar_show(primary_sel, x_rotation_locked, y_rotation_locked, z_rotation_locked)
 
 
 func update_icons():

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -1,13 +1,6 @@
 @tool
 extends MenuButton
 
-const ICN_CT = preload("../resources/road_container.png")
-const ICN_RP = preload("../resources/road_point.png")
-const ICN_LN = preload("../resources/road_lane.png")
-const ICN_AG = preload("../resources/road_lane_agent.png")
-const RcSubMenu = preload("./rc_submenu.gd")
-
-
 signal regenerate_pressed
 signal select_container_pressed
 signal create_container
@@ -16,10 +9,12 @@ signal create_lane
 signal create_lane_agent
 signal create_2x2_road
 signal export_mesh
+signal lock_rotation_x_toggled(locked: bool)
+signal lock_rotation_y_toggled(locked: bool)
+signal lock_rotation_z_toggled(locked: bool)
 
 # ripple up from children
 signal pressed_add_custom_roadcontainer(path)
-
 
 enum CreateMenu {
 	REGENERATE,
@@ -29,40 +24,57 @@ enum CreateMenu {
 	LANE,
 	LANEAGENT,
 	TWO_X_TWO,
-	EXPORT_MESH
+	EXPORT_MESH,
+	LOCK_ROTATION_X,
+	LOCK_ROTATION_Y,
+	LOCK_ROTATION_Z,
 }
 
 enum MenuMode {
 	STANDARD,
-	SAVED_SUBSCENE, # Don't offer to create children
-	EDGE_SELECTED, # Not yet used, could offer intersections/next pieces to add.
+	SAVED_SUBSCENE,  # Don't offer to create children
+	EDGE_SELECTED,  # Not yet used, could offer intersections/next pieces to add.
 }
+
+const ICN_CT = preload("../resources/road_container.png")
+const ICN_RP = preload("../resources/road_point.png")
+const ICN_LN = preload("../resources/road_lane.png")
+const ICN_AG = preload("../resources/road_lane_agent.png")
+const RcSubMenu = preload("./rc_submenu.gd")
 
 var menu_mode = MenuMode.STANDARD
 var rc_submenu: PopupMenu
 
 
 func _enter_tree() -> void:
-	var pup:Popup = get_popup()
-	pup.connect("id_pressed", Callable(self, "_create_menu_item_clicked"))
+	var pup: Popup = get_popup()
+
+	pup.id_pressed.connect(_create_menu_item_clicked)
+
 	if not is_instance_valid(rc_submenu):
 		load_submenu()
 
 
 func load_submenu() -> void:
-	var pup:Popup = get_popup()
+	var pup: Popup = get_popup()
 	rc_submenu = RcSubMenu.new()
 	rc_submenu.pressed_add_custom_roadcontainer.connect(_on_pressed_add_custom_roadcontainer)
 	pup.add_child(rc_submenu)
 
 
-func on_toolbar_show(primary_sel: Node) -> void:
+func on_toolbar_show(
+	primary_sel: Node, x_rotation_locked: bool, y_rotation_locked: bool, z_rotation_locked: bool
+) -> void:
 	if primary_sel.has_method("is_subscene") and primary_sel.is_subscene():
 		menu_mode = MenuMode.SAVED_SUBSCENE
 	else:
 		menu_mode = MenuMode.STANDARD
 
-	var pup:PopupMenu = get_popup()
+	var pup: PopupMenu = get_popup()
+
+	# this prevents the menu from closing when a check item is clicked
+	pup.hide_on_checkable_item_selection = false
+
 	var idx = 0
 	pup.clear()
 
@@ -76,7 +88,7 @@ func on_toolbar_show(primary_sel: Node) -> void:
 	#if menu_mode == MenuMode.SAVED_SUBSCENE:
 	#	# Don't offer to modify subscenes
 	#	return
-	
+
 	# Set icon width so that it's scaled for the UI properly
 	# Though it would seem like DisplayServer.screen_get_scale() would be good to
 	# use, it seems that the icon scale is already correctly handled on mac OSX
@@ -87,65 +99,106 @@ func on_toolbar_show(primary_sel: Node) -> void:
 
 	pup.add_separator()
 	idx += 1
+
 	pup.add_icon_item(ICN_CT, "RoadContainer", CreateMenu.CONTAINER)
 	pup.set_item_icon_max_width(idx, width)
 	pup.set_item_tooltip(idx, "Adds a RoadContianer child to RoadManager")
 	idx += 1
+
 	pup.add_icon_item(ICN_RP, "RoadPoint", CreateMenu.POINT)
 	pup.set_item_icon_max_width(idx, width)
 	pup.set_item_tooltip(idx, "Adds a new RoadPoint")
 	idx += 1
+
 	pup.add_icon_item(ICN_LN, "RoadLane (AI path)", CreateMenu.LANE)
 	pup.set_item_icon_max_width(idx, width)
 	pup.set_item_tooltip(idx, "Adds a RoadLane which can be used for AI paths")
 	idx += 1
+
 	pup.add_icon_item(ICN_AG, "RoadLaneAgent (AI)", CreateMenu.LANEAGENT)
 	pup.set_item_icon_max_width(idx, width)
 	pup.set_item_tooltip(idx, "Adds a RoadLaneAgent to follow RoadLane paths")
 	idx += 1
+
 	pup.add_separator()
 	idx += 1
+
 	pup.add_item("2x2 road", CreateMenu.TWO_X_TWO)
 	pup.set_item_tooltip(idx, "Adds a segment of road with 2 lanes each way")
 	idx += 1
+
 	# rc_items must be name of the child of this menu
 	if not is_instance_valid(rc_submenu):
 		load_submenu()
+
 	rc_submenu.name = "rc_items"
 	pup.add_submenu_item("RoadContainer presets", "rc_items", idx)
 	idx += 1
-	
-	pup.add_separator()
-	pup.add_item("Export RoadContainer", CreateMenu.EXPORT_MESH)
+
+	pup.add_separator("Lock new node rotation?")
 	idx += 1
+
+	pup.add_check_item("Lock X", CreateMenu.LOCK_ROTATION_X)
+	pup.set_item_checked(idx, x_rotation_locked)
+	idx += 1
+
+	pup.add_check_item("Lock Y", CreateMenu.LOCK_ROTATION_Y2)
+	pup.set_item_checked(idx, y_rotation_locked)
+	idx += 1
+
+	pup.add_check_item("Lock Z", CreateMenu.LOCK_ROTATION_Z)
+	pup.set_item_checked(idx, z_rotation_locked)
+	idx += 1
+
+	pup.add_separator()
+	idx += 1
+
+	pup.add_item("Export RoadContainer", CreateMenu.EXPORT_MESH)
 	if not primary_sel is RoadContainer:
 		pup.set_item_disabled(idx, true)
-		
 
 
 func _exit_tree() -> void:
-	get_popup().disconnect("id_pressed", Callable(self, "_create_menu_item_clicked"))
+	get_popup().id_pressed.disconnect(_create_menu_item_clicked)
 
 
 func _create_menu_item_clicked(id: int) -> void:
 	match id:
 		CreateMenu.REGENERATE:
-			emit_signal("regenerate_pressed")
+			regenerate_pressed.emit()
 		CreateMenu.SELECT_CONTAINER:
-			emit_signal("select_container_pressed")
+			select_container_pressed.emit()
 		CreateMenu.CONTAINER:
-			emit_signal("create_container")
+			create_container.emit()
 		CreateMenu.POINT:
-			emit_signal("create_roadpoint")
+			create_roadpoint.emit()
 		CreateMenu.LANE:
-			emit_signal("create_lane")
+			create_lane.emit()
 		CreateMenu.LANEAGENT:
-			emit_signal("create_lane_agent")
+			create_lane_agent.emit()
 		CreateMenu.TWO_X_TWO:
-			emit_signal("create_2x2_road")
+			create_2x2_road.emit()
 		CreateMenu.EXPORT_MESH:
-			emit_signal("export_mesh")
+			export_mesh.emit()
+		CreateMenu.LOCK_ROTATION_X:
+			var new_checked = _toggle_check_item(id)
+			lock_rotation_x_toggled.emit(new_checked)
+		CreateMenu.LOCK_ROTATION_Y:
+			var new_checked = _toggle_check_item(id)
+			lock_rotation_y_toggled.emit(new_checked)
+		CreateMenu.LOCK_ROTATION_Z:
+			var new_checked = _toggle_check_item(id)
+			lock_rotation_z_toggled.emit(new_checked)
 
 
-func _on_pressed_add_custom_roadcontainer(path:String) -> void:
+## Toggle the given check item and return its new state
+func _toggle_check_item(id: int) -> bool:
+	var pup: PopupMenu = get_popup()
+	var index = pup.get_item_index(id)
+	var new_checked = not pup.is_item_checked(index)
+	pup.set_item_checked(index, new_checked)
+	return new_checked
+
+
+func _on_pressed_add_custom_roadcontainer(path: String) -> void:
 	pressed_add_custom_roadcontainer.emit(path)

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -26,7 +26,7 @@ enum CreateMenu {
 	TWO_X_TWO,
 	EXPORT_MESH,
 	LOCK_ROTATION_X,
-	LOCK_ROTATION_Y,
+	LOCK_ROTATION_Y = 90,  # for some reason, this being `9` breaks the checkbox
 	LOCK_ROTATION_Z,
 }
 
@@ -142,7 +142,7 @@ func on_toolbar_show(
 	pup.set_item_checked(idx, x_rotation_locked)
 	idx += 1
 
-	pup.add_check_item("Lock Y", CreateMenu.LOCK_ROTATION_Y2)
+	pup.add_check_item("Lock Y", CreateMenu.LOCK_ROTATION_Y)
 	pup.set_item_checked(idx, y_rotation_locked)
 	idx += 1
 


### PR DESCRIPTION
<img width="884" height="478" alt="Screenshot 2025-09-14 at 3 39 32 PM" src="https://github.com/user-attachments/assets/7d391120-ddea-402d-b8c3-6f27fbadedaa" />

Whenever adding new road points by clicking, I would often get them with tiny variations in the X/Z rotation (i.e. `-0.2`). These subtle variations would add up over time, resulting in twisted roads. For more "sensitive" vehicle implementations, this can cause issues.

I figured adding checkboxes to the road menu to lock the rotation would be a decent workaround without changing any default behavior.