### PR TITLE
Button to make RoadPoints editable in scene

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -1022,6 +1022,9 @@ func update_lane_seg_connections():
 		for prior_ln in prior_seg_lanes:
 			# prior lane be set to track to a next lane
 			for next_ln in next_seg_lanes:
+				if is_instance_valid(next_ln.owner):
+					# Don't auto update paths owned by the editor
+					continue
 				if prior_ln.lane_next_tag == next_ln.lane_prior_tag:
 					# TODO: When directionality is made consistent, we should no longer
 					# need to invert the direction assignment here.

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -388,6 +388,7 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		# TODO: Check for existing lanes and reuse (but also clean up if needed)
 		# var ln_child = self.get_node_or_null(ln_name)
 		var ln_child = null
+		var is_user_editable := false
 		ln_child = _par.get_node_or_null(ln_name)
 		if not is_instance_valid(ln_child) or not ln_child is RoadLane:
 			ln_child = RoadLane.new()
@@ -402,11 +403,7 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 			ln_child.set_meta("_edit_lock_", true)
 			ln_child.auto_free_vehicles = container.auto_free_vehicles
 		elif is_instance_valid(ln_child.owner):
-			# Sill could be nice to auto-connect adjacent nodes
-			last_ln = null
-			last_ln_reverse = false
-			lanes_added += 1
-			continue # do not auto update editor visible RoadLanes
+			is_user_editable = true
 		else:
 			ln_child.curve.clear_points()
 		var new_ln:RoadLane = ln_child
@@ -436,18 +433,25 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		# TODO(#46): Swtich to re-sampling and adding more points following the
 		# curve along from the parent path generator, including its use of ease
 		# in and out at the edges.
-		offset_curve(self, new_ln, in_offset, out_offset, start_point, end_point, new_ln_reverse)
+		if not is_user_editable:
+			offset_curve(self, new_ln, in_offset, out_offset, start_point, end_point, new_ln_reverse)
 
 		# Visually display if indicated, and not mid transform (low_poly)
-		if low_poly:
+		if is_user_editable:
+			# Never deleted anyways
+			new_ln.draw_in_editor = container.draw_lanes_editor
+		elif low_poly:
 			new_ln.draw_in_editor = false
 		else:
 			new_ln.draw_in_editor = container.draw_lanes_editor
-		new_ln.draw_in_game = container.draw_lanes_game
-		new_ln.refresh_geom = true
-		new_ln.rebuild_geom()
+		
+		if not is_user_editable:
+			new_ln.draw_in_game = container.draw_lanes_game
+			new_ln.refresh_geom = true
+			new_ln.rebuild_geom()
 
 		# Update lane connectedness for left/right lane connections.
+		# Attempt to do so for user editable lanes
 		if not last_ln == null and last_ln_reverse == new_ln_reverse:
 			# If the last lane and this one are facing the same way, then they
 			# should be adjacent for lane changing. Which lane (left/right) is
@@ -647,13 +651,20 @@ func get_lanes() -> Array:
 func clear_lane_segments(ignore_list: Array = []) -> void:
 	for l: RoadLane in self.get_lanes():
 		if l in ignore_list or is_instance_valid(l.owner):
-			return
+			continue
 		var ln:RoadLane = l.get_node_or_null(l.lane_next)
 		if ln && ln.lane_prior == ln.get_path_to(l):
 			ln.lane_prior = NodePath("")
 		var lp:RoadLane = l.get_node_or_null(l.lane_prior)
 		if lp && lp.lane_next == lp.get_path_to(l):
 			lp.lane_next = NodePath("")
+		
+		var ll:RoadLane = l.get_node_or_null(l.lane_left)
+		if ll && ll.lane_right == ll.get_path_to(l):
+			ll.lane_right = NodePath("")
+		var lr:RoadLane = l.get_node_or_null(l.lane_right)
+		if lr && lr.lane_left == lr.get_path_to(l):
+			lr.lane_left = NodePath("")
 		l.queue_free()
 
 

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -402,6 +402,10 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 			ln_child.set_meta("_edit_lock_", true)
 			ln_child.auto_free_vehicles = container.auto_free_vehicles
 		elif is_instance_valid(ln_child.owner):
