### PR TITLE
Fixing nodepath reference on project open

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -474,7 +474,7 @@ func get_manager(): # -> Optional[RoadManager]
 	var _this_manager = null
 	var _last_par = get_parent()
 	while true:
-		if _last_par == null:
+		if _last_par == null or not _last_par.is_inside_tree():
 			break
 		if _last_par.get_path() == ^"/root":
 			break


### PR DESCRIPTION
This commit fixes an issue which would lead to many printouts to the console, about 2 per road container or more, saying`  ERROR: Cannot get path of node as it is not in a scene tree.`. This would happen when you open your godot project and had multiple open scenes, and at least one of those _other_ scenes that is not the initially active one by default has at least 1 RoadContainer in it. Could potential impact the way a default material is assigned (which is why this function is called where it is), but so far haven't seen any real consequence to this, especially since that would always happen in the context of the editor in a live scene.

Closes #251 