### PR TITLE
Fix RoadIntersection geo tickbox

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -464,12 +464,13 @@ func _set_create_geo(value: bool) -> void:
 	create_geo = value
 	for ch in get_children():
 		# Cyclic loading, have to use workaround
-		if not ch.has_method("is_road_point"):
-			continue
-		for rp_ch in ch.get_children():
-			# Cycling loading, have to use workaround
-			if rp_ch.has_method("is_road_segment"):
-				rp_ch.do_roadmesh_creation()
+		if ch is RoadPoint:
+			for rp_ch in ch.get_children():
+				# Cycling loading, have to use workaround
+				if rp_ch.has_method("is_road_segment"):
+					rp_ch.do_roadmesh_creation()
+		if ch is RoadIntersection:
+			ch._do_roadmesh_creation()
 	if value == true:
 		_dirty = true
 		call_deferred("_dirty_rebuild_deferred")


### PR DESCRIPTION
Fixes being able to enable or disable geo for RoadIntersection meshes

Previously, you had to restart Godot to properly get the RoadContainer- level disabling or re-enabling of geo to reflect as expected.

Demo of the now-working, intended functionality:

https://github.com/user-attachments/assets/2dca29d6-7515-41e2-b982-e1cdb79b016e