+			# Sill could be nice to auto-connect adjacent nodes
+			last_ln = null
+			last_ln_reverse = false
+			lanes_added += 1
 			continue # do not auto update editor visible RoadLanes
 		else:
 			ln_child.curve.clear_points()

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -401,6 +401,8 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 				ln_child.add_to_group(manager.ai_lane_group)
 			ln_child.set_meta("_edit_lock_", true)
 			ln_child.auto_free_vehicles = container.auto_free_vehicles
+		elif is_instance_valid(ln_child.owner):
+			continue # do not auto update editor visible RoadLanes
 		else:
 			ln_child.curve.clear_points()
 		var new_ln:RoadLane = ln_child
@@ -457,7 +459,7 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		lanes_added += 1
 		last_ln = new_ln # For the next loop iteration.
 		last_ln_reverse = new_ln_reverse
-	clear_lane_segments(active_lanes)
+	clear_lane_segments(active_lanes) # input is the *ignore* list
 
 	return lanes_added > 0
 
@@ -640,7 +642,7 @@ func get_lanes() -> Array:
 ## Remove all RoadLanes attached to this RoadSegment
 func clear_lane_segments(ignore_list: Array = []) -> void:
 	for l: RoadLane in self.get_lanes():
-		if l in ignore_list:
+		if l in ignore_list or is_instance_valid(l.owner):
 			return
 		var ln:RoadLane = l.get_node_or_null(l.lane_next)
 		if ln && ln.lane_prior == ln.get_path_to(l):

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -404,6 +404,7 @@ func _show_road_toolbar() -> void:
 
 		# Aditional tools
 		_road_toolbar.create_menu.export_mesh.connect(_export_mesh_modal)
+		_road_toolbar.create_menu.bake_road_lanes.connect(bake_roadlanes_selected)
 		_road_toolbar.create_menu.feedback_pressed.connect(_on_feedback_pressed)
 		_road_toolbar.create_menu.report_issue_pressed.connect(_on_report_issue_pressed)
 		_road_toolbar.create_menu.create_terrain3d_connector.connect(add_and_configure_terrain3d_connector)
@@ -429,6 +430,7 @@ func _hide_road_toolbar() -> void:
 		
 		# Aditional tools
 		_road_toolbar.create_menu.export_mesh.disconnect(_export_mesh_modal)
+		_road_toolbar.create_menu.bake_road_lanes.disconnect(bake_roadlanes_selected)
 		_road_toolbar.create_menu.feedback_pressed.disconnect(_on_feedback_pressed)
 		_road_toolbar.create_menu.report_issue_pressed.disconnect(_on_report_issue_pressed)
 		_road_toolbar.create_menu.create_terrain3d_connector.disconnect(add_and_configure_terrain3d_connector)
@@ -1343,6 +1345,47 @@ func delete_roadcontainer(container: RoadContainer) -> void:
 		if is_instance_valid(mgr):
 			undo_redo.add_do_method(self, "set_selection", mgr)
 	undo_redo.add_undo_method(self, "set_selection_list", editor_selected)
+	undo_redo.commit_action()
+
+
+func bake_roadlanes_selected() -> void:
+	var sel = get_selected_node()
+	if sel is RoadContainer:
+		bake_roadlanes_action(sel.get_roadpoints() + sel.get_intersections())
+		return
+	elif sel is RoadGraphNode:
+		bake_roadlanes_action([sel])
+
+
+## Takes any scene-hidden, auto-generated AI lanes and directly add them to scene.\n\n
+##
+## Useful for hand modifying or custom tuning.
+## graph_nodes: Should be RoadGraphNode but can't type due to lack of covariants
+func bake_roadlanes_action(graph_nodes: Array) -> void:
+	var undo_redo = get_undo_redo()
+	undo_redo.create_action("Bake RoadLanes")
+	var conts: Array[RoadContainer] = []
+	
+	for parent in graph_nodes:
+		if not parent.container in conts:
+			conts.append(parent.container)
+		for _ch in parent.get_children(false):
+			var rl: RoadLane = _ch as RoadLane
+			if not is_instance_valid(rl):
+				continue
+			# Assign to own to be visible in editor and save to file, container
+			# will then ignore when auto refreshing/deleting
+			undo_redo.add_do_method(rl, "set_meta", "_edit_lock_", false)
+			undo_redo.add_undo_method(rl, "set_meta", "_edit_lock_", true)
+			undo_redo.add_do_property(rl, "owner", parent.owner)
+			undo_redo.add_undo_property(rl, "owner", rl.owner)
+
+	for _cont in conts:
+		# Necessary to ensure the scenetree updates, otherwise won't appear
+		# until they switch away and back to this scene
+		undo_redo.add_do_method(_cont, "_defer_refresh_on_change")
+		undo_redo.add_undo_method(_cont, "_defer_refresh_on_change")
+
 	undo_redo.commit_action()
 
 

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1375,7 +1375,7 @@ func bake_roadlanes_action(graph_nodes: Array) -> void:
 				continue
 			# Assign to own to be visible in editor and save to file, container
 			# will then ignore when auto refreshing/deleting
-			undo_redo.add_do_method(rl, "set_meta", "_edit_lock_", false)
+			undo_redo.add_do_method(rl, "remove_meta", "_edit_lock_")
 			undo_redo.add_undo_method(rl, "set_meta", "_edit_lock_", true)
 			undo_redo.add_do_property(rl, "owner", parent.owner)
 			undo_redo.add_undo_property(rl, "owner", rl.owner)

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1353,7 +1353,6 @@ func make_roadlanes_editable_from_selection() -> void:
 	var sel = get_selected_node()
 	if sel is RoadContainer:
 		make_roadlanes_editable_action(sel.get_roadpoints() + sel.get_intersections())
-		return
 	elif sel is RoadGraphNode:
 		make_roadlanes_editable_action([sel])
 
@@ -1365,12 +1364,13 @@ func make_roadlanes_editable_from_selection() -> void:
 func make_roadlanes_editable_action(graph_nodes: Array) -> void:
 	var undo_redo = get_undo_redo()
 	undo_redo.create_action("Make RoadLanes Editable")
-	var conts: Array[RoadContainer] = []
 	
 	for parent in graph_nodes:
-		if not parent.container in conts:
-			conts.append(parent.container)
+		var segs: Array[RoadSegment] = []
 		for _ch in parent.get_children(false):
+			if _ch is RoadSegment:
+				segs.append(_ch)
+				continue
 			var rl: RoadLane = _ch as RoadLane
 			if not is_instance_valid(rl):
 				continue
@@ -1384,12 +1384,13 @@ func make_roadlanes_editable_action(graph_nodes: Array) -> void:
 			undo_redo.add_undo_method(rl, "set_meta", "_edit_lock_", true)
 			undo_redo.add_do_property(rl, "owner", parent.owner)
 			undo_redo.add_undo_property(rl, "owner", rl.owner)
-
-	for _cont in conts:
-		# Necessary to ensure the scenetree updates, otherwise won't appear
-		# until they switch away and back to this scene
-		undo_redo.add_do_method(_cont, "_defer_refresh_on_change")
-		undo_redo.add_undo_method(_cont, "_defer_refresh_on_change")
+			
+		# Instead of refreshing the whole container, we can just force the
+		# lanes to regenerate.
+		for seg in segs:
+			undo_redo.add_do_method(seg, "generate_lane_segments")
+			undo_redo.add_undo_method(seg, "generate_lane_segments")
+		# TODO: Add the equivalent path for populating RoadLanes on intersections
 
 	undo_redo.commit_action()
 

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -404,7 +404,7 @@ func _show_road_toolbar() -> void:
 
 		# Aditional tools
 		_road_toolbar.create_menu.export_mesh.connect(_export_mesh_modal)
-		_road_toolbar.create_menu.bake_road_lanes.connect(bake_roadlanes_selected)
+		_road_toolbar.create_menu.make_lanes_editable.connect(make_roadlanes_editable_from_selection)
 		_road_toolbar.create_menu.feedback_pressed.connect(_on_feedback_pressed)
 		_road_toolbar.create_menu.report_issue_pressed.connect(_on_report_issue_pressed)
 		_road_toolbar.create_menu.create_terrain3d_connector.connect(add_and_configure_terrain3d_connector)
@@ -430,7 +430,7 @@ func _hide_road_toolbar() -> void:
 		
 		# Aditional tools
 		_road_toolbar.create_menu.export_mesh.disconnect(_export_mesh_modal)
-		_road_toolbar.create_menu.bake_road_lanes.disconnect(bake_roadlanes_selected)
+		_road_toolbar.create_menu.make_lanes_editable.disconnect(make_roadlanes_editable_from_selection)
 		_road_toolbar.create_menu.feedback_pressed.disconnect(_on_feedback_pressed)
 		_road_toolbar.create_menu.report_issue_pressed.disconnect(_on_report_issue_pressed)
 		_road_toolbar.create_menu.create_terrain3d_connector.disconnect(add_and_configure_terrain3d_connector)
