### PR TITLE
Hotfix for godot 4.7 null return in void function

### DIFF
--- a/road_demos/procedural_generator/road_actor_manager.gd
+++ b/road_demos/procedural_generator/road_actor_manager.gd
@@ -21,7 +21,7 @@ var _stashed_vehicles: Array = [] #these are to be added on spawn
 func _ready():
 	if road_actor_scenes.is_empty():
 		push_error("Road Actor Scenes are empty in ", name, ". No actor will be created")
-		return null
+		return
 
 
 ## Spawn random actor (from road_actor_scenes) at the pos


### PR DESCRIPTION
Fixes this syntax error after installing the project - despite not being in the core addon, the demo scene makes it rather noisy:

<img width="889" height="484" alt="Screenshot 2026-06-19 at 12 43 30 AM" src="https://github.com/user-attachments/assets/0272df07-3f1a-42d4-8de9-321919484602" />
