### PR TITLE
Extended performance demo with samples and options

### DIFF
--- a/road_demos/performance_stress_test/performance_stress_test.gd
+++ b/road_demos/performance_stress_test/performance_stress_test.gd
@@ -9,12 +9,13 @@ extends Node3D
 @onready var update_btn := %update
 @onready var sample_input := %sample_input
 
+var init_update_btn_txt: String
 var rebuild_count := 0
 var samples := []
 
 
 func _ready() -> void:
-	run_rebuild()
+	init_update_btn_txt = update_btn.text
 
 
 func update_settings() -> void:
@@ -26,11 +27,12 @@ func update_settings() -> void:
 		rc.create_edge_curves = edges_btn.button_pressed
 		rc.create_geo = geo_btn.button_pressed
 		rc.underside_thickness = 2 if underside_btn.button_pressed else -1
-		
+		# Always ensure using full geo
 		rc.use_lowpoly_preview = false
 
 
 func run_rebuild() -> void:
+	set_update_disabled()
 	print("Running rebuild")
 	update_settings()
 	var containers := manager.get_containers()
@@ -60,12 +62,13 @@ func run_rebuild() -> void:
 		"underside" if underside_btn.button_pressed else "no underside",
 		
 	]
-	var line1 := "Averge time to generate containers: %s ms over %s samples" % [
+	var line1 := "Generation time: %s ms over %s samples" % [
 		total_sample_time / samples.size(), samples.size()]
-	var line2 := "%sx segment rebuilds with %s" % [rebuild_count, settings_txt]
-	print(line1)
-	print(line2)
-	label.text = "%s\n%s" % [line1, line2]
+	var line2 := "%sx segments built across %s containers" % [rebuild_count, containers.size()]
+	var line3 := "Configuration: %s" % settings_txt
+	var msg = "%s\n\n%s\n%s" % [line1, line2, line3]
+	label.text = msg
+	print(msg)
 	assert(rebuild_count == seg_counts)
 
 
@@ -75,6 +78,12 @@ func _roads_updated(segments: Array) -> void:
 
 func _on_update_pressed() -> void:
 	samples = []
+	set_update_disabled()
+
+
+func set_update_disabled() -> void:
+	update_btn.disabled
+	update_btn.text = "Generating..."
 
 
 func _physics_process(delta: float) -> void:
@@ -82,3 +91,5 @@ func _physics_process(delta: float) -> void:
 		run_rebuild()
 		if samples.size() == sample_input.value:
 			print("Completed samples")
+			update_btn.disabled = false
+			update_btn.text = init_update_btn_txt

--- a/road_demos/performance_stress_test/performance_stress_test.gd
+++ b/road_demos/performance_stress_test/performance_stress_test.gd
@@ -1,30 +1,84 @@
 extends Node3D
 
-@export var label: Label
-
+@onready var label := %results
 @onready var manager:RoadManager = $RoadManager
+@onready var edges_btn := %edges
+@onready var lanes_btn := %lanes
+@onready var geo_btn := %geo
+@onready var underside_btn := %underside
+@onready var update_btn := %update
+@onready var sample_input := %sample_input
 
 var rebuild_count := 0
+var samples := []
+
 
 func _ready() -> void:
+	run_rebuild()
+
+
+func update_settings() -> void:
 	var containers := manager.get_containers()
 	var seg_counts := 0
 	for _node in containers:
+		var rc := _node as RoadContainer
+		rc.generate_ai_lanes = lanes_btn.button_pressed
+		rc.create_edge_curves = edges_btn.button_pressed
+		rc.create_geo = geo_btn.button_pressed
+		rc.underside_thickness = 2 if underside_btn.button_pressed else -1
+		
+		rc.use_lowpoly_preview = false
+
+
+func run_rebuild() -> void:
+	print("Running rebuild")
+	update_settings()
+	var containers := manager.get_containers()
+	var seg_counts := 0
+	rebuild_count = 0
+	for _node in containers:
 		var _cont: RoadContainer = _node
-		var res = _cont.on_road_updated.connect(_roads_updated)
-		assert(res == OK)
+		if not _cont.on_road_updated.is_connected(_roads_updated):
+			var res = _cont.on_road_updated.connect(_roads_updated)
+			assert(res == OK)
 		seg_counts += len(_cont.get_segments())
 
 	var _time_start := Time.get_ticks_msec()
 	manager.rebuild_all_containers(true)
-	var _time_postgen = Time.get_ticks_msec()
-	var line1 = "Time to generate containers: %s ms" % (_time_postgen - _time_start)
-	var line2 = "%sx segment rebuilds compared to %s actual segments" % [rebuild_count, seg_counts]
+	var _time_postgen := Time.get_ticks_msec()
+	
+	var sample_time := _time_postgen - _time_start
+	samples.append(sample_time)
+	var total_sample_time := 0
+	for _sample in samples:
+		total_sample_time += _sample
+	
+	var settings_txt := "%s, %s, %s, %s" % [
+		"AI lanes" if lanes_btn.button_pressed else "no AI lanes",
+		"edge curves" if edges_btn.button_pressed else "no edge curves",
+		"geo" if geo_btn.button_pressed else "no geo",
+		"underside" if underside_btn.button_pressed else "no underside",
+		
+	]
+	var line1 := "Averge time to generate containers: %s ms over %s samples" % [
+		total_sample_time / samples.size(), samples.size()]
+	var line2 := "%sx segment rebuilds with %s" % [rebuild_count, settings_txt]
 	print(line1)
-	print(line1)
+	print(line2)
 	label.text = "%s\n%s" % [line1, line2]
 	assert(rebuild_count == seg_counts)
 
 
 func _roads_updated(segments: Array) -> void:
 	rebuild_count += len(segments)
+
+
+func _on_update_pressed() -> void:
+	samples = []
+
+
+func _physics_process(delta: float) -> void:
+	if samples.size() < sample_input.value:
+		run_rebuild()
+		if samples.size() == sample_input.value:
+			print("Completed samples")

--- a/road_demos/performance_stress_test/performance_stress_test.tscn
+++ b/road_demos/performance_stress_test/performance_stress_test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://crx2pjy5t6xpn"]
+[gd_scene load_steps=10 format=3 uid="uid://crx2pjy5t6xpn"]
 
 [ext_resource type="Script" uid="uid://cph7euje06kel" path="res://addons/road-generator/nodes/road_container.gd" id="1"]
 [ext_resource type="Material" uid="uid://dpashsuk5lr4x" path="res://addons/road-generator/resources/road_texture.material" id="2"]
@@ -8,12 +8,9 @@
 [ext_resource type="Script" uid="uid://difs1qg4mpcpw" path="res://addons/road-generator/nodes/road_point.gd" id="4"]
 [ext_resource type="Script" uid="uid://donsa8sn2uump" path="res://road_demos/performance_stress_test/performance_stress_test.gd" id="5"]
 
-[sub_resource type="Curve" id="Curve_7642f"]
-_data = [Vector2(0.222426, 0), 0.0, 0.0, 0, 0, Vector2(0.900735, 1), 0.0, 0.0, 0, 0]
-point_count = 2
-
-[sub_resource type="CurveTexture" id="CurveTexture_odh0v"]
-curve = SubResource("Curve_7642f")
+[sub_resource type="Theme" id="Theme_7642f"]
+LineEdit/font_sizes/font_size = 30
+SpinBox/constants/buttons_width = 30
 
 [sub_resource type="PlaneMesh" id="1"]
 size = Vector2(800, 700)
@@ -30,22 +27,38 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("2_rn5x3")
 
-[node name="TextureRect" type="TextureRect" parent="UI"]
-modulate = Color(1, 1, 1, 0.360784)
+[node name="TextureRect" type="ColorRect" parent="UI"]
+modulate = Color(1, 1, 1, 0.588235)
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-texture = SubResource("CurveTexture_odh0v")
+color = Color(0, 0, 0, 1)
 
-[node name="MarginContainer" type="MarginContainer" parent="UI"]
-custom_minimum_size = Vector2(100, 0)
+[node name="MarginContainer2" type="MarginContainer" parent="UI"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = -20
+theme_override_constants/margin_bottom = -20
+
+[node name="DemoUiCommon" parent="UI/MarginContainer2" instance=ExtResource("2_brvyu")]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="UI"]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.2
+anchor_top = 0.2
+anchor_right = 0.8
+anchor_bottom = 0.8
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/margin_left = 20
@@ -56,10 +69,8 @@ theme_override_constants/margin_bottom = 20
 [node name="VBoxContainer" type="VBoxContainer" parent="UI/MarginContainer"]
 layout_mode = 2
 
-[node name="DemoUiCommon" parent="UI/MarginContainer/VBoxContainer" instance=ExtResource("2_brvyu")]
-layout_mode = 2
-
 [node name="spacer" type="Control" parent="UI/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="UI/MarginContainer/VBoxContainer"]
@@ -73,20 +84,32 @@ theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/shadow_offset_y = 3
 theme_override_constants/shadow_outline_size = 4
 theme_override_font_sizes/font_size = 30
-text = "Samples"
+text = "Use "
 
 [node name="Control" type="Control" parent="UI/MarginContainer/VBoxContainer/HBoxContainer"]
+visible = false
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 
 [node name="sample_input" type="SpinBox" parent="UI/MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+theme = SubResource("Theme_7642f")
 min_value = 1.0
 max_value = 99.39
 value = 5.0
 rounded = true
 allow_greater = true
+
+[node name="samples2" type="Label" parent="UI/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_y = 3
+theme_override_constants/shadow_outline_size = 4
+theme_override_font_sizes/font_size = 30
+text = "samples"
 
 [node name="enable" type="Label" parent="UI/MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -100,19 +123,7 @@ text = "Enable features"
 
 [node name="options" type="HBoxContainer" parent="UI/MarginContainer/VBoxContainer"]
 layout_mode = 2
-theme_override_constants/separation = 15
-
-[node name="edges" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
-unique_name_in_owner = true
-layout_mode = 2
-toggle_mode = true
-text = "Edge curves"
-
-[node name="lanes" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
-unique_name_in_owner = true
-layout_mode = 2
-toggle_mode = true
-text = "AI Lanes"
+theme_override_constants/separation = 10
 
 [node name="geo" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
 unique_name_in_owner = true
@@ -127,24 +138,37 @@ layout_mode = 2
 toggle_mode = true
 text = "Underside"
 
+[node name="edges" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+text = "Edge curves"
+
+[node name="lanes" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+text = "AI Lanes"
+
 [node name="spacer2" type="Control" parent="UI/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
 [node name="update" type="Button" parent="UI/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 text = "Regenerate"
 
-[node name="results" type="Label" parent="UI/MarginContainer/VBoxContainer"]
+[node name="spacer3" type="Control" parent="UI/MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+
+[node name="results" type="RichTextLabel" parent="UI/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/shadow_offset_y = 3
-theme_override_constants/shadow_outline_size = 4
-theme_override_font_sizes/font_size = 30
-text = "Loading..."
+theme_override_font_sizes/normal_font_size = 30
+text = "Pending results..."
+fit_content = true
 
 [node name="RoadManager" type="Node3D" parent="."]
 script = ExtResource("3")

--- a/road_demos/performance_stress_test/performance_stress_test.tscn
+++ b/road_demos/performance_stress_test/performance_stress_test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://crx2pjy5t6xpn"]
+[gd_scene load_steps=11 format=3 uid="uid://crx2pjy5t6xpn"]
 
 [ext_resource type="Script" uid="uid://cph7euje06kel" path="res://addons/road-generator/nodes/road_container.gd" id="1"]
 [ext_resource type="Material" uid="uid://dpashsuk5lr4x" path="res://addons/road-generator/resources/road_texture.material" id="2"]
@@ -8,12 +8,18 @@
 [ext_resource type="Script" uid="uid://difs1qg4mpcpw" path="res://addons/road-generator/nodes/road_point.gd" id="4"]
 [ext_resource type="Script" uid="uid://donsa8sn2uump" path="res://road_demos/performance_stress_test/performance_stress_test.gd" id="5"]
 
+[sub_resource type="Curve" id="Curve_7642f"]
+_data = [Vector2(0.222426, 0), 0.0, 0.0, 0, 0, Vector2(0.900735, 1), 0.0, 0.0, 0, 0]
+point_count = 2
+
+[sub_resource type="CurveTexture" id="CurveTexture_odh0v"]
+curve = SubResource("Curve_7642f")
+
 [sub_resource type="PlaneMesh" id="1"]
 size = Vector2(800, 700)
 
-[node name="PerformanceStressTest" type="Node3D" node_paths=PackedStringArray("label")]
+[node name="PerformanceStressTest" type="Node3D"]
 script = ExtResource("5")
-label = NodePath("UI/MarginContainer/VBoxContainer/results")
 
 [node name="UI" type="Control" parent="."]
 layout_mode = 3
@@ -24,7 +30,18 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("2_rn5x3")
 
+[node name="TextureRect" type="TextureRect" parent="UI"]
+modulate = Color(1, 1, 1, 0.360784)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = SubResource("CurveTexture_odh0v")
+
 [node name="MarginContainer" type="MarginContainer" parent="UI"]
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -42,7 +59,84 @@ layout_mode = 2
 [node name="DemoUiCommon" parent="UI/MarginContainer/VBoxContainer" instance=ExtResource("2_brvyu")]
 layout_mode = 2
 
+[node name="spacer" type="Control" parent="UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="samples" type="Label" parent="UI/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_y = 3
+theme_override_constants/shadow_outline_size = 4
+theme_override_font_sizes/font_size = 30
+text = "Samples"
+
+[node name="Control" type="Control" parent="UI/MarginContainer/VBoxContainer/HBoxContainer"]
+custom_minimum_size = Vector2(20, 0)
+layout_mode = 2
+
+[node name="sample_input" type="SpinBox" parent="UI/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 1.0
+max_value = 99.39
+value = 5.0
+rounded = true
+allow_greater = true
+
+[node name="enable" type="Label" parent="UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_y = 3
+theme_override_constants/shadow_outline_size = 4
+theme_override_font_sizes/font_size = 30
+text = "Enable features"
+
+[node name="options" type="HBoxContainer" parent="UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="edges" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+text = "Edge curves"
+
+[node name="lanes" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+text = "AI Lanes"
+
+[node name="geo" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+button_pressed = true
+text = "Geo"
+
+[node name="underside" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+text = "Underside"
+
+[node name="spacer2" type="Control" parent="UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="update" type="Button" parent="UI/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Regenerate"
+
 [node name="results" type="Label" parent="UI/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
@@ -792,3 +886,5 @@ skeleton = NodePath("../..")
 transform = Transform3D(0.998786, -0.00470587, -0.0490428, 0.0492681, 0.0953997, 0.994219, 0, -0.995428, 0.0955157, 0, 48.5217, 0)
 directional_shadow_mode = 0
 sky_mode = 1
+
+[connection signal="pressed" from="UI/MarginContainer/VBoxContainer/update" to="." method="_on_update_pressed"]


### PR DESCRIPTION
This makes the stress scene much more useful for actual before/after performance testing. As a result of testing this branch + merging it into a temp branch with the new decorations feature work, I've already determined that the new approach of creating more exact road edge curves is actually *faster* to construct compared to the approximate method (good!). Could be that runtime inference is a bit slower since there's more points, but haven't checked that yet.

Didn't do this yet, in the future will also update to include some intersections so we can try with/without/only those too

Demo of the usages:

https://github.com/user-attachments/assets/25daa904-9306-406b-8470-2cd4f9687528