@@ -1348,22 +1348,23 @@ func delete_roadcontainer(container: RoadContainer) -> void:
 	undo_redo.commit_action()
 
 
-func bake_roadlanes_selected() -> void:
+## Makes RoadLanes editable and saved to the scene tree based on selected node.
+func make_roadlanes_editable_from_selection() -> void:
 	var sel = get_selected_node()
 	if sel is RoadContainer:
-		bake_roadlanes_action(sel.get_roadpoints() + sel.get_intersections())
+		make_roadlanes_editable_action(sel.get_roadpoints() + sel.get_intersections())
 		return
 	elif sel is RoadGraphNode:
-		bake_roadlanes_action([sel])
+		make_roadlanes_editable_action([sel])
 
 
 ## Takes any scene-hidden, auto-generated AI lanes and directly add them to scene.\n\n
 ##
 ## Useful for hand modifying or custom tuning.
 ## graph_nodes: Should be RoadGraphNode but can't type due to lack of covariants
-func bake_roadlanes_action(graph_nodes: Array) -> void:
+func make_roadlanes_editable_action(graph_nodes: Array) -> void:
 	var undo_redo = get_undo_redo()
-	undo_redo.create_action("Bake RoadLanes")
+	undo_redo.create_action("Make RoadLanes Editable")
 	var conts: Array[RoadContainer] = []
 	
 	for parent in graph_nodes:
@@ -1372,6 +1373,10 @@ func bake_roadlanes_action(graph_nodes: Array) -> void:
 		for _ch in parent.get_children(false):
 			var rl: RoadLane = _ch as RoadLane
 			if not is_instance_valid(rl):
+				continue
+			if is_instance_valid(rl.owner):
+				# Already was made real before, doing it again would cause the
+				# editor lock to appear on undo.
 				continue
 			# Assign to own to be visible in editor and save to file, container
 			# will then ignore when auto refreshing/deleting

--- a/addons/road-generator/ui/road_container_edit.gd
+++ b/addons/road-generator/ui/road_container_edit.gd
@@ -20,10 +20,13 @@ func _can_handle(object):
 func _parse_category(object: Object, category: String) -> void:
 	if category != "road_container.gd":
 		return
+	
 	panel_instance = RoadContainerPanel.instantiate()
 	panel_instance.call("set_edi", _edi)
+	panel_instance.call_deferred("update_selected_road_container", object)
 	add_custom_control(panel_instance)
 	panel_instance.export_gltf.connect(_editor_plugin._export_mesh_modal)
+	panel_instance.bake_roadlanes.connect(_editor_plugin.bake_roadlanes_action)
 
 
 func set_edi(value):

--- a/addons/road-generator/ui/road_container_edit.gd
+++ b/addons/road-generator/ui/road_container_edit.gd
@@ -26,7 +26,7 @@ func _parse_category(object: Object, category: String) -> void:
 	panel_instance.call_deferred("update_selected_road_container", object)
 	add_custom_control(panel_instance)
 	panel_instance.export_gltf.connect(_editor_plugin._export_mesh_modal)
-	panel_instance.bake_roadlanes.connect(_editor_plugin.bake_roadlanes_action)
+	panel_instance.make_roadlanes_editable.connect(_editor_plugin.make_roadlanes_editable_action)
 
 
 func set_edi(value):

--- a/addons/road-generator/ui/road_container_panel.gd
+++ b/addons/road-generator/ui/road_container_panel.gd
@@ -3,9 +3,9 @@
 extends VBoxContainer
 
 signal export_gltf
-signal bake_roadlanes(container: Array)
+signal make_roadlanes_editable(graph_nodes: Array) # array of any classes from RoadGraphNode
 
-@onready var bake_button: Button = $bake_roadlanes
+@onready var editable_lanes_button: Button = $bake_roadlanes
 
 var sel_container: RoadContainer
 
@@ -27,7 +27,7 @@ func update_selected_road_container(object: RoadContainer):
 func update_road_container_panel() -> void:
 	if not is_instance_valid(sel_container):
 		return
-	bake_button.disabled = not sel_container.generate_ai_lanes
+	editable_lanes_button.disabled = not sel_container.generate_ai_lanes
 
 
 func _on_export_gltf_pressed() -> void:
@@ -38,5 +38,5 @@ func _container_updated_callback(segs: Array) -> void:
 	update_road_container_panel()
 
 
-func _on_bake_roadlanes_pressed() -> void:
-	bake_roadlanes.emit(sel_container.get_roadpoints() + sel_container.get_intersections())
+func _on_make_roadlanes_editbale_pressed() -> void:
+	make_roadlanes_editable.emit(sel_container.get_roadpoints() + sel_container.get_intersections())

--- a/addons/road-generator/ui/road_container_panel.gd
+++ b/addons/road-generator/ui/road_container_panel.gd
@@ -3,11 +3,40 @@
 extends VBoxContainer
 
 signal export_gltf
+signal bake_roadlanes(container: Array)
+
+@onready var bake_button: Button = $bake_roadlanes
+
+var sel_container: RoadContainer
 
 var _edi : set = set_edi
 
 func set_edi(value):
 	_edi = value
+	update_road_container_panel()
+
+
+func update_selected_road_container(object: RoadContainer):
+	if is_instance_valid(sel_container) and sel_container.on_road_updated.is_connected(_container_updated_callback):
+		sel_container.on_road_updated.disconnect(_container_updated_callback)
+	sel_container = object
+	sel_container.on_road_updated.connect(_container_updated_callback)
+	update_road_container_panel()
+
+
+func update_road_container_panel() -> void:
+	if not is_instance_valid(sel_container):
+		return
+	bake_button.disabled = not sel_container.generate_ai_lanes
+
 
 func _on_export_gltf_pressed() -> void:
 	export_gltf.emit()
+
+
+func _container_updated_callback(segs: Array) -> void:
+	update_road_container_panel()
+
+
+func _on_bake_roadlanes_pressed() -> void:
+	bake_roadlanes.emit(sel_container.get_roadpoints() + sel_container.get_intersections())

--- a/addons/road-generator/ui/road_container_panel.tscn
+++ b/addons/road-generator/ui/road_container_panel.tscn
@@ -19,8 +19,15 @@ layout_mode = 2
 tooltip_text = "Export all children to a .gltf / .glb file"
 text = "Export to gLTF"
 
+[node name="bake_roadlanes" type="Button" parent="."]
+layout_mode = 2
+tooltip_text = "Make all RoadLanes visible and editable. 
+Must have `generate_ai_lanes` enabled."
+text = "Bake RoadLanes"
+
 [node name="spacer2" type="Control" parent="."]
 custom_minimum_size = Vector2(0, 5)
 layout_mode = 2
 
 [connection signal="pressed" from="export_gltf" to="." method="_on_export_gltf_pressed"]
+[connection signal="pressed" from="bake_roadlanes" to="." method="_on_bake_roadlanes_pressed"]

--- a/addons/road-generator/ui/road_container_panel.tscn
+++ b/addons/road-generator/ui/road_container_panel.tscn
@@ -30,4 +30,4 @@ custom_minimum_size = Vector2(0, 5)
 layout_mode = 2
 
 [connection signal="pressed" from="export_gltf" to="." method="_on_export_gltf_pressed"]
-[connection signal="pressed" from="bake_roadlanes" to="." method="_on_bake_roadlanes_pressed"]
+[connection signal="pressed" from="bake_roadlanes" to="." method="_on_make_roadlanes_editbale_pressed"]

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -10,7 +10,7 @@ signal create_lane_agent
 signal create_terrain3d_connector
 signal create_2x2_road
 signal export_mesh
-signal bake_road_lanes
+signal make_lanes_editable
 signal feedback_pressed
 signal report_issue_pressed
 
@@ -28,7 +28,7 @@ enum CreateMenu {
 	TERRAIN3D_CONNECTOR,
 	TWO_X_TWO,
 	EXPORT_MESH,
-	BAKE_ROAD_LANES,
+	MAKE_LANES_EDITABLE,
 	FEEDBACK,
 	REPORT_ISSUE
 }
@@ -150,7 +150,7 @@ func on_toolbar_show(primary_sel: Node) -> void:
 		pup.set_item_disabled(idx, true)
 	idx += 1
 	
-	pup.add_item("Bake RoadLanes", CreateMenu.BAKE_ROAD_LANES)
+	pup.add_item("Make RoadLanes Editable", CreateMenu.MAKE_LANES_EDITABLE)
 	if not primary_sel is RoadContainer or not primary_sel.generate_ai_lanes:
 		pup.set_item_disabled(idx, true)
 	idx += 1
