### PR TITLE
Improve intersection UX

### DIFF
--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -175,21 +175,12 @@ func add_branch(road_point: RoadPoint) -> void:
 	edge_points.append(road_point)
 	_sort_edges_clockwise()
 	
-	# Identify the closest facing opene egde of the intersection.
-	var is_prior_connected = road_point.is_prior_connected()
-	var is_next_connected = road_point.is_next_connected()
+	# Pick the closest facing open egde of this RoadPoint to connect
+	var open_dir := road_point.get_facing_open_dir(self)
 	road_point._is_internal_updating = true
-	if not is_prior_connected and not is_next_connected:
-		# Determine which direction to use.
-		var dir_to_inter: Vector3 = self.position - road_point.position 
-		var is_fwd_facing:bool = (road_point.global_basis.z.dot(dir_to_inter)) > 0
-		if is_fwd_facing:
-			road_point.next_pt_init = road_point.get_path_to(self)
-		else:
-			road_point.prior_pt_init = road_point.get_path_to(self)
-	elif is_prior_connected: # TODO: shoudl do if fwd or next prior connected, accounting for cross dirs
+	if open_dir == RoadPoint.PointInit.NEXT:
 		road_point.next_pt_init = road_point.get_path_to(self)
-	elif is_next_connected:
+	elif open_dir == RoadPoint.PointInit.PRIOR:
 		road_point.prior_pt_init = road_point.get_path_to(self)
 	else:
 		push_error("Cannot connect RoadPoint %s already fully connected" % road_point.name)

