### PR TITLE
Add RoadActor tilting and wraparound

### DIFF
--- a/addons/road-generator/nodes/road_lane_agent.gd
+++ b/addons/road-generator/nodes/road_lane_agent.gd
@@ -215,21 +215,37 @@ func find_nearest_lane(pos = null, distance: float = 50.0) -> RoadLane:
 	return closest_lane
 
 
-## Finds the poistion this many many units forward (or backwards, if negative)
-## along the current lane, assigning a new lane if the next one is reached
-func move_along_lane(move_distance: float) -> Vector3:
+## Finds the position move_distance units forward (or backwards, if negative)
+## along the current lane, assigning a new lane if the next one is reached.[br][br]
+##
+## Identical to move_along_lane, but returns a Transform3D including lane tilt.
+func move_along_lane_with_rotation(move_distance: float) -> Transform3D:
 	return _move_along_lane(move_distance, true)
 
 
-## Finds the poistion this many many units forward (or backwards, if negative)
+## Finds the position move_distance units forward (or backwards, if negative)
+## along the current lane, without assigning a new lane[br][br]
+##
+## Identical to test_move_along_lane, but returns a Transform3D including lane tilt.
+func test_move_along_lane_with_rotation(move_distance: float) -> Transform3D:
+	return _move_along_lane(move_distance, false)
+
+
+## Finds the position move_distance units forward (or backwards, if negative)
+## along the current lane, assigning a new lane if the next one is reached
+func move_along_lane(move_distance: float) -> Vector3:
+	return _move_along_lane(move_distance, true).origin
+
+
+## Finds the position move_distance units forward (or backwards, if negative)
 ## along the current lane, without assigning a new lane
 func test_move_along_lane(move_distance: float) -> Vector3:
-	return _move_along_lane(move_distance, false)
+	return _move_along_lane(move_distance, false).origin
 
 
 ## Get the next position along the RoadLane based on moving this amount
 ## from the current position (in meters)
-func _move_along_lane(move_distance: float, update_lane: bool = true) -> Vector3:
+func _move_along_lane(move_distance: float, update_lane: bool = true) -> Transform3D:
 	if not is_instance_valid(current_lane):
 		current_lane = null
 	var pos = actor.global_transform.origin
@@ -262,13 +278,14 @@ func _move_along_lane(move_distance: float, update_lane: bool = true) -> Vector3
 			check_next_offset += _update_lane.curve.get_baked_length()
 	if update_lane && _update_lane != current_lane:
 		assign_lane(_update_lane)
-	var ref_local = _update_lane.curve.sample_baked(check_next_offset)
-	var new_point: Vector3 = _update_lane.to_global(ref_local)
+	var ref_local: Transform3D = _update_lane.curve.sample_baked_with_rotation(check_next_offset)
+	ref_local.origin = _update_lane.curve.sample_baked(check_next_offset)
+	var new_transform: Transform3D = _update_lane.global_transform * ref_local
 	if update_lane && distance_left != 0: #workaround for missing connections
 		_update_lane = find_nearest_lane(pos - actor.global_transform.basis.z * sign(move_distance), 1)
 		if is_instance_valid(_update_lane) && _update_lane != current_lane: # it's still possible to find merging transition lanes
 			assign_lane(_update_lane)
-	return new_point
+	return new_transform
 
 
 ## Input of < 0 or > 0 to move abs(direction) amount of left or right lanes accordingly

--- a/addons/road-generator/nodes/road_lane_agent.gd
+++ b/addons/road-generator/nodes/road_lane_agent.gd
@@ -278,7 +278,7 @@ func _move_along_lane(move_distance: float, update_lane: bool = true) -> Transfo
 			check_next_offset += _update_lane.curve.get_baked_length()
 	if update_lane && _update_lane != current_lane:
 		assign_lane(_update_lane)
