### PR TITLE
Add+remove intersection branch

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -831,7 +831,7 @@ func validate_edges(autofix: bool = false) -> bool:
 				_invalidate_edge(_idx, autofix, "next_pt_init should be empty for this edge's next pt")
 				continue
 			else:
-				target = this_pt.get_next_rp()
+				target = this_pt.get_next_road_node()
 		elif this_dir == this_pt.PointInit.PRIOR:
 			if this_pt.prior_pt_init != ^"":
 				# Shouldn't be marked as connecting to another local pt, "" indicates edge pt.
@@ -839,7 +839,7 @@ func validate_edges(autofix: bool = false) -> bool:
 				_invalidate_edge(_idx, autofix, "prior_pt_init should be empty for this edge's prior pt")
 				continue
 			else:
-				target = this_pt.get_prior_rp()
+				target = this_pt.get_prior_road_node()
 		elif this_dir == -1:
 			# The local dir should never be -1, since it's defined locally.
 			is_valid = false
@@ -1169,8 +1169,8 @@ func on_point_update(node:RoadGraphNode, low_poly:bool) -> void:
 		return
 	var point: RoadPoint = node as RoadPoint
 	if point.is_on_edge():
-		#var prior = point.get_prior_rp()
-		#var next = point.get_next_rp()
+		#var prior = point.get_prior_road_node()
+		#var next = point.get_next_road_node()
 		# TODO: Need to trigger transform updates on these nodes,
 		# without triggering emit_transform etc, these turn into infinite loops or godot crashes
 		#if is_instance_valid(prior) and prior.container != self:

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -472,10 +472,10 @@ func is_on_edge() -> bool:
 func cross_container_connected() -> bool:
 	if not is_on_edge():
 		return false
-	var _pr = get_prior_rp()
+	var _pr = get_prior_road_node()
 	if is_instance_valid(_pr) and _pr.container != self.container:
 		return true
-	var _nt = get_next_rp()
+	var _nt = get_next_road_node()
 	if is_instance_valid(_nt) and _nt.container != self.container:
 		return true
 	return false
@@ -513,8 +513,13 @@ func is_next_connected() -> bool:
 	return false
 
 
-## Returns prior RP direct reference, accounting for cross-container connections
+## Deprecated in favor of get_next_graphnode
 func get_prior_rp():
+	return get_prior_road_node()
+
+
+## Returns prior RP direct reference, accounting for cross-container connections
+func get_prior_road_node() -> RoadGraphNode:
 	if self.prior_pt_init:
 		return get_node(prior_pt_init)
 	# If no sibling point, could still have a cross-container connection
@@ -528,12 +533,17 @@ func get_prior_rp():
 		var target_container = container.get_node(container.edge_containers[_idx])
 		return target_container.get_node(container.edge_rp_targets[_idx])
 	if not self.terminated:
-		push_warning("RP should have been present in container edge list (get_prior_rp)")
+		push_warning("RP should have been present in container edge list (get_prior_road_node)")
 	return null
 
 
-## Returns prior RP direct reference, accounting for cross-container connections
+## Deprecated in favor of get_next_graphnode
 func get_next_rp():
+	return get_next_road_node()
+
+
+## Returns next RP direct reference, accounting for cross-container connections
+func get_next_road_node() -> RoadGraphNode:
 	if self.next_pt_init:
 		return get_node(next_pt_init)
 	# If no sibling point, could still have a cross-container connection
@@ -547,7 +557,7 @@ func get_next_rp():
 		var target_container = container.get_node(container.edge_containers[_idx])
 		return target_container.get_node(container.edge_rp_targets[_idx])
 	if not self.terminated:
-		push_warning("RP should have been present in container edge list (get_next_rp)")
+		push_warning("RP should have been present in container edge list (get_next_road_node)")
 	return null
 
 

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -540,12 +540,12 @@ func _handle_gui_add_mode(camera: Camera3D, event: InputEvent) -> int:
 				_overlay_rp_hovering = null
 				_overlay_hint_disconnect = false
 				_overlay_hint_connection = false
-			elif target.get_prior_rp() == point:
+			elif target.get_prior_road_node() == point:
 				# If this pt is directly connected to the target, offer quick dis-connect tool
 				_overlay_rp_selected = target
 				_overlay_hint_disconnect = true
 				_overlay_hint_connection = false
