### PR TITLE
Fixed the order of lane connections on the 2x2 roundabout

### DIFF
--- a/addons/road-generator/custom_containers/roundabout_2x2.tscn
+++ b/addons/road-generator/custom_containers/roundabout_2x2.tscn
@@ -212,7 +212,7 @@ lane_prior_tag = "F1"
 curve = SubResource("Curve3D_15rct")
 script = ExtResource("4_h8c5r")
 lane_left = NodePath("../pF0_nF0-uturn")
-lane_right = NodePath("../pF1_nF1")
+lane_right = NodePath("../pF0_nF0")
 lane_next_tag = "F0"
 lane_prior_tag = "F0"
 
@@ -260,7 +260,7 @@ lane_prior_tag = "F1"
 curve = SubResource("Curve3D_h083d")
 script = ExtResource("4_h8c5r")
 lane_left = NodePath("../pF0_nF0-uturn")
-lane_right = NodePath("../pF1_nF1")
+lane_right = NodePath("../pF0_nF0")
 lane_next_tag = "F0"
 lane_prior_tag = "F0"
 
@@ -308,7 +308,7 @@ lane_prior_tag = "F1"
 curve = SubResource("Curve3D_g61lx")
 script = ExtResource("4_h8c5r")
 lane_left = NodePath("../pF0_nF0-uturn")
-lane_right = NodePath("../pF1_nF1")
+lane_right = NodePath("../pF0_nF0")
 lane_next_tag = "F0"
 lane_prior_tag = "F0"
 
@@ -356,7 +356,7 @@ lane_prior_tag = "F1"
 curve = SubResource("Curve3D_vqvfw")
 script = ExtResource("4_h8c5r")
 lane_left = NodePath("../pF0_nF0-uturn")
-lane_right = NodePath("../pF1_nF1")
+lane_right = NodePath("../pF0_nF0")
 lane_next_tag = "F0"
 lane_prior_tag = "F0"
 


### PR DESCRIPTION
Left-right order now matches right-left oder, no lanes are skipped.

Before (see how going from the left-turn equivalent then connects to the right-turn, skipping straight through)

https://github.com/user-attachments/assets/f28cf54e-f51c-413d-a821-efaf2f279d60

Now:

https://github.com/user-attachments/assets/f8e27cb1-5ca4-40fa-94a9-6355bbf23b75