-	var ref_local: Transform3D = _update_lane.curve.sample_baked_with_rotation(check_next_offset)
+	var ref_local: Transform3D = _update_lane.curve.sample_baked_with_rotation(check_next_offset, true, true)
 	ref_local.origin = _update_lane.curve.sample_baked(check_next_offset)
 	var new_transform: Transform3D = _update_lane.global_transform * ref_local
 	if update_lane && distance_left != 0: #workaround for missing connections

--- a/road_demos/demo_resources/actors/road_actor.gd
+++ b/road_demos/demo_resources/actors/road_actor.gd
@@ -14,6 +14,7 @@ enum DriveState {
 @export var visualize_lane := false
 @export var seek_ahead := 5.0 # How many meters in front of agent to seek position
 @export var auto_register: bool = true
+@export var wrap_lane: bool = false
 
 @onready var agent:RoadLaneAgent = get_node("%road_lane_agent")
 
@@ -98,6 +99,47 @@ func _get_player_input() -> Vector3:
 	return Vector3(lane_move, 0, -dir) # neg z is "forward"
 
 
+## Traces the current lane to find the furtherest backwards RoadLane connected
+func _find_lane_chain_start(from_lane: RoadLane) -> RoadLane:
+	if not is_instance_valid(from_lane):
+		return null
+	var lane_cursor: RoadLane = from_lane
+	var visited := {}
+	while true:
+		var lane_id := lane_cursor.get_instance_id()
+		if visited.has(lane_id): # handle cycles
+			return lane_cursor
+		visited[lane_id] = true
+		if not lane_cursor.lane_prior:
+			return lane_cursor
+		var prior_lane = lane_cursor.get_node_or_null(lane_cursor.lane_prior)
+		if not is_instance_valid(prior_lane) or not prior_lane is RoadLane:
+			return lane_cursor
+		lane_cursor = prior_lane
+	return lane_cursor
+
+
+## Moves the actor to the beginning of the lane sequence if it just reached the end of its lane
+func _try_wrap_at_lane_end(move_dist: float) -> void:
+	if not wrap_lane:
+		return
+	if move_dist <= 0:
+		return
+	if not is_instance_valid(agent.current_lane):
+		return
+	if agent.current_lane.lane_next:
+		return
+	if not agent.close_to_lane_end(move_dist, agent.MoveDir.FORWARD):
+		return
+	var start_lane := _find_lane_chain_start(agent.current_lane)
+	if not is_instance_valid(start_lane):
+		return
+	agent.assign_lane(start_lane)
+	var start_ref_local: Transform3D = start_lane.curve.sample_baked_with_rotation(0.0)
+	start_ref_local.origin = start_lane.curve.sample_baked(0.0)
+	global_transform = start_lane.global_transform * start_ref_local
+
+
 func _physics_process(delta: float) -> void:
 	velocity.y = 0
 	var target_dir:Vector3 = get_input()
@@ -119,14 +161,7 @@ func _physics_process(delta: float) -> void:
 	# matches a positive move_along_lane call, while negative would be
 	# going in reverse in the lane's intended direction.
 	var move_dist:float = get_signed_speed() * delta
+	_try_wrap_at_lane_end(move_dist)
 
-	var next_pos: Vector3 = agent.move_along_lane(move_dist)
-	global_transform.origin = next_pos
-
-	# Get another point a little further in front for orientation seeking,
-	# without actually moving the vehicle (ie don't update the assign lane
-	# if this margin puts us into the next lane in front)
-	var orientation:Vector3 = agent.test_move_along_lane(0.05)
-
-	if ! global_transform.origin.is_equal_approx(orientation):
-		look_at(orientation, Vector3.UP)
+	var next_lane_transform: Transform3D = agent.move_along_lane_with_rotation(move_dist)
+	global_transform = next_lane_transform

--- a/road_demos/road_museum/road_museum.tscn
+++ b/road_demos/road_museum/road_museum.tscn
@@ -185,15 +185,15 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.14783, 3.8147e-06, -3.66865
 wrap_lane = true
 
 [node name="RoadActor4" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.2787, -5.72205e-06, -6.82003)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.2787, -5.72205e-06, -11.8369)
 wrap_lane = true
 
 [node name="RoadActor5" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.28377, -3.8147e-06, -57.7748)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.28377, -3.8147e-06, -52.5929)
 wrap_lane = true
 
 [node name="RoadActor6" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.3651, -3.8147e-06, -56.673)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.3651, -3.8147e-06, -43.5009)
 wrap_lane = true
 
 [node name="RoadActor7" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
@@ -322,7 +322,7 @@ edge_rp_locals = Array[NodePath]([NodePath("RP_001"), NodePath("RP_003")])
 edge_rp_local_dirs = Array[int]([0, 1])
 
 [node name="RoadActor" parent="RoadManager/Twist" instance=ExtResource("4_5p3l5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.73209, 0, -4.02292)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.55571, 0, -4.02292)
 target_speed = 20
 wrap_lane = true
 

--- a/road_demos/road_museum/road_museum.tscn
+++ b/road_demos/road_museum/road_museum.tscn
@@ -41,48 +41,48 @@ script = ExtResource("11_hm2jj")
 
 [sub_resource type="Curve3D" id="Curve3D_5vw3u"]
 _data = {
-"points": PackedVector3Array(0, 0, 0, 0, 0, 16.0769, -6.2, 0, 0, 0, 0, -4.91692, -34.8453, 0, 24.4224, -5.62221, 0, 42.5478),
-"tilts": PackedFloat32Array(0, 0)
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, -6.2, 0, 1.66893e-06, 0, 0, 0, 0, 0, 0, -6.18655, 0, 4.26224, 0, 0, 0, 0, 0, 0, -6.15481, 0, 8.53787, 0, 0, 0, 0, 0, 0, -6.10851, 0, 12.8189, 0, 0, 0, 0, 0, 0, -6.04924, 0, 17.1007, 0, 0, 0, 0, 0, 0, -5.9816, 0, 21.3783, 0, 0, 0, 0, 0, 0, -5.90758, 0, 25.6454, 0, 0, 0, 0, 0, 0, -5.82882, 0, 29.8987, 0, 0, 0, 0, 0, 0, -5.74895, 0, 34.1324, 0, 0, 0, 0, 0, 0, -5.6746, 0, 38.322, 0, 0, 0, 0, 0, 0, -5.62221, 0, 42.5478),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
-point_count = 2
+point_count = 11
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_stsme"]
 albedo_color = Color(0.137725, 0.260995, 0.142001, 1)
 
 [sub_resource type="Curve3D" id="Curve3D_l4jy4"]
 _data = {
-"points": PackedVector3Array(0, 0, 0, 0, 0, 15.8571, 10.2, 0, 0, 0, 0, -5.13669, -34.8453, 0, 24.4224, 10.7778, 0, 42.5478),
-"tilts": PackedFloat32Array(0, 0)
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, 10.7778, 0, 42.5478, 0, 0, 0, 0, 0, 0, 10.7252, 0, 38.2451, 0, 0, 0, 0, 0, 0, 10.6492, 0, 33.8838, 0, 0, 0, 0, 0, 0, 10.5684, 0, 29.5951, 0, 0, 0, 0, 0, 0, 10.4896, 0, 25.3386, 0, 0, 0, 0, 0, 0, 10.4161, 0, 21.1046, 0, 0, 0, 0, 0, 0, 10.3494, 0, 16.8876, 0, 0, 0, 0, 0, 0, 10.2909, 0, 12.677, 0, 0, 0, 0, 0, 0, 10.245, 0, 8.46499, 0, 0, 0, 0, 0, 0, 10.2134, 0, 4.24363, 0, 0, 0, 0, 0, 0, 10.2, 0, -2.38419e-06),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
-point_count = 2
+point_count = 11
 
 [sub_resource type="Curve3D" id="Curve3D_ehsx3"]
 _data = {
-"points": PackedVector3Array(0, 0, 0, 0, 0, 15.9938, 0, 0, 0, 0, 0, -5, -34.8453, 0, 24.4224, 0.577789, 0, 42.5478),
-"tilts": PackedFloat32Array(0, 0)
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, 0.577793, 0, 42.5478, 0, 0, 0, 0, 0, 0, 0.525328, 0, 38.293, 0, 0, 0, 0, 0, 0, 0.450339, 0, 34.0384, 0, 0, 0, 0, 0, 0, 0.370114, 0, 29.7839, 0, 0, 0, 0, 0, 0, 0.291337, 0, 25.5294, 0, 0, 0, 0, 0, 0, 0.217539, 0, 21.2748, 0, 0, 0, 0, 0, 0, 0.150236, 0, 17.0201, 0, 0, 0, 0, 0, 0, 0.0912614, 0, 12.7653, 0, 0, 0, 0, 0, 0, 0.045126, 0, 8.51032, 0, 0, 0, 0, 0, 0, 0.0134416, 0, 4.25521, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
-point_count = 2
+point_count = 11
 
 [sub_resource type="Curve3D" id="Curve3D_rpgj5"]
 _data = {
-"points": PackedVector3Array(0, 0, 0, 4.12268e-06, 4.12268e-06, 34.5836, -8.2, 5.37634e-06, -9.77516e-07, 24.4836, -17.3803, 11.2304, 19.3418, -21.9194, 79.8571, -54.997, 12.1602, 56.0724),
-"tilts": PackedFloat32Array(6.97654e-07, -0.206548)
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, -8.2, -2.3365e-05, -1.66893e-06, 0, 0, 0, 0, 0, 0, -8.31191, -0.0239596, 4.01, 0, 0, 0, 0, 0, 0, -8.6167, -0.0833516, 7.93842, 0, 0, 0, 0, 0, 0, -9.10505, -0.168548, 11.7766, 0, 0, 0, 0, 0, 0, -9.76714, -0.269832, 15.5227, 0, 0, 0, 0, 0, 0, -10.593, -0.377542, 19.1725, 0, 0, 0, 0, 0, 0, -11.5729, -0.482231, 22.7259, 0, 0, 0, 0, 0, 0, -12.7166, -0.573531, 26.1744, 0, 0, 0, 0, 0, 0, -14.0028, -0.641206, 29.5172, 0, 0, 0, 0, 0, 0, -15.4173, -0.676337, 32.7491, 0, 0, 0, 0, 0, 0, -16.9485, -0.670414, 35.858, 0, 0, 0, 0, 0, 0, -18.5783, -0.615887, 38.8246, 0, 0, 0, 0, 0, 0, -20.3067, -0.49584, 41.5981, 0, 0, 0, 0, 0, 0, -22.0585, -0.323818, 44.1739, 0, 0, 0, 0, 0, 0, -23.8624, -0.117786, 46.6069, 0, 0, 0, 0, 0, 0, -25.7566, 0.133118, 48.8935, 0, 0, 0, 0, 0, 0, -27.763, 0.430141, 51.0652, 0, 0, 0, 0, 0, 0, -29.9747, 0.809694, 53.1413, 0, 0, 0, 0, 0, 0, -32.5108, 1.37521, 54.9999, 0, 0, 0, 0, 0, 0, -35.3708, 2.16089, 56.5957, 0, 0, 0, 0, 0, 0, -38.5131, 3.24695, 57.7212, 0, 0, 0, 0, 0, 0, -41.8281, 4.59616, 58.3849, 0, 0, 0, 0, 0, 0, -45.204, 6.20682, 58.5043, 0, 0, 0, 0, 0, 0, -48.5601, 8.03634, 58.1155, 0, 0, 0, 0, 0, 0, -51.8339, 10.0297, 57.2914, 0, 0, 0, 0, 0, 0, -54.9969, 12.1602, 56.0724),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
-point_count = 2
+point_count = 26
 
 [sub_resource type="Curve3D" id="Curve3D_jqmwt"]
 _data = {
-"points": PackedVector3Array(0, 0, 0, 4.78411e-06, 4.78411e-06, 40.132, 8.2, -5.37634e-06, 9.77516e-07, 35.916, -25.4959, 16.4743, 19.3418, -21.9194, 79.8571, -59.6819, 15.486, 71.4331),
-"tilts": PackedFloat32Array(6.97654e-07, -0.161082)
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, -59.6819, 15.4859, 71.4331, 0, 0, 0, 0, 0, 0, -56.4291, 13.302, 72.6907, 0, 0, 0, 0, 0, 0, -52.8836, 11.1497, 73.626, 0, 0, 0, 0, 0, 0, -49.0671, 9.05939, 74.1855, 0, 0, 0, 0, 0, 0, -44.971, 7.05739, 74.2916, 0, 0, 0, 0, 0, 0, -40.6317, 5.18663, 73.8677, 0, 0, 0, 0, 0, 0, -36.0764, 3.4429, 72.9303, 0, 0, 0, 0, 0, 0, -31.361, 1.89463, 71.3513, 0, 0, 0, 0, 0, 0, -26.5383, 0.538172, 69.1749, 0, 0, 0, 0, 0, 0, -21.8058, -0.522268, 66.3153, 0, 0, 0, 0, 0, 0, -17.3382, -1.27512, 62.8973, 0, 0, 0, 0, 0, 0, -13.3137, -1.72071, 59.0615, 0, 0, 0, 0, 0, 0, -9.79038, -1.90929, 54.9414, 0, 0, 0, 0, 0, 0, -6.73041, -1.92342, 50.6869, 0, 0, 0, 0, 0, 0, -4.10521, -1.83372, 46.4409, 0, 0, 0, 0, 0, 0, -1.85257, -1.67349, 42.1878, 0, 0, 0, 0, 0, 0, 0.120479, -1.47764, 37.9353, 0, 0, 0, 0, 0, 0, 1.8489, -1.26126, 33.6765, 0, 0, 0, 0, 0, 0, 3.35408, -1.03627, 29.4116, 0, 0, 0, 0, 0, 0, 4.64452, -0.81254, 25.1436, 0, 0, 0, 0, 0, 0, 5.71673, -0.600081, 20.8769, 0, 0, 0, 0, 0, 0, 6.59506, -0.408082, 16.6269, 0, 0, 0, 0, 0, 0, 7.28277, -0.244259, 12.4043, 0, 0, 0, 0, 0, 0, 7.7809, -0.116275, 8.21763, 0, 0, 0, 0, 0, 0, 8.08794, -0.0320512, 4.07983, 0, 0, 0, 0, 0, 0, 8.2, 2.3365e-05, 1.66893e-06),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
-point_count = 2
+point_count = 26
 
 [sub_resource type="Curve3D" id="Curve3D_g106h"]
 _data = {
-"points": PackedVector3Array(0, 0, 0, 4.4534e-06, 4.4534e-06, 37.3578, 0, 0, 0, 28.8056, -20.4484, 13.2129, 19.3418, -21.9194, 79.8571, -56.7681, 13.4175, 61.8795),
-"tilts": PackedFloat32Array(6.97654e-07, -0.170778)
+"points": PackedVector3Array(0, 0, 0, 0, 0, 0, -56.7681, 13.4175, 61.8795, 0, 0, 0, 0, 0, 0, -53.5729, 11.2681, 63.1191, 0, 0, 0, 0, 0, 0, -50.2013, 9.2182, 64.0034, 0, 0, 0, 0, 0, 0, -46.678, 7.29525, 64.4876, 0, 0, 0, 0, 0, 0, -43.0359, 5.542, 64.4977, 0, 0, 0, 0, 0, 0, -39.3347, 3.99916, 63.9829, 0, 0, 0, 0, 0, 0, -35.6475, 2.66356, 63.0005, 0, 0, 0, 0, 0, 0, -32.0541, 1.58151, 61.4942, 0, 0, 0, 0, 0, 0, -28.5898, 0.700264, 59.6032, 0, 0, 0, 0, 0, 0, -25.3226, 0.039978, 57.3126, 0, 0, 0, 0, 0, 0, -22.2455, -0.454216, 54.7341, 0, 0, 0, 0, 0, 0, -19.3764, -0.799461, 51.9034, 0, 0, 0, 0, 0, 0, -16.7311, -1.0123, 48.8496, 0, 0, 0, 0, 0, 0, -14.2815, -1.12941, 45.6318, 0, 0, 0, 0, 0, 0, -12.0252, -1.1673, 42.2731, 0, 0, 0, 0, 0, 0, -9.98966, -1.13281, 38.7759, 0, 0, 0, 0, 0, 0, -8.13953, -1.05166, 35.1783, 0, 0, 0, 0, 0, 0, -6.47285, -0.935748, 31.493, 0, 0, 0, 0, 0, 0, -4.98856, -0.796053, 27.7311, 0, 0, 0, 0, 0, 0, -3.69204, -0.642745, 23.9008, 0, 0, 0, 0, 0, 0, -2.59723, -0.486641, 20.0081, 0, 0, 0, 0, 0, 0, -1.68821, -0.338093, 16.0679, 0, 0, 0, 0, 0, 0, -0.968698, -0.206137, 12.0882, 0, 0, 0, 0, 0, 0, -0.443499, -0.099762, 8.07759, 0, 0, 0, 0, 0, 0, -0.118385, -0.0280023, 4.04489, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+"tilts": PackedFloat32Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
-point_count = 2
+point_count = 26
 
 [node name="Node3D" type="Node3D"]
 
@@ -182,18 +182,23 @@ next_pt_init = NodePath("../RP_003")
 
 [node name="RoadActor3" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.14783, 3.8147e-06, -3.66865)
+wrap_lane = true
 
 [node name="RoadActor4" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.2787, -5.72205e-06, -6.82003)
+wrap_lane = true
 
 [node name="RoadActor5" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.28377, -3.8147e-06, -57.7748)
+wrap_lane = true
 
 [node name="RoadActor6" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.3651, -3.8147e-06, -56.673)
+wrap_lane = true
 
 [node name="RoadActor7" parent="RoadManager/LaneChange" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.65714, -3.8147e-06, -59.9074)
+wrap_lane = true
 
 [node name="Collisions" type="Node3D" parent="RoadManager"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 30, 0, 0)
@@ -319,10 +324,12 @@ edge_rp_local_dirs = Array[int]([0, 1])
 [node name="RoadActor" parent="RoadManager/Twist" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.73209, 0, -4.02292)
 target_speed = 20
+wrap_lane = true
 
 [node name="RoadActor2" parent="RoadManager/Twist" instance=ExtResource("4_5p3l5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.73209, -2.54588, -116.863)
 target_speed = 20
+wrap_lane = true
 
 [node name="RP_001" type="Node3D" parent="RoadManager/Twist"]
 script = ExtResource("4_tgwwo")
@@ -685,6 +692,7 @@ curve = SubResource("Curve3D_5vw3u")
 metadata/_edit_lock_ = true
 
 [node name="barrier" parent="RoadManager/DecorationsDemo/RP_002/edge_R" instance=ExtResource("17_7n47g")]
+path_rotation_accurate = false
 
 [node name="edge_grass_R" type="CSGPolygon3D" parent="RoadManager/DecorationsDemo/RP_002/edge_R"]
 transform = Transform3D(1, 2.98023e-08, 0, 2.98023e-08, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -695,6 +703,7 @@ path_interval_type = 0
 path_interval = 1.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = true
 path_continuous_u = true
 path_u_distance = 1.0
@@ -706,6 +715,7 @@ curve = SubResource("Curve3D_l4jy4")
 metadata/_edit_lock_ = true
 
 [node name="barrier" parent="RoadManager/DecorationsDemo/RP_002/edge_F" instance=ExtResource("17_7n47g")]
+path_rotation_accurate = false
 
 [node name="edge_grass_F" type="CSGPolygon3D" parent="RoadManager/DecorationsDemo/RP_002/edge_F"]
 transform = Transform3D(1, 2.98023e-08, 0, 2.98023e-08, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -716,6 +726,7 @@ path_interval_type = 0
 path_interval = 1.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = true
 path_continuous_u = true
 path_u_distance = 1.0
@@ -741,6 +752,7 @@ curve = SubResource("Curve3D_rpgj5")
 metadata/_edit_lock_ = true
 
 [node name="barrier" parent="RoadManager/DecorationsDemo/RP_003/edge_R" instance=ExtResource("17_7n47g")]
+path_rotation_accurate = false
 
 [node name="edge_grass_R" type="CSGPolygon3D" parent="RoadManager/DecorationsDemo/RP_003/edge_R"]
 transform = Transform3D(1, 2.98023e-08, 0, 2.98023e-08, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -751,6 +763,7 @@ path_interval_type = 0
 path_interval = 1.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = true
 path_continuous_u = true
 path_u_distance = 1.0
@@ -762,6 +775,7 @@ curve = SubResource("Curve3D_jqmwt")
 metadata/_edit_lock_ = true
 
 [node name="barrier" parent="RoadManager/DecorationsDemo/RP_003/edge_F" instance=ExtResource("17_7n47g")]
+path_rotation_accurate = false
 
 [node name="edge_grass_F" type="CSGPolygon3D" parent="RoadManager/DecorationsDemo/RP_003/edge_F"]
 transform = Transform3D(1, 2.98023e-08, 0, 2.98023e-08, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -772,6 +786,7 @@ path_interval_type = 0
 path_interval = 1.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = true
 path_continuous_u = true
 path_u_distance = 1.0

--- a/test/unit/test_road_lane_agent.gd
+++ b/test/unit/test_road_lane_agent.gd
@@ -1,0 +1,98 @@
+extends "res://addons/gut/test.gd"
+
+const MOVE_DISTANCE := 2.0
+const FLOAT_TOLERANCE := 0.001
+const TOLERANCE_VEC := Vector3(FLOAT_TOLERANCE, FLOAT_TOLERANCE, FLOAT_TOLERANCE)
+
+
+func _build_agent_fixture() -> Dictionary:
+	var world: RoadManager = add_child_autofree(RoadManager.new())
+
+	var lane_a: RoadLane = autoqfree(RoadLane.new())
+	lane_a.name = "lane_a"
+	lane_a.curve = Curve3D.new()
+	lane_a.curve.up_vector_enabled = true
+	lane_a.curve.add_point(Vector3(0.0, 0.0, 0.0), Vector3.ZERO, Vector3.ZERO)
+	lane_a.curve.add_point(Vector3(0.0, 0.0, 10.0), Vector3.ZERO, Vector3.ZERO)
+	lane_a.curve.set_point_tilt(0, 0.0)
+	lane_a.curve.set_point_tilt(1, 0.6)
+	world.add_child(lane_a)
+
+	var lane_b: RoadLane = autoqfree(RoadLane.new())
+	lane_b.name = "lane_b"
+	lane_b.curve = Curve3D.new()
+	lane_b.curve.up_vector_enabled = true
+	lane_b.curve.add_point(Vector3(0.0, 0.0, 10.0), Vector3.ZERO, Vector3.ZERO)
+	lane_b.curve.add_point(Vector3(0.0, 0.0, 20.0), Vector3.ZERO, Vector3.ZERO)
+	lane_b.curve.set_point_tilt(0, 0.6)
+	lane_b.curve.set_point_tilt(1, 0.6)
+	world.add_child(lane_b)
+
+	lane_a.lane_next = lane_a.get_path_to(lane_b)
+	lane_b.lane_prior = lane_b.get_path_to(lane_a)
+
+	var actor: Node3D = autoqfree(Node3D.new())
+	actor.name = "actor"
+	world.add_child(actor)
+	actor.global_position = Vector3(0.0, 0.0, 9.5)
+
+	var agent: RoadLaneAgent = autoqfree(RoadLaneAgent.new())
+	agent.auto_register = false
+	actor.add_child(agent)
+	agent.actor = actor
+	agent.current_lane = lane_a
+
+	return {
+		"lane_a": lane_a,
+		"lane_b": lane_b,
+		"agent": agent,
+	}
+
+
+func _assert_basis_almost_eq(a: Basis, b: Basis, message: String) -> void:
+	assert_almost_eq(a.x, b.x, TOLERANCE_VEC, "%s x" % message)
+	assert_almost_eq(a.y, b.y, TOLERANCE_VEC, "%s y" % message)
+	assert_almost_eq(a.z, b.z, TOLERANCE_VEC, "%s z" % message)
+
+
+# ------------------------------------------------------------------------------
+
+
+func test_move_with_rotation():
+	var actor_move := _build_agent_fixture()
+	var moved_transform: Transform3D = actor_move.agent.move_along_lane_with_rotation(MOVE_DISTANCE)
+
+	assert_eq(
+		actor_move.agent.current_lane,
+		actor_move.lane_b,
+		"move_along_lane_with_rotation should assign next lane")
+	assert_true(
+		moved_transform.basis.y.distance_to(Vector3.UP) > FLOAT_TOLERANCE,
+		"Transform should include lane tilt")
+
+	var actor_test := _build_agent_fixture()
+	var tested_transform: Transform3D = actor_test.agent.test_move_along_lane_with_rotation(MOVE_DISTANCE)
+
+	assert_eq(
+		actor_test.agent.current_lane,
+		actor_test.lane_a,
+		"test_move_along_lane_with_rotation should not assign a new lane")
+	assert_almost_eq(
+		moved_transform.origin, tested_transform.origin, TOLERANCE_VEC, "Transform origins should match")
+	_assert_basis_almost_eq(moved_transform.basis, tested_transform.basis, "Transform bases should match")
+
+
+func test_move_along_lane():
+	var actor_move := _build_agent_fixture()
+	var moved_position: Vector3 = actor_move.agent.move_along_lane(MOVE_DISTANCE)
+
+	assert_eq(actor_move.agent.current_lane, actor_move.lane_b, "move_along_lane should assign next lane")
+
+	var actor_test := _build_agent_fixture()
+	var tested_position: Vector3 = actor_test.agent.test_move_along_lane(MOVE_DISTANCE)
+
+	assert_eq(
+		actor_test.agent.current_lane,
+		actor_test.lane_a,
+		"test_move_along_lane should not assign a new lane")
+	assert_almost_eq(moved_position, tested_position, TOLERANCE_VEC, "Positions should match")

--- a/test/unit/test_road_lane_agent.gd.uid
+++ b/test/unit/test_road_lane_agent.gd.uid
@@ -1,0 +1,1 @@
+uid://t1yunjeyr0cr


### PR DESCRIPTION
This adds support for RoadLaneAgent's, along with the provided RoadActor, to follow the tilt of the RoadLane it is following.

- The tilting functionality is ultimately up to the user of the RoadLaneAgent
- Followed a similar naming convention as internal nodes and maintained backwards compatibility by keeping the same functions for `(test)move_along_lane` just return the transform's origin location
- Added wraparound feature to the RoadActor demo resource, useful for the museum scene to have cars on a "loop".
  - Contemplated adding this to the RoadLaneAgent, but ultimately it's very workflow specific. Someone could argue following the same lane backwards, someone else could argue to randomly spawn this agent at any open edge. So, the RoadActor was a better place for it, since someone could modify to fit their needs.


Demo:

https://github.com/user-attachments/assets/f33681a3-0e27-43ff-a670-0af4ef076a73