--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -47,6 +47,7 @@ enum TrafficUpdate{
 enum PointInit {
 	NEXT,
 	PRIOR,
+	NEITHER # Used to indicate if a query or check failed, e.g. no open direction
 }
 
 enum Alignment {
@@ -481,6 +482,28 @@ func cross_container_connected() -> bool:
 	if is_instance_valid(_nt) and _nt.container != self.container:
 		return true
 	return false
+
+
+## Returns the best open facing direction from this RP to a target graph node
+##
+## This is reusable logic to identify the best facing direction to connect.
+func get_facing_open_dir(target: RoadGraphNode) -> PointInit:
+	var is_prior_connected = is_prior_connected()
+	var is_next_connected = is_next_connected()
+	if not is_prior_connected and not is_next_connected:
+		# Determine which direction to use.
+		var dir_to_target: Vector3 = target.global_position - global_position 
+		var is_fwd_facing:bool = (global_basis.z.dot(dir_to_target)) > 0
+		if is_fwd_facing:
+			return PointInit.NEXT
+		else:
+			return PointInit.PRIOR
+	elif is_prior_connected:
+		return PointInit.NEXT
+	elif is_next_connected:
+		return PointInit.PRIOR
+	else:
+		return PointInit.NEITHER
 
 
 ## Indicates whether this direction is connected, accounting for container connections

--- a/addons/road-generator/plugin.cfg
+++ b/addons/road-generator/plugin.cfg
@@ -3,5 +3,5 @@
 name="RoadGenerator"
 description="A plugin for creating 3D highways/streets and lane-following traffic"
 author="Moo-Ack! Productions (TheDuckCow)"
-version="0.9.1"
+version="0.9.2"
 script="plugin.gd"

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1501,6 +1501,8 @@ func subaction_create_intersection(source_rp: RoadPoint, rp_branch: RoadPoint, u
 	var prior_graph: RoadGraphNode
 	var prior_rp: RoadPoint
 	var prior_samedir: bool = true
+	var src_origin := source_rp.global_transform.origin
+	var src_up := source_rp.global_transform.basis.y
 	
 	var next_graph: RoadGraphNode
 	var next_rp: RoadPoint
@@ -1547,6 +1549,10 @@ func subaction_create_intersection(source_rp: RoadPoint, rp_branch: RoadPoint, u
 		if not is_instance_valid(_branch) or not _branch is RoadPoint:
 			continue
 		#subaction_add_branch(inter, _branch, undo_redo)
+		if not _branch.get_prior_road_node() and not _branch.get_next_road_node():
+			print("Auto rotate this RP: ", _branch.name)
+			undo_redo.add_do_method(_branch, "look_at", src_origin, src_up)
+			undo_redo.add_undo_property(_branch, "global_transform", _branch.global_transform)
 		undo_redo.add_do_method(inter, "add_branch", _branch)
 	undo_redo.add_do_reference(inter)
 	
@@ -1555,6 +1561,8 @@ func subaction_create_intersection(source_rp: RoadPoint, rp_branch: RoadPoint, u
 		if not is_instance_valid(_branch) or not _branch is RoadPoint:
 			continue
 		undo_redo.add_undo_method(inter, "remove_branch", _branch)
+		if not _branch.prior_pt_init and not _branch.next_pt_init:
+			print("Auto rotate this RP: ", _branch.name)
 	
 	undo_redo.add_undo_method(source_rp.get_parent(), "remove_child", inter)
 	undo_redo.add_undo_method(inter, "set_owner", null)

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1040,6 +1040,48 @@ func convert_to_intersection_with_new_branch(rp_init: RoadPoint, rp_branch: Road
 	undo_redo.commit_action()
 
 
+## Converts a RoadPoint into an intersection and creates a new RoadPoint at the click point as a branch
+func convert_to_intersection_with_new_roadpoint(rp_init: RoadPoint, pos: Vector3, nrm: Vector3) -> void:
+	var undo_redo = get_undo_redo()
+	
+	undo_redo.create_action("Create intersection and new RoadPoint")
+	
+	var rp := RoadPoint.new()
+	rp.name = rp.increment_name("RP_001")
+	undo_redo.add_do_method(rp_init.container, "add_child", rp, true)
+	undo_redo.add_do_method(rp, "set_owner", rp_init.owner)
+	
+	if nrm == Vector3.ZERO:
+		nrm = Vector3.UP
+	
+	var new_transform = rp_init.global_transform
+	new_transform.origin = pos
+	new_transform.basis.y = nrm
+	undo_redo.add_do_property(rp, "global_transform", new_transform)
+	undo_redo.add_do_method(rp, "look_at", rp_init.global_transform.origin, new_transform.basis.y)
+	undo_redo.add_do_property(rp, "global_transform.basis.y", new_transform.basis.y)
+	
+	undo_redo.add_do_reference(rp)
+	
+	var inter = subaction_create_intersection(rp_init, rp, undo_redo)
+	
+	undo_redo.add_undo_method(rp_init.container, "remove_child", rp)
+	undo_redo.add_undo_method(rp, "set_owner", null)
+	
+	undo_redo.add_do_method(rp_init.container, "rebuild_segments", false)
+	undo_redo.add_undo_method(rp_init.container, "rebuild_segments", false)
+	
+	undo_redo.add_do_method(self, "_call_update_edges", rp_init.container)
+	undo_redo.add_undo_method(self, "_call_update_edges", rp_init.container)
+	
+	var editor_selected:Array = _edi.get_selection().get_selected_nodes()
+	undo_redo.add_do_method(self, "set_selection", rp)
+	undo_redo.add_undo_method(self, "set_selection_list", editor_selected)
+	
+	undo_redo.commit_action()
+
+
+
 func add_and_connect_rp_to_intersection(inter: RoadIntersection, pos: Vector3, nrm: Vector3) -> void:
 	var undo_redo = get_undo_redo()
 	if not is_instance_valid(inter):

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1123,16 +1123,53 @@ func add_and_connect_rp_to_intersection(inter: RoadIntersection, pos: Vector3, n
 	undo_redo.commit_action()
 
 
+## Direclty connects if same container, or creates new intermediate RP if different
 func connect_rp_to_intersection(inter: RoadIntersection, rp: RoadPoint) -> void:
 	var undo_redo = get_undo_redo()
-	if inter.container != rp.container:
-		push_error("RoadIntersection and RoadPoint don't belong to the same RoadContainer")
-		return
-	
-	undo_redo.create_action("Connect RoadPoint to RoadIntersection")
-	subaction_add_branch(inter, rp, undo_redo)
-	undo_redo.add_do_method(self, "_call_update_edges", inter.container)
-	undo_redo.add_undo_method(self, "_call_update_edges", inter.container)
+	var same_cont := inter.container == rp.container
+
+	if same_cont:
+		undo_redo.create_action("Connect RoadPoint to RoadIntersection")
+		subaction_add_branch(inter, rp, undo_redo)
+		undo_redo.add_do_method(self, "_call_update_edges", inter.container)
+		undo_redo.add_undo_method(self, "_call_update_edges", inter.container)
+	else: # Insert new RP, cross-container connect, then crate the branch
+
+		# Determine which direction to use, for the cross-container connection
+		# replicates internal logic from RoadIntersection.add_branch
+		var dir_to_inter: Vector3 = inter.position - rp.position 
+		var is_fwd_facing:bool = (rp.global_basis.z.dot(dir_to_inter)) > 0
+		var rp_to_newrp_dir := rp.get_facing_open_dir(inter)
+		if rp_to_newrp_dir == RoadPoint.PointInit.NEITHER:
+			push_error("Can't connect RP to itnersection, intial RoadPoint %s already fully connected" % rp.name)
+			return
+		var newrp_to_rp_dir := RoadPoint.PointInit.PRIOR if rp_to_newrp_dir == RoadPoint.PointInit.NEXT else RoadPoint.PointInit.NEXT
+		
+		undo_redo.create_action("Connect RoadPoint to RoadIntersection with new cross-container RoadPoint")
+
+		var new_rp := RoadPoint.new()
+		new_rp.copy_settings_from(rp)
+		new_rp.name = new_rp.increment_name("RP_001")
+
+		undo_redo.add_do_method(inter.container, "add_child", new_rp, true)
+		undo_redo.add_do_method(new_rp, "set_owner", inter.container.owner)
+		undo_redo.add_do_property(new_rp, "global_transform", rp.global_transform)
+		undo_redo.add_do_reference(new_rp)
+		
+		# connect to original container/RP
+		undo_redo.add_do_method(self, "_call_update_edges", rp.container)
+		undo_redo.add_do_method(self, "_call_update_edges", inter.container)
+		undo_redo.add_do_method(rp, "connect_container", rp_to_newrp_dir, new_rp, newrp_to_rp_dir)
+
+		subaction_add_branch(inter, new_rp, undo_redo)
+		
+		undo_redo.add_undo_method(rp, "disconnect_container", rp_to_newrp_dir, newrp_to_rp_dir)
+
+		undo_redo.add_undo_method(inter.container, "remove_child", new_rp)
+		undo_redo.add_undo_method(new_rp, "set_owner", null)
+
+		undo_redo.add_undo_method(self, "_call_update_edges", rp.container)
+		undo_redo.add_undo_method(self, "_call_update_edges", inter.container)
 	
 	undo_redo.commit_action()
 

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1531,9 +1531,9 @@ func subaction_create_intersection(source_rp: RoadPoint, rp_branch: RoadPoint, u
 	inter.name = "Intersection"
 	undo_redo.add_do_method(source_rp.get_parent(), "add_child", inter, true)
 	undo_redo.add_do_method(inter, "set_owner", source_rp.owner)
-	var target_transform: Transform3D = source_rp.global_transform
+	var target_transform: Transform3D = source_rp.transform
 	target_transform.basis = Basis.IDENTITY # Necesary as any rotation meses up generated mesh
-	undo_redo.add_do_property(inter, "global_transform", target_transform)
+	undo_redo.add_do_property(inter, "transform", target_transform)
 	
 	var prior_graph: RoadGraphNode
 	var prior_rp: RoadPoint

--- a/addons/road-generator/ui/connection_tool.gd
+++ b/addons/road-generator/ui/connection_tool.gd
@@ -454,13 +454,18 @@ func draw_hint_create_rp(overlay: Control) -> void:
 
 func draw_hint_create_intersection(overlay: Control) -> void:
 	var col: Color = Color.AQUA
-	for idx in hint_source_points.size():
-		var src := hint_source_points[idx]
-		var trg := hint_target_points[idx]
-		var dashed: bool = idx > 0
-		_draw_connector(overlay, src, trg, col, dashed)
-		_draw_mouse_label(overlay, col, "Create Intersection")
-	_draw_edges(overlay, col, false)
+	if hint_target_points.is_empty():
+		if hint_source_points.size() > 0:
+			_draw_connector(overlay, hint_source_points[0], cursor, col, true)
+			_draw_mouse_label(overlay, col, "Create Intersection")
+	else:
+		for idx in hint_source_points.size():
+			var src := hint_source_points[idx]
+			var trg := hint_target_points[idx]
+			var dashed: bool = idx > 0
+			_draw_connector(overlay, src, trg, col, dashed)
+			_draw_mouse_label(overlay, col, "Create Intersection")
+		_draw_edges(overlay, col, false)
 
 
 func draw_hint_disconnect(overlay: Control, label: String) -> void:
@@ -755,7 +760,9 @@ func _handle_add_mode_input(camera: Camera3D, event: InputEvent) -> int:
 		elif selection is RoadPoint and not is_instance_valid(hover_roadnode):
 			var rp_sel_filled:bool = selection.is_prior_connected() and selection.is_next_connected()
 			if rp_sel_filled:
-				pass
+				hint_source_nodes.append(selection)
+				hint_source_points.append(camera.unproject_position(selection.global_transform.origin))
+				hinting = HintState.CREATE_INTERSECTION
 			else:
 				hint_source_nodes.append(selection)
 				hint_source_points.append(camera.unproject_position(selection.global_transform.origin))
@@ -985,8 +992,15 @@ func _perform_action(camera: Camera3D) -> int:
 				plg.add_roadcontainer_and_roadpoint(mgr, pos, nrm)
 			return INPUT_STOP
 		HintState.CREATE_INTERSECTION:
-			if hint_source_nodes[0] is RoadPoint and hint_target_nodes[0] is RoadPoint:
+			if hint_source_nodes.size() > 0 and hint_target_nodes.size() > 0 and hint_source_nodes[0] is RoadPoint and hint_target_nodes[0] is RoadPoint:
 				plg.convert_to_intersection_with_new_branch(hint_target_nodes[0], hint_source_nodes[0])
+			elif hint_source_nodes.size() > 0 and hint_source_nodes[0] is RoadPoint and hint_target_nodes.is_empty():
+				var selection = hint_source_nodes[0]
+				var res: Array = get_click_point_with_context(
+					_intersect_dict, _intersect_mouse_src, _intersect_mouse_nrm, camera, selection)
+				var pos:Vector3 = res[0]
+				var nrm:Vector3 = res[1]
+				plg.convert_to_intersection_with_new_roadpoint(selection, pos, nrm)
 			else:
 				print("Not implemented")
 			return INPUT_STOP

--- a/addons/road-generator/ui/connection_tool.gd
+++ b/addons/road-generator/ui/connection_tool.gd
@@ -771,7 +771,7 @@ func _handle_add_mode_input(camera: Camera3D, event: InputEvent) -> int:
 			hint_source_nodes.append(selection)
 			hint_source_points.append(camera.unproject_position(selection.global_transform.origin))
 			hinting = HintState.CREATE_RP
-		elif hover_roadnode is RoadPoint and selection is RoadPoint:
+		elif selection is RoadPoint and hover_roadnode is RoadPoint:
 			# TODO - extract into func handle_add_rp2rp?
 			# Connection context, but need to check if same container and if 
 			var rp_sel: RoadPoint = selection
@@ -808,24 +808,25 @@ func _handle_add_mode_input(camera: Camera3D, event: InputEvent) -> int:
 				_hint_intersection_creation(rp_hover, rp_sel, camera)
 			elif not rp_hover_filled and rp_sel_filled:
 				_hint_intersection_creation(rp_sel, rp_hover, camera)
-		elif hover_roadnode is RoadIntersection and selection is RoadPoint:
+		elif selection is RoadPoint and hover_roadnode is RoadIntersection:
 			if selection.is_prior_connected() and selection.is_next_connected():
-				# Fully connected
+				# Fully connected, potentially could offer to "merge" everything
+				# into one intersection
 				pass
 			else:
 				var inter: RoadIntersection = hover_roadnode
 				var rp: RoadPoint = selection
-				if inter.container == rp.container:
-					hint_source_nodes.append(rp)
-					hint_source_points.append(camera.unproject_position(rp.global_transform.origin))
-					hint_target_nodes.append(inter)
-					hint_target_points.append(camera.unproject_position(inter.global_transform.origin))
-					_insert_edge_hint(rp, camera)
-					if rp in inter.edge_points:
-						hinting = HintState.DISCONNECT
-					else:
-						hinting = HintState.CONNECT
-		elif hover_roadnode is RoadPoint and selection is RoadIntersection:
+				#if inter.container == rp.container:
+				hint_source_nodes.append(rp)
+				hint_source_points.append(camera.unproject_position(rp.global_transform.origin))
+				hint_target_nodes.append(inter)
+				hint_target_points.append(camera.unproject_position(inter.global_transform.origin))
+				_insert_edge_hint(rp, camera)
+				if rp in inter.edge_points:
+					hinting = HintState.DISCONNECT
+				else:
+					hinting = HintState.CONNECT
+		elif selection is RoadIntersection and hover_roadnode is RoadPoint:
 			var inter: RoadIntersection = selection
 			var rp: RoadPoint = hover_roadnode
 			if inter.container == rp.container:
@@ -838,6 +839,11 @@ func _handle_add_mode_input(camera: Camera3D, event: InputEvent) -> int:
 					hinting = HintState.DISCONNECT
 				else:
 					hinting = HintState.CONNECT
+		elif selection is RoadIntersection and hover_roadnode is RoadIntersection:
+			# In future, could offer to merge (if close) or create midpoints between,
+			# supporting a workflow of creating intersection points first and then
+			# connections between them later.
+			pass
 		
 		plg.update_overlays()
 	elif not event is InputEventMouseButton:

--- a/addons/road-generator/ui/connection_tool.gd
+++ b/addons/road-generator/ui/connection_tool.gd
@@ -41,7 +41,7 @@ const white_col = Color(1, 1, 1, 0.9) ## Outline color
 const rad_size := 10.0 ## Connector dot radius
 
 var plg:EditorPlugin
-var snap_threshold := 25.0 ## Threshold for snapping distance of nodes in the scene
+var snap_threshold := 25.0 ## Threshold for snapping distance in meters of nodes in the scene
 var snapping: int = SnapState.IDLE ## Current state of snapping
 var pre_snap_trans: Array[Transform3D] = []
 
@@ -311,6 +311,26 @@ func nearest_graphnode_from_raycast(intersect: Dictionary) -> RoadGraphNode:
 		return nearest_point
 	elif collider.name.begins_with("intersection_mesh_col"):
 		var intersection: RoadIntersection = collider.get_parent().get_parent()
+		
+		# Identify if any of the intersection edges are open and close to
+		# the hover pos, such that we should connet to that point instead.
+		var open_rps: Array[RoadPoint] = []
+		var closest_rp: RoadPoint
+		var closest_dist := -1.0
+		for _rp in intersection.edge_points:
+			if _rp.is_prior_connected() and _rp.is_next_connected():
+				continue
+			var compare_radius = _rp.lane_width * _rp.lanes.size() / 2.0
+			compare_radius *= compare_radius
+			var compare_dist := _rp.global_position.distance_squared_to(position)
+			if compare_dist > compare_radius:
+				continue
+			if closest_dist < 0 or compare_dist < closest_dist:
+				closest_dist = compare_dist
+				closest_rp = _rp
+		if is_instance_valid(closest_rp):
+			# If the hover point is very close to a RoadPoint, consider it as the hover instead
+			return closest_rp
 		return intersection
 	else:
 		# Might be a custom RoadContainer.
@@ -816,7 +836,6 @@ func _handle_add_mode_input(camera: Camera3D, event: InputEvent) -> int:
 			else:
 				var inter: RoadIntersection = hover_roadnode
 				var rp: RoadPoint = selection
-				#if inter.container == rp.container:
 				hint_source_nodes.append(rp)
 				hint_source_points.append(camera.unproject_position(rp.global_transform.origin))
 				hint_target_nodes.append(inter)

--- a/addons/road-generator/ui/connection_tool.gd
+++ b/addons/road-generator/ui/connection_tool.gd
@@ -312,14 +312,12 @@ func nearest_graphnode_from_raycast(intersect: Dictionary) -> RoadGraphNode:
 	elif collider.name.begins_with("intersection_mesh_col"):
 		var intersection: RoadIntersection = collider.get_parent().get_parent()
 		
-		# Identify if any of the intersection edges are open and close to
-		# the hover pos, such that we should connet to that point instead.
+		# Identify if any intersection edges are close to the cursor click pos
+		# to allow for direct (dis)connection downstream
 		var open_rps: Array[RoadPoint] = []
 		var closest_rp: RoadPoint
 		var closest_dist := -1.0
 		for _rp in intersection.edge_points:
-			if _rp.is_prior_connected() and _rp.is_next_connected():
-				continue
 			var compare_radius = _rp.lane_width * _rp.lanes.size() / 2.0
 			compare_radius *= compare_radius
 			var compare_dist := _rp.global_position.distance_squared_to(position)
@@ -329,7 +327,6 @@ func nearest_graphnode_from_raycast(intersect: Dictionary) -> RoadGraphNode:
 				closest_dist = compare_dist
 				closest_rp = _rp
 		if is_instance_valid(closest_rp):
-			# If the hover point is very close to a RoadPoint, consider it as the hover instead
 			return closest_rp
 		return intersection
 	else:


### PR DESCRIPTION
This addresses several points from https://github.com/TheDuckCow/godot-road-generator/issues/365:

- Issue 1: (done) Allow creating intersections from fully connected nodes by hovering over the void
  <img width="449" height="329" alt="new-intersection" src="https://github.com/user-attachments/assets/eb378911-7a32-4d93-bdd2-6a75470575de" />
- Issue 2: (done) Auto rotate initially non-connected RoadPoints when creating a new intersection (demo shows working undo/redo
    <img width="580" height="385" alt="demo-auto-rotate" src="https://github.com/user-attachments/assets/8708f1fb-ddaa-4226-aa22-a780bce48950" />
- Issue 3: (done) Allow connecting a RoadPoints and RoadIntersections on different RoadContainers
  - Works by inserting another overlapping RoadPoint at the interface.

   https://github.com/user-attachments/assets/ed9a6e9a-774d-400f-931d-999884abd489

- Issue 4 (done): If the RC is rotated, the intersection created within is double rotated, needs to be undone. Will be fair for any prefab or duplicated RC's in the interface that get moved around. 
- Issue 5 (done): Allow connecting to an open edge of an intersection's roadpoints if you hover close enough to one 
    <img width="678" height="450" alt="connecting-open-inter-edge" src="https://github.com/user-attachments/assets/90d9e60c-319a-431d-9c41-eff55d9d928f" />


## Allowing cross-container intersection connections

Instead of actually allowing intersections be edges, as the source ticket postulated we could do, I've decided to go with the concept of just inserting additional RoadPoints into the scene when dealing with any cross-container issues, to keep that paradigm in place. Unconnected edges of RoadIntersections do already end up in the Edge RP lists of containers, which is great. So there's really no need to extend RoadContainers themselves to be edges, since there will always be an RP at the actual edge itself.

## Testing scenarios

I used this list during development to make sure I covered all scenarios:

## **Setup**:

- RCA
    - InterA
    - RPA
    - RPA1 (fully connected to RPA and RPA2)
    - RPA2 (connected to RPA1)
    - InterA2 (some other intersection elsewhere in same container)
- RCB
    - InterB
    - RPB
    - …
    - RPB2 (extends out from PRB)

## **Scenarios**

- Have **InterA** selected, hover over **nothing**:
    - Should do: creates RP within RCA, connects back to InterA
    - Previously did: nothing
    - [x]  Status: Now implemented!
- Have **RPA** selected, hover over **another segment** connected to RPB2:
    - Should do: offer to connect, creating new RP at RPB2’s position but in RCA container
    - Currently does: Same
    - [x]  Status: _Already worked_
- Reverse of above: **RPB2** selected, hover **over intersection** InterA but closer to RPA
    - Should do: offer to connect, but will crate a new RP at RPB2's location within RCA, and connect that point as a new branch to InterA; RPA remains open
    - Currently does: Nothing
    - [x]  Status: Now implemented!
- Have **RPA** selected, hover over **InterB**
    - Should do: Add a new point at RPA's location in RCB, and connect that to InterB as a branch
    - Currently does: Nothing
    - [x]  Status: Now implemented!
- Have **InterA** selected, hover over **InterB**
    - Should do: Let's do nothing, even within the same container we don't offer connecting InterA directly to InterB, as it'd be ambiguous where the middle RoadPoint should go (could be midpoint, but then what about floor snapping etc? Woudl we fire a raycast at the midpoint? Too complex)
    - Currently does: Nothing
    - [x]  Status: keep it doing nothing
- Have RPA1 (fully connected) selected, hover over InterB
    - Should do: Nothing, this is like the option above, except it's starting with the initial step of creating the intersection before then trying to directly connect to another intersection with an ambiguous midpoint RP
    - Currently does: Nothing
    - [x]  Status: keep it doing nothing
- Have RPA1 (fully connected) selected, hover over a RPB2 (open on one side)
    - Should do: I thought about offering to create an intersection, but then we'd want to offer the reverse - which would mean creating an intersection out of a fully connected RP in _another_ container, which feels like it could get a bit messy. It would make sense for the user, it's just a bit more than I want to tackle right now
    - Currently does: Nothing
    - [ ]  Status: Skip for now.