@@ -182,8 +182,8 @@ func _create_menu_item_clicked(id: int) -> void:
 			create_2x2_road.emit()
 		CreateMenu.EXPORT_MESH:
 			export_mesh.emit()
-		CreateMenu.BAKE_ROAD_LANES:
-			bake_road_lanes.emit()
+		CreateMenu.MAKE_LANES_EDITABLE:
+			make_lanes_editable.emit()
 		CreateMenu.FEEDBACK:
 			feedback_pressed.emit()
 		CreateMenu.REPORT_ISSUE:

--- a/addons/road-generator/ui/road_toolbar_create_menu.gd
+++ b/addons/road-generator/ui/road_toolbar_create_menu.gd
@@ -10,6 +10,7 @@ signal create_lane_agent
 signal create_terrain3d_connector
 signal create_2x2_road
 signal export_mesh
+signal bake_road_lanes
 signal feedback_pressed
 signal report_issue_pressed
 
@@ -27,6 +28,7 @@ enum CreateMenu {
 	TERRAIN3D_CONNECTOR,
 	TWO_X_TWO,
 	EXPORT_MESH,
+	BAKE_ROAD_LANES,
 	FEEDBACK,
 	REPORT_ISSUE
 }
@@ -128,7 +130,6 @@ func on_toolbar_show(primary_sel: Node) -> void:
 	idx += 1
 
 	pup.add_separator()
-	idx += 1
 
 	pup.add_item("2x2 road", CreateMenu.TWO_X_TWO)
 	pup.set_item_tooltip(idx, "Adds a segment of road with 2 lanes each way")
@@ -143,11 +144,16 @@ func on_toolbar_show(primary_sel: Node) -> void:
 	idx += 1
 
 	pup.add_separator()
-	idx += 1
 
 	pup.add_item("Export RoadContainer", CreateMenu.EXPORT_MESH)
 	if not primary_sel is RoadContainer:
 		pup.set_item_disabled(idx, true)
+	idx += 1
+	
+	pup.add_item("Bake RoadLanes", CreateMenu.BAKE_ROAD_LANES)
+	if not primary_sel is RoadContainer or not primary_sel.generate_ai_lanes:
+		pup.set_item_disabled(idx, true)
+	idx += 1
 	
 	pup.add_separator()
 	pup.add_item("Report issue", CreateMenu.REPORT_ISSUE)
@@ -176,6 +182,8 @@ func _create_menu_item_clicked(id: int) -> void:
 			create_2x2_road.emit()
 		CreateMenu.EXPORT_MESH:
 			export_mesh.emit()
+		CreateMenu.BAKE_ROAD_LANES:
+			bake_road_lanes.emit()
 		CreateMenu.FEEDBACK:
 			feedback_pressed.emit()
 		CreateMenu.REPORT_ISSUE:


### PR DESCRIPTION
This feature adds panel and menu options for making RoadPoints editable in the scene tree for manual tuning.

### Motivation

RoadLanes are normally hidden away from you, so you don't accidentally move them or rename them (used for auto connections). But sometimes, you need to adjust these auto-generated lanes for special road shapes or other circumstances. With this feature, you're able to persist them to the scene tree for further editing, while still retaining the auto-generated ones elsewhere.

<img width="1332" height="926" alt="image" src="https://github.com/user-attachments/assets/8f6a7cbc-80a4-4c33-a555-dc87b7c30252" />

### Demo, to be added to docs once merged:


https://github.com/user-attachments/assets/eb5e250a-6ef9-4ed3-b52c-8235e6a95130



### UX flows:

- Select a RoadContainer, if AI lanes are enabled, you can go to the Roads menu or RoadContainer inspectorpanel, you can press "Bake RoadLanes" (may rename the user-visible action name)
- Select a RoadPoint, if AI lanes are enabled for the parent container, can go to the Roads menu to bake RoadPoints (not added to the RoadPoint panel, feels a little crowded there already)
- After "baking", if you delete one of the "baked" RoadLanes, the next time the road is refreshed, the deleted one will come back as a automated, hidden one again, while the others remain manually defined. (Note: this part needs some improvements)


Limitations: The system for automatically tagging adjacent neighboring RoadLanes may cease to work or not refresh correctly.