-			elif target.get_next_rp() == point:
+			elif target.get_next_road_node() == point:
 				# If this pt is directly connected to the selection, offer quick dis-connect tool
 				_overlay_rp_selected = target
 				_overlay_hint_disconnect = true
@@ -1498,16 +1498,16 @@ func _disconnect_rp_on_click(rp_a, rp_b):
 
 	var from_dir
 	var target_dir
-	if rp_a.get_prior_rp() == rp_b:
+	if rp_a.get_prior_road_node() == rp_b:
 		from_dir = RoadPoint.PointInit.PRIOR
-	elif rp_a.get_next_rp() == rp_b:
+	elif rp_a.get_next_road_node() == rp_b:
 		from_dir = RoadPoint.PointInit.NEXT
 	else:
 		push_error("Not initially connected")
 		return
-	if rp_b.get_prior_rp() == rp_a:
+	if rp_b.get_prior_road_node() == rp_a:
 		target_dir = RoadPoint.PointInit.PRIOR
-	elif rp_b.get_next_rp() == rp_a:
+	elif rp_b.get_next_road_node() == rp_a:
 		target_dir = RoadPoint.PointInit.NEXT
 	else:
 		push_error("Not initially connected")
@@ -1752,8 +1752,8 @@ func subaction_flip_roadpoint(rp: RoadPoint, undo_redo:EditorUndoRedoManager) ->
 		undo_redo.add_undo_property(rp.container, "edge_rp_local_dirs", edge_rp_local_dirs_old)
 		
 		# Check if cross-container connected at this RP and grab container if so
-		var _pr = rp.get_prior_rp()
-		var _nt = rp.get_next_rp()
+		var _pr = rp.get_prior_road_node()
+		var _nt = rp.get_next_road_node()
 		var other_cont:RoadContainer
 		if is_instance_valid(_pr) and _pr.container != rp.container:
 			other_cont = _pr.container

--- a/addons/road-generator/ui/road_intersection_gizmo.gd
+++ b/addons/road-generator/ui/road_intersection_gizmo.gd
@@ -76,7 +76,6 @@ func _redraw(gizmo) -> void:
 		collider.bottom_radius = prior_lane_width_avg / 2.0  # resulting
 		collider.top_radius = prior_lane_width_avg / 2.0
 		collider.height = prior_lane_width_avg / 20.0
-		print("Applying new RoadIntersection gizmo scale: ", prior_lane_width_avg)
 	
 	intersection_widget.visible = true
 	intersection_widget.transform = intersection.global_transform

--- a/demo/procedural_generator/procedural_generator.gd
+++ b/demo/procedural_generator/procedural_generator.gd
@@ -67,7 +67,7 @@ func update_road() -> void:
 
 ## Manually clear prior/next points to ensure it gets fully disconnected
 func remove_rp(edge_rp: RoadPoint, dir: int) -> void:
-	var next_edge_rp: RoadPoint = edge_rp.get_next_rp() if dir == RoadPoint.PointInit.PRIOR else edge_rp.get_prior_rp()
+	var next_edge_rp: RoadPoint = edge_rp.get_next_road_node() if dir == RoadPoint.PointInit.PRIOR else edge_rp.get_prior_road_node()
 	var flip_dir: int = RoadPoint.PointInit.NEXT if dir == RoadPoint.PointInit.PRIOR else RoadPoint.PointInit.PRIOR
 	var spawner = edge_rp.get_node("ActorSpawner")
 	assert(spawner)

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -35,10 +35,15 @@ func create_intersection_two_branch(container):
 	var i1 = autoqfree(RoadIntersection.new())
 	var p1 = autoqfree(RoadPoint.new())
 	var p2 = autoqfree(RoadPoint.new())
+	p1.name = "p1"
+	p2.name = "p2"
 
 	container.add_child(i1)
 	container.add_child(p1)
 	container.add_child(p2)
+	p1.position.z -= 10
+	
+	p2.position.z += 10
 	assert_eq(container.get_child_count(), 3, "All graph nodes added")
 
 	var edges: Array[RoadPoint] = [p1, p2]


### PR DESCRIPTION
Fully implement functioning add+remove intersection branch functions.

Complete with automated tests to ensure RoadPoints are properly connected and the appropriate signals are emitted.

Need to still check I actually got the forward/reverse directions right, but will be obvious in the next steps when using with the actual connect tool, which is the next steps.

Also marked `get_prior_rp` and `get_next_rp` as deprecated in favor of the renamed function doing the same, but also allowing to return intersection nodes.