### PR TITLE
Generate RoadLanes for procedural intersections

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -442,6 +442,8 @@ func _set_draw_lanes_editor(value: bool):
 		if not generate_ai_lanes:
 			seg.clear_lane_segments()
 		seg.update_lane_visibility() # could still have some manually added
+	for inter in get_intersections():
+		inter.update_lane_visibility()
 
 
 func _get_draw_lanes_editor() -> bool:
@@ -452,6 +454,8 @@ func _set_draw_lanes_game(value: bool):
 	_draw_lanes_game = value
 	for seg in get_segments():
 		seg.update_lane_visibility()
+	for inter in get_intersections():
+		inter.update_lane_visibility()
 
 
 func _get_draw_lanes_game() -> bool:

--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -1175,6 +1175,13 @@ func force_assign_lanes() -> void:
 				continue
 			lanes.append(_rl)
 
+	# Then RoadLanes that are children of intersections
+	for _inter in get_intersections():
+		for _rl in _inter.get_children():
+			if not _rl is RoadLane:
+				continue
+			lanes.append(_rl)
+
 	# Now get loose, direct child RoadLanes of container
 	for _ch in get_children():
 		if not _ch is RoadLane:

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -226,6 +226,14 @@ func sort_branches() -> void:
 		_sort_edges_clockwise()
 
 
+## Match the draw settings of generated lanes to the container's settings.
+func update_lane_visibility() -> void:
+	for child in get_children():
+		if child is RoadLane:
+			child.draw_in_editor = container.draw_lanes_editor
+			child.draw_in_game = container.draw_lanes_game
+
+
 ## Check if mesh needs to be rebuilt.[br][br]
 ##
 ## Returns true if rebuild was done, else (including if invalid) false.

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -269,6 +269,8 @@ func _rebuild() -> void:
 	_mesh.mesh = mesh
 	container._create_collisions(_mesh)
 
+	settings.generate_lanes(self, edge_points, container)
+
 
 func _do_roadmesh_creation():
 	var do_create := _should_add_mesh()

--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1474,6 +1474,10 @@ func make_roadlanes_editable_action(graph_nodes: Array) -> void:
 		for seg in segs:
 			undo_redo.add_do_method(seg, "generate_lane_segments")
 			undo_redo.add_undo_method(seg, "generate_lane_segments")
+		if parent is RoadIntersection:
+			undo_redo.add_do_method(parent, "refresh_intersection_mesh")
+			undo_redo.add_undo_method(parent, "refresh_intersection_mesh")
+
 		# TODO: Add the equivalent path for populating RoadLanes on intersections
 
 	undo_redo.commit_action()

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -19,6 +19,9 @@ enum _IntersectNGonFacing {
 
 const SegGeo := preload("res://addons/road-generator/procgen/segment_geo.gd")
 
+const STOP_ROW_SIZE: float = 2.0  # TODO: make proportional to density
+const LANE_NAME_PREFIX := "RoadLane_"
+
 # ------------------------------------------------------------------------------
 #endregion
 #region Abstract overrides
@@ -40,6 +43,52 @@ func generate_mesh(intersection: Node3D, edges: Array[RoadPoint], container: Roa
 func get_min_distance_from_intersection_point(rp: RoadPoint) -> float:
 	# TODO TBD when mesh generation is implemented.
 	return 0.0
+
+
+func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
+	if not intersection.has_method("is_road_intersection"):
+		push_error("intersection is not an intersection node, skipping lane generation.")
+		return
+
+	var active_lanes: Array[RoadLane] = []
+	if not container.generate_ai_lanes:
+		_clear_generated_lanes(intersection, active_lanes)
+		return
+
+	var manager: RoadManager = container.get_manager()
+
+	for edge: RoadPoint in edges:
+		if not is_instance_valid(edge):
+			continue
+
+		var lane_name := "%s%s" % [LANE_NAME_PREFIX, edge.name]
+		var existing := intersection.get_node_or_null(lane_name)
+		var lane: RoadLane
+		if existing is RoadLane:
+			lane = existing
+		else:
+			lane = RoadLane.new()
+			intersection.add_child(lane)
+			lane.name = lane_name
+			lane.set_meta("_edit_lock_", true)
+			lane.auto_free_vehicles = container.auto_free_vehicles
+			if container.debug_scene_visible:
+				lane.owner = container.get_owner()
+		active_lanes.append(lane)
+
+		if container.ai_lane_group != "":
+			lane.add_to_group(container.ai_lane_group)
+		elif is_instance_valid(manager) and manager.ai_lane_group != "":
+			lane.add_to_group(manager.ai_lane_group)
+
+		_assign_edge_stub_curve(lane, edge, intersection)
+
+		lane.draw_in_editor = container.draw_lanes_editor
+		lane.draw_in_game = container.draw_lanes_game
+		lane.refresh_geom = true
+		lane.rebuild_geom()
+
+	_clear_generated_lanes(intersection, active_lanes)
 
 
 # ------------------------------------------------------------------------------
@@ -65,6 +114,37 @@ func _get_edge_facing(edge: RoadPoint, intersection: Node3D) -> _IntersectNGonFa
 	return facing
 
 
+## World-space center of an edge's stop line, where its lanes meet the intersection.
+func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
+	var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
+	var parallel_v: Vector3 = edge.global_transform.basis.z.normalized()
+	if facing == _IntersectNGonFacing.ORIGIN:
+		parallel_v = -parallel_v
+	return edge.global_transform.origin + parallel_v * STOP_ROW_SIZE
+
+
+## Straight line from the intersection center to the edge's stop line,
+## stored in the lane's local space.
+func _assign_edge_stub_curve(lane: RoadLane, edge: RoadPoint, intersection: Node3D) -> void:
+	var to_local: Transform3D = lane.global_transform.affine_inverse()
+	var curve := Curve3D.new()
+	curve.add_point(to_local * intersection.global_transform.origin)
+	curve.add_point(to_local * _edge_stop_center(edge, intersection))
+	lane.curve = curve
+
+
+## Frees previously generated lanes that are no longer active.
+func _clear_generated_lanes(intersection: Node3D, keep: Array[RoadLane]) -> void:
+	for child in intersection.get_children():
+		if not (child is RoadLane):
+			continue
+		if not str(child.name).begins_with(LANE_NAME_PREFIX):
+			continue
+		if keep.has(child):
+			continue
+		child.queue_free()
+
+
 ## Generates a triangles from shoulders to intersection point,
 ## and triangles from an edge's shoulders to the intersection point.
 ## The end result is a very low-poly n-gon.[br][br]
@@ -82,8 +162,6 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 	const TOPSIDE_SMOOTHING_GROUP = 1
 	surface_tool.set_smooth_group(TOPSIDE_SMOOTHING_GROUP)
 
-	const STOP_ROW_SIZE: float = 2.0  # TODO: make proportional to density
-	
 	# First, add an additional row of quads to each edge,
 	# to give a UV space for stop marks or other markings.
 	# We also prepare the intersection by storing appropriate

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -345,7 +345,7 @@ func _clear_generated_lanes(intersection: Node3D, keep: Array[RoadLane]) -> void
 	for child in intersection.get_children():
 		if not (child is RoadLane):
 			continue
-		if not str(child.name).begins_with(LANE_NAME_PREFIX):
+		if is_instance_valid(child.owner):
 			continue
 		if keep.has(child):
 			continue

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -241,9 +241,13 @@ func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager
 
 
 ## Creates or updates a single lane with its tags, curve and draw settings.
+## Lanes the user has promoted to editable (given an owner) are left untouched.
 func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, active_lanes: Array[RoadLane], lane_name: String, prior_tag: String, next_tag: String, entry: Vector3, entry_dir: Vector3, exit_point: Vector3, exit_dir: Vector3) -> void:
+	var existing := intersection.get_node_or_null(lane_name)
 	var lane := _get_or_create_lane(intersection, container, manager, lane_name)
 	active_lanes.append(lane)
+	if existing is RoadLane and is_instance_valid(existing.owner):
+		return
 	lane.lane_prior_tag = prior_tag
 	lane.lane_next_tag = next_tag
 	_assign_through_curve(lane, intersection, entry, exit_point, entry_dir, exit_dir)
@@ -253,10 +257,13 @@ func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadMan
 	lane.rebuild_geom()
 
 
-## World-space center of a single lane at its edge's stop line.
+## World-space center of a single lane at its edge's stop line. Geometric edges
+## center their lanes; divider-aligned edges keep the direction split at origin.
 func _lane_stop_position(edge: RoadPoint, intersection: Node3D, lane_index: int) -> Vector3:
-	var total := edge.traffic_dir.size()
-	var offset := (lane_index - total / 2.0 + 0.5) * edge.lane_width
+	var reference := edge.traffic_dir.size() / 2.0
+	if edge.alignment == RoadPoint.Alignment.DIVIDER:
+		reference = edge.get_rev_lane_count()
+	var offset := (lane_index - reference + 0.5) * edge.lane_width
 	var perpendicular_v: Vector3 = edge.global_transform.basis.x.normalized()
 	return _edge_stop_center(edge, intersection) + perpendicular_v * offset
 

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -81,7 +81,8 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 				next_tag = target["tag"]
 			var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, src["tag"]]
 			_emit_lane(intersection, container, manager, active_lanes, lane_name,
-					src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir)
+					src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir,
+					not exiting.is_empty())
 
 		# Turn lanes: the turn-side entering lane reaches each remaining edge.
 		for j in range(edges.size()):
@@ -238,7 +239,7 @@ func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager
 
 ## Creates or updates a single lane with its tags, curve and draw settings.
 ## Lanes the user has promoted to editable (given an owner) are left untouched.
-func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, active_lanes: Array[RoadLane], lane_name: String, prior_tag: String, next_tag: String, entry: Vector3, entry_dir: Vector3, exit_point: Vector3, exit_dir: Vector3) -> void:
+func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, active_lanes: Array[RoadLane], lane_name: String, prior_tag: String, next_tag: String, entry: Vector3, entry_dir: Vector3, exit_point: Vector3, exit_dir: Vector3, extend_exit: bool = true) -> void:
 	var existing := intersection.get_node_or_null(lane_name)
 	var lane := _get_or_create_lane(intersection, container, manager, lane_name)
 	active_lanes.append(lane)
@@ -246,7 +247,7 @@ func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadMan
 		return
 	lane.lane_prior_tag = prior_tag
 	lane.lane_next_tag = next_tag
-	_assign_through_curve(lane, intersection, entry, exit_point, entry_dir, exit_dir)
+	_assign_through_curve(lane, intersection, entry, exit_point, entry_dir, exit_dir, extend_exit)
 	lane.draw_in_editor = container.draw_lanes_editor
 	lane.draw_in_game = container.draw_lanes_game
 	lane.refresh_geom = true
@@ -264,20 +265,31 @@ func _lane_stop_position(edge: RoadPoint, intersection: Node3D, lane_index: int)
 	return _edge_stop_center(edge, intersection) + perpendicular_v * offset
 
 
-## Curve from an entry point to an exit point, in the lane's local space, with
-## bezier handles aligned to the entry and exit travel directions so the lane
-## arcs smoothly (and stays straight when the directions are colinear).
-func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3, exit_point: Vector3, entry_dir: Vector3, exit_dir: Vector3) -> void:
+## Curve from an entry RoadPoint to an exit RoadPoint, in the lane's local space.
+## The lane runs straight from each RoadPoint up to its stop line, then arcs
+## across the intersection with bezier handles aligned to the entry and exit
+## travel directions (staying straight when those directions are colinear). With
+## no exit edge to reach, the lane simply ends at the stop line.
+func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3, exit_point: Vector3, entry_dir: Vector3, exit_dir: Vector3, extend_exit: bool = true) -> void:
 	var to_local: Transform3D = lane.global_transform.affine_inverse()
-	var start := to_local * entry
-	var end := to_local * exit_point
-	var handle := start.distance_to(end) / 3.0
-	var start_tangent := (to_local.basis * entry_dir).normalized() * handle
-	var end_tangent := (to_local.basis * exit_dir).normalized() * handle
+	var dir_in := (to_local.basis * entry_dir).normalized()
+	var dir_out := (to_local.basis * exit_dir).normalized()
+	var entry_stop := to_local * entry
+	var exit_stop := to_local * exit_point
+	var lead := dir_in * (STOP_ROW_SIZE / 3.0)
+	var handle := entry_stop.distance_to(exit_stop) / 3.0
 
 	var curve := Curve3D.new()
-	curve.add_point(start, Vector3.ZERO, start_tangent)
-	curve.add_point(end, -end_tangent, Vector3.ZERO)
+	# Lead in from the entry RoadPoint to its stop line, then arc across.
+	curve.add_point(entry_stop - dir_in * STOP_ROW_SIZE, Vector3.ZERO, lead)
+	curve.add_point(entry_stop, -lead, dir_in * handle)
+	if extend_exit:
+		# Arc to the exit stop line, then lead out to the exit RoadPoint.
+		var out_lead := dir_out * (STOP_ROW_SIZE / 3.0)
+		curve.add_point(exit_stop, -dir_out * handle, out_lead)
+		curve.add_point(exit_stop + dir_out * STOP_ROW_SIZE, -out_lead, Vector3.ZERO)
+	else:
+		curve.add_point(exit_stop, -dir_out * handle, Vector3.ZERO)
 	lane.curve = curve
 
 

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -52,7 +52,7 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 		return
 
 	var manager: RoadManager = container.get_manager()
-	var paired := _compute_edge_pairs(edges, intersection)
+	var primaries := _compute_edge_primaries(edges, intersection)
 
 	for i in range(edges.size()):
 		var edge: RoadPoint = edges[i]
@@ -65,12 +65,13 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 		if entering.is_empty():
 			continue
 		var entry_dir := _edge_inward_dir(edge, intersection)
-		var partner: int = paired[i]
+		var primary: int = primaries[i]
 
-		# Through lanes: paired edges carry every entering lane straight across to
-		# their partner. An unpaired edge emits no through lane.
-		if partner >= 0:
-			var exiting := _edge_exit_lanes(edges[partner], intersection)
+		# Through lanes: every entering lane routes straight across to this edge's
+		# primary target. Surplus lanes merge onto its outermost exit lane, built
+		# from the divider outward.
+		if primary >= 0:
+			var exiting := _edge_exit_lanes(edges[primary], intersection)
 			for k in range(entering.size()):
 				var src: Dictionary = entering[k]
 				var entry := _lane_stop_position(edge, intersection, src["index"])
@@ -89,7 +90,7 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 
 		# Turn lanes: the turn-side entering lane reaches each remaining edge.
 		for j in range(edges.size()):
-			if j == i or j == partner or not is_instance_valid(edges[j]):
+			if j == i or j == primary or not is_instance_valid(edges[j]):
 				continue
 			var target_edge: RoadPoint = edges[j]
 			var target_facing: _IntersectNGonFacing = _get_edge_facing(target_edge, intersection)
@@ -195,12 +196,12 @@ func _edge_is_eligible(edges: Array[RoadPoint], index: int, intersection: Node3D
 	return _get_edge_facing(edges[index], intersection) != _IntersectNGonFacing.OTHER
 
 
-## Pairs each edge with the one across the intersection it points most directly
-## at (smallest angle from dead-ahead, regardless of distance). Two edges are
-## paired only when they choose each other; the returned array holds each edge's
-## partner index, or -1 when it has none. Resolved without recursion, so the
-## pairing never depends on evaluation order.
-func _compute_edge_pairs(edges: Array[RoadPoint], intersection: Node3D) -> Array[int]:
+## Picks each edge's primary target: the edge across the intersection it points
+## most directly at (smallest angle from dead-ahead, regardless of distance).
+## The returned array holds each edge's primary index, or -1 when it has none.
+## Every eligible edge routes its entering lanes through to its primary, whether
+## or not the choice is reciprocated.
+func _compute_edge_primaries(edges: Array[RoadPoint], intersection: Node3D) -> Array[int]:
 	var origin := intersection.global_transform.origin
 	var count := edges.size()
 	var primary: Array[int] = []
@@ -220,14 +221,7 @@ func _compute_edge_pairs(edges: Array[RoadPoint], intersection: Node3D) -> Array
 				best_dot = dot
 				best = j
 		primary[i] = best
-	var paired: Array[int] = []
-	paired.resize(count)
-	paired.fill(-1)
-	for i in range(count):
-		var choice := primary[i]
-		if choice >= 0 and primary[choice] == i:
-			paired[i] = choice
-	return paired
+	return primary
 
 
 ## True if the target edge lies clockwise (to the right) of the edge's inbound

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -225,12 +225,14 @@ func _compute_edge_primaries(edges: Array[RoadPoint], intersection: Node3D) -> A
 
 
 ## True if the target edge lies clockwise (to the right) of the edge's inbound
-## direction about the intersection's up axis.
+## direction about the intersection's up axis. A right turn sources from the
+## outer entering lane; a left turn from the inner (divider-side) lane.
 func _turn_is_clockwise(edge: RoadPoint, target: RoadPoint, intersection: Node3D) -> bool:
 	var up: Vector3 = intersection.global_transform.basis.y.normalized()
 	var inward := _edge_inward_dir(edge, intersection)
 	var to_target := (target.global_transform.origin - intersection.global_transform.origin).normalized()
-	return inward.signed_angle_to(to_target, up) > 0.0
+	# Around +Y, a right turn yields a negative signed angle from inbound to target.
+	return inward.signed_angle_to(to_target, up) < 0.0
 
 
 ## Finds an existing generated lane by name or creates one, ensuring group

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -76,12 +76,15 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 			lane.lane_prior_tag = lane_info["tag"]
 
 			var entry := _lane_stop_position(edge, intersection, lane_info["index"])
+			var entry_dir := _edge_inward_dir(edge, intersection)
 			var exit_point := intersection.global_transform.origin
+			var exit_dir := entry_dir
 			if not exiting.is_empty():
 				var target: Dictionary = exiting[mini(k, exiting.size() - 1)]
 				exit_point = _lane_stop_position(target["edge"], intersection, target["index"])
+				exit_dir = -_edge_inward_dir(target["edge"], intersection)
 				lane.lane_next_tag = target["tag"]
-			_assign_through_curve(lane, intersection, entry, exit_point)
+			_assign_through_curve(lane, intersection, entry, exit_point, entry_dir, exit_dir)
 
 			lane.draw_in_editor = container.draw_lanes_editor
 			lane.draw_in_game = container.draw_lanes_game
@@ -114,13 +117,19 @@ func _get_edge_facing(edge: RoadPoint, intersection: Node3D) -> _IntersectNGonFa
 	return facing
 
 
-## World-space center of an edge's stop line, where its lanes meet the intersection.
-func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
+## World-space direction along an edge pointing toward the intersection (the
+## travel direction of its entering lanes).
+func _edge_inward_dir(edge: RoadPoint, intersection: Node3D) -> Vector3:
 	var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
 	var parallel_v: Vector3 = edge.global_transform.basis.z.normalized()
 	if facing == _IntersectNGonFacing.ORIGIN:
 		parallel_v = -parallel_v
-	return edge.global_transform.origin + parallel_v * STOP_ROW_SIZE
+	return parallel_v
+
+
+## World-space center of an edge's stop line, where its lanes meet the intersection.
+func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
+	return edge.global_transform.origin + _edge_inward_dir(edge, intersection) * STOP_ROW_SIZE
 
 
 func _entering_dir(facing: _IntersectNGonFacing) -> int:
@@ -213,12 +222,20 @@ func _lane_stop_position(edge: RoadPoint, intersection: Node3D, lane_index: int)
 	return _edge_stop_center(edge, intersection) + perpendicular_v * offset
 
 
-## Straight line from an entry point to an exit point, in the lane's local space.
-func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3, exit_point: Vector3) -> void:
+## Curve from an entry point to an exit point, in the lane's local space, with
+## bezier handles aligned to the entry and exit travel directions so the lane
+## arcs smoothly (and stays straight when the directions are colinear).
+func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3, exit_point: Vector3, entry_dir: Vector3, exit_dir: Vector3) -> void:
 	var to_local: Transform3D = lane.global_transform.affine_inverse()
+	var start := to_local * entry
+	var end := to_local * exit_point
+	var handle := start.distance_to(end) / 3.0
+	var start_tangent := (to_local.basis * entry_dir).normalized() * handle
+	var end_tangent := (to_local.basis * exit_dir).normalized() * handle
+
 	var curve := Curve3D.new()
-	curve.add_point(to_local * entry)
-	curve.add_point(to_local * exit_point)
+	curve.add_point(start, Vector3.ZERO, start_tangent)
+	curve.add_point(end, -end_tangent, Vector3.ZERO)
 	lane.curve = curve
 
 

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -52,6 +52,7 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 		return
 
 	var manager: RoadManager = container.get_manager()
+	var paired := _compute_edge_pairs(edges, intersection)
 
 	for i in range(edges.size()):
 		var edge: RoadPoint = edges[i]
@@ -64,29 +65,31 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 		if entering.is_empty():
 			continue
 		var entry_dir := _edge_inward_dir(edge, intersection)
-		var opposite := _opposite_edge(edges, i, intersection)
+		var partner: int = paired[i]
 
-		# Through lanes: every entering lane continues to the opposite edge.
-		var exiting := _opposite_exit_lanes(edges, i, intersection)
-		for k in range(entering.size()):
-			var src: Dictionary = entering[k]
-			var entry := _lane_stop_position(edge, intersection, src["index"])
-			var exit_point := intersection.global_transform.origin
-			var exit_dir := entry_dir
-			var next_tag := ""
-			if not exiting.is_empty():
-				var target: Dictionary = exiting[mini(k, exiting.size() - 1)]
-				exit_point = _lane_stop_position(target["edge"], intersection, target["index"])
-				exit_dir = -_edge_inward_dir(target["edge"], intersection)
-				next_tag = target["tag"]
-			var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, src["tag"]]
-			_emit_lane(intersection, container, manager, active_lanes, lane_name,
-					src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir,
-					not exiting.is_empty())
+		# Through lanes: paired edges carry every entering lane straight across to
+		# their partner. An unpaired edge emits no through lane.
+		if partner >= 0:
+			var exiting := _edge_exit_lanes(edges[partner], intersection)
+			for k in range(entering.size()):
+				var src: Dictionary = entering[k]
+				var entry := _lane_stop_position(edge, intersection, src["index"])
+				var exit_point := intersection.global_transform.origin
+				var exit_dir := entry_dir
+				var next_tag := ""
+				if not exiting.is_empty():
+					var target: Dictionary = exiting[mini(k, exiting.size() - 1)]
+					exit_point = _lane_stop_position(target["edge"], intersection, target["index"])
+					exit_dir = -_edge_inward_dir(target["edge"], intersection)
+					next_tag = target["tag"]
+				var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, src["tag"]]
+				_emit_lane(intersection, container, manager, active_lanes, lane_name,
+						src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir,
+						not exiting.is_empty())
 
 		# Turn lanes: the turn-side entering lane reaches each remaining edge.
 		for j in range(edges.size()):
-			if j == i or j == opposite or not is_instance_valid(edges[j]):
+			if j == i or j == partner or not is_instance_valid(edges[j]):
 				continue
 			var target_edge: RoadPoint = edges[j]
 			var target_facing: _IntersectNGonFacing = _get_edge_facing(target_edge, intersection)
@@ -172,38 +175,59 @@ func _directional_lanes(edge: RoadPoint, dir: int) -> Array:
 	return result
 
 
-## Exit lanes of the edge most directly opposite the one at `index`, tagged with
-## the edge they belong to so a through lane can target them.
-func _opposite_exit_lanes(edges: Array[RoadPoint], index: int, intersection: Node3D) -> Array:
-	var opposite := _opposite_edge(edges, index, intersection)
-	if opposite < 0:
-		return []
-	var opposite_edge: RoadPoint = edges[opposite]
-	var facing: _IntersectNGonFacing = _get_edge_facing(opposite_edge, intersection)
+## Exit lanes available on an edge, tagged with the edge they belong to so a
+## through lane can target them.
+func _edge_exit_lanes(edge: RoadPoint, intersection: Node3D) -> Array:
+	var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
 	if facing == _IntersectNGonFacing.OTHER:
 		return []
-	var lanes := _directional_lanes(opposite_edge, _exiting_dir(facing))
+	var lanes := _directional_lanes(edge, _exiting_dir(facing))
 	for lane in lanes:
-		lane["edge"] = opposite_edge
+		lane["edge"] = edge
 	return lanes
 
 
-## Index of the edge whose direction from the intersection is most opposed to
-## the edge at `index`, or -1 if none.
-func _opposite_edge(edges: Array[RoadPoint], index: int, intersection: Node3D) -> int:
+## True when the edge at `index` is a valid, intersection-facing edge eligible
+## to take part in lane matching.
+func _edge_is_eligible(edges: Array[RoadPoint], index: int, intersection: Node3D) -> bool:
+	if not is_instance_valid(edges[index]):
+		return false
+	return _get_edge_facing(edges[index], intersection) != _IntersectNGonFacing.OTHER
+
+
+## Pairs each edge with the one across the intersection it points most directly
+## at (smallest angle from dead-ahead, regardless of distance). Two edges are
+## paired only when they choose each other; the returned array holds each edge's
+## partner index, or -1 when it has none. Resolved without recursion, so the
+## pairing never depends on evaluation order.
+func _compute_edge_pairs(edges: Array[RoadPoint], intersection: Node3D) -> Array[int]:
 	var origin := intersection.global_transform.origin
-	var dir_index := (edges[index].global_transform.origin - origin).normalized()
-	var best := -1
-	var best_dot := INF
-	for j in range(edges.size()):
-		if j == index or not is_instance_valid(edges[j]):
+	var count := edges.size()
+	var primary: Array[int] = []
+	primary.resize(count)
+	primary.fill(-1)
+	for i in range(count):
+		if not _edge_is_eligible(edges, i, intersection):
 			continue
-		var dir_other := (edges[j].global_transform.origin - origin).normalized()
-		var dot := dir_index.dot(dir_other)
-		if dot < best_dot:
-			best_dot = dot
-			best = j
-	return best
+		var dir_i := (edges[i].global_transform.origin - origin).normalized()
+		var best := -1
+		var best_dot := INF
+		for j in range(count):
+			if j == i or not _edge_is_eligible(edges, j, intersection):
+				continue
+			var dot := dir_i.dot((edges[j].global_transform.origin - origin).normalized())
+			if dot < best_dot:
+				best_dot = dot
+				best = j
+		primary[i] = best
+	var paired: Array[int] = []
+	paired.resize(count)
+	paired.fill(-1)
+	for i in range(count):
+		var choice := primary[i]
+		if choice >= 0 and primary[choice] == i:
+			paired[i] = choice
+	return paired
 
 
 ## True if the target edge lies clockwise (to the right) of the edge's inbound

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -99,7 +99,8 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 			var target_exit := _directional_lanes(target_edge, _exiting_dir(target_facing))
 			if target_exit.is_empty():
 				continue
-			var clockwise := _turn_is_clockwise(edge, target_edge, intersection)
+			var reference_edge: RoadPoint = edges[primary] if primary >= 0 else null
+			var clockwise := _turn_is_clockwise(edge, target_edge, reference_edge, intersection)
 			var turn_src: Dictionary = entering[entering.size() - 1] if clockwise else entering[0]
 			var turn_dst: Dictionary = target_exit[target_exit.size() - 1] if clockwise else target_exit[0]
 			var turn_entry := _lane_stop_position(edge, intersection, turn_src["index"])
@@ -242,15 +243,23 @@ func _compute_edge_primaries(edges: Array[RoadPoint], intersection: Node3D) -> A
 	return primary
 
 
-## True if the target edge lies clockwise (to the right) of the edge's inbound
-## direction about the intersection's up axis. A right turn sources from the
-## outer entering lane; a left turn from the inner (divider-side) lane.
-func _turn_is_clockwise(edge: RoadPoint, target: RoadPoint, intersection: Node3D) -> bool:
+## True if the target edge lies clockwise (to the right) of the straight-through
+## direction toward this edge's `reference` (primary) target. Measuring handedness
+## against the primary, rather than the raw inbound facing, ties every left/right
+## flip to the moment the edge's primary pairing changes, so a turn never crosses
+## traffic mid-rotation. Falls back to inbound facing when there is no primary.
+## A right turn sources from the outer entering lane; a left turn from the inner
+## (divider-side) lane.
+func _turn_is_clockwise(edge: RoadPoint, target: RoadPoint, reference: RoadPoint, intersection: Node3D) -> bool:
 	var up: Vector3 = intersection.global_transform.basis.y.normalized()
-	var inward := _edge_inward_dir(edge, intersection)
-	var to_target := (target.global_transform.origin - intersection.global_transform.origin).normalized()
-	# Around +Y, a right turn yields a negative signed angle from inbound to target.
-	return inward.signed_angle_to(to_target, up) < 0.0
+	var ahead: Vector3
+	if is_instance_valid(reference):
+		ahead = reference.global_transform.origin - edge.global_transform.origin
+	else:
+		ahead = _edge_inward_dir(edge, intersection)
+	var to_target := target.global_transform.origin - edge.global_transform.origin
+	# Around +Y, a right turn yields a negative signed angle from ahead to target.
+	return ahead.signed_angle_to(to_target, up) < 0.0
 
 
 ## Finds an existing generated lane by name or creates one, ensuring group

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -46,10 +46,6 @@ func get_min_distance_from_intersection_point(rp: RoadPoint) -> float:
 
 
 func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
-	if not intersection.has_method("is_road_intersection"):
-		push_error("intersection is not an intersection node, skipping lane generation.")
-		return
-
 	var active_lanes: Array[RoadLane] = []
 	if not container.generate_ai_lanes:
 		_clear_generated_lanes(intersection, active_lanes)

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -146,11 +146,11 @@ func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
 
 
 func _entering_dir(facing: _IntersectNGonFacing) -> int:
-	return RoadPoint.LaneDir.FORWARD if facing == _IntersectNGonFacing.AWAY else RoadPoint.LaneDir.REVERSE
+	return RoadPoint.LaneDir.REVERSE if facing == _IntersectNGonFacing.AWAY else RoadPoint.LaneDir.FORWARD
 
 
 func _exiting_dir(facing: _IntersectNGonFacing) -> int:
-	return RoadPoint.LaneDir.REVERSE if facing == _IntersectNGonFacing.AWAY else RoadPoint.LaneDir.FORWARD
+	return RoadPoint.LaneDir.FORWARD if facing == _IntersectNGonFacing.AWAY else RoadPoint.LaneDir.REVERSE
 
 
 ## Lanes of the given direction on an edge, ordered from the centerline outward,

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -21,6 +21,15 @@ const SegGeo := preload("res://addons/road-generator/procgen/segment_geo.gd")
 
 const STOP_ROW_SIZE: float = 2.0  # TODO: make proportional to density
 
+## Meters of lateral error treated as equivalent to one radian of facing
+## misalignment when scoring primary candidates. Lateral offset is weighted more
+## heavily than angle, so a candidate the source aims squarely at is preferred
+## over one that merely faces back from off to the side.
+const _PRIMARY_ANGLE_WEIGHT: float = 6.0
+## Error added to a candidate sitting beside or behind the source, ruling out
+## same-side edges as through partners.
+const _PRIMARY_BEHIND_PENALTY: float = 1.0e6
+
 # ------------------------------------------------------------------------------
 #endregion
 #region Abstract overrides
@@ -199,15 +208,6 @@ func _edge_is_eligible(edges: Array[RoadPoint], index: int, intersection: Node3D
 	return _get_edge_facing(edges[index], intersection) != _IntersectNGonFacing.OTHER
 
 
-## Meters of lateral error treated as equivalent to one radian of facing
-## misalignment when scoring primary candidates. Lateral offset is weighted more
-## heavily than angle, so a candidate the source aims squarely at is preferred
-## over one that merely faces back from off to the side.
-const _PRIMARY_ANGLE_WEIGHT: float = 6.0
-## Error added to a candidate sitting beside or behind the source, ruling out
-## same-side edges as through partners.
-const _PRIMARY_BEHIND_PENALTY: float = 1.0e6
-
 ## Perpendicular distance from `rel` to the ray along `dir`, scaled by lane width
 ## so the lateral-vs-angle balance in pairing holds for roads built at any lane
 ## size: a road with wide lanes spaces its edges proportionally wider, and without
@@ -297,7 +297,19 @@ func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager
 
 ## Creates or updates a single lane with its tags, curve and draw settings.
 ## Lanes the user has promoted to editable (given an owner) are left untouched.
-func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, active_lanes: Array[RoadLane], lane_name: String, prior_tag: String, next_tag: String, entry: Vector3, entry_dir: Vector3, exit_point: Vector3, exit_dir: Vector3, extend_exit: bool = true) -> void:
+func _emit_lane(
+		intersection: Node3D,
+		container: RoadContainer,
+		manager: RoadManager,
+		active_lanes: Array[RoadLane],
+		lane_name: String,
+		prior_tag: String,
+		next_tag: String,
+		entry: Vector3,
+		entry_dir: Vector3,
+		exit_point: Vector3,
+		exit_dir: Vector3,
+		extend_exit: bool = true) -> void:
 	var existing := intersection.get_node_or_null(lane_name)
 	var lane := _get_or_create_lane(intersection, container, manager, lane_name)
 	active_lanes.append(lane)

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -20,7 +20,6 @@ enum _IntersectNGonFacing {
 const SegGeo := preload("res://addons/road-generator/procgen/segment_geo.gd")
 
 const STOP_ROW_SIZE: float = 2.0  # TODO: make proportional to density
-const LANE_NAME_PREFIX := "RoadLane_"
 
 # ------------------------------------------------------------------------------
 #endregion
@@ -51,6 +50,7 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 		_clear_generated_lanes(intersection, active_lanes)
 		return
 
+	var used_names := {}
 	var manager: RoadManager = container.get_manager()
 	var primaries := _compute_edge_primaries(edges, intersection)
 
@@ -78,12 +78,14 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 				var exit_point := intersection.global_transform.origin
 				var exit_dir := entry_dir
 				var next_tag := ""
+				var merged := false
 				if not exiting.is_empty():
+					merged = k >= exiting.size()
 					var target: Dictionary = exiting[mini(k, exiting.size() - 1)]
 					exit_point = _lane_stop_position(target["edge"], intersection, target["index"])
 					exit_dir = -_edge_inward_dir(target["edge"], intersection)
 					next_tag = target["tag"]
-				var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, src["tag"]]
+				var lane_name := _tagged_lane_name(used_names, edge.name, src["tag"], "r" if merged else "")
 				_emit_lane(intersection, container, manager, active_lanes, lane_name,
 						src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir,
 						not exiting.is_empty())
@@ -106,7 +108,7 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 			var turn_entry := _lane_stop_position(edge, intersection, turn_src["index"])
 			var turn_exit := _lane_stop_position(target_edge, intersection, turn_dst["index"])
 			var turn_exit_dir := -_edge_inward_dir(target_edge, intersection)
-			var turn_name := "%s%s_%s_%s" % [LANE_NAME_PREFIX, edge.name, turn_src["tag"], target_edge.name]
+			var turn_name := _tagged_lane_name(used_names, edge.name, turn_src["tag"], "a")
 			_emit_lane(intersection, container, manager, active_lanes, turn_name,
 					turn_src["tag"], turn_dst["tag"], turn_entry, entry_dir, turn_exit, turn_exit_dir)
 
@@ -347,6 +349,22 @@ func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3,
 	else:
 		curve.add_point(exit_stop, -dir_out * handle, Vector3.ZERO)
 	lane.curve = curve
+
+
+## Builds a lane's tagged name in the segment-lane style, prefixed by the source
+## edge: `edge_pTAG_nTAG` for a straight through lane, with an `a` suffix for a
+## turn or `r` for an outer lane squeezed into a merge. A counter is appended when
+## a name would otherwise repeat (e.g. two turns off the same lane), keeping every
+## lane uniquely and stably named for reuse across rebuilds.
+func _tagged_lane_name(used: Dictionary, edge_name: String, tag: String, suffix: String) -> String:
+	var base := "%s_p%s_n%s%s" % [edge_name, tag, tag, suffix]
+	var lane_name := base
+	var counter := 2
+	while used.has(lane_name):
+		lane_name = "%s%d" % [base, counter]
+		counter += 1
+	used[lane_name] = true
+	return lane_name
 
 
 ## Frees previously generated lanes that are no longer active.

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -60,33 +60,21 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 	for edge: RoadPoint in edges:
 		if not is_instance_valid(edge):
 			continue
+		var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
+		if facing == _IntersectNGonFacing.OTHER:
+			continue
 
-		var lane_name := "%s%s" % [LANE_NAME_PREFIX, edge.name]
-		var existing := intersection.get_node_or_null(lane_name)
-		var lane: RoadLane
-		if existing is RoadLane:
-			lane = existing
-		else:
-			lane = RoadLane.new()
-			intersection.add_child(lane)
-			lane.name = lane_name
-			lane.set_meta("_edit_lock_", true)
-			lane.auto_free_vehicles = container.auto_free_vehicles
-			if container.debug_scene_visible:
-				lane.owner = container.get_owner()
-		active_lanes.append(lane)
+		for lane_info in _entering_lanes(edge, facing):
+			var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, lane_info["tag"]]
+			var lane := _get_or_create_lane(intersection, container, manager, lane_name)
+			active_lanes.append(lane)
+			lane.lane_prior_tag = lane_info["tag"]
+			_assign_entering_curve(lane, edge, intersection, lane_info["index"])
 
-		if container.ai_lane_group != "":
-			lane.add_to_group(container.ai_lane_group)
-		elif is_instance_valid(manager) and manager.ai_lane_group != "":
-			lane.add_to_group(manager.ai_lane_group)
-
-		_assign_edge_stub_curve(lane, edge, intersection)
-
-		lane.draw_in_editor = container.draw_lanes_editor
-		lane.draw_in_game = container.draw_lanes_game
-		lane.refresh_geom = true
-		lane.rebuild_geom()
+			lane.draw_in_editor = container.draw_lanes_editor
+			lane.draw_in_game = container.draw_lanes_game
+			lane.refresh_geom = true
+			lane.rebuild_geom()
 
 	_clear_generated_lanes(intersection, active_lanes)
 
@@ -123,13 +111,60 @@ func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
 	return edge.global_transform.origin + parallel_v * STOP_ROW_SIZE
 
 
-## Straight line from the intersection center to the edge's stop line,
+## Lanes flowing into the intersection from an edge, each as a dictionary with
+## its `index` in the edge's traffic_dir and its `F#`/`R#` `tag`.
+func _entering_lanes(edge: RoadPoint, facing: _IntersectNGonFacing) -> Array:
+	var entering_dir := RoadPoint.LaneDir.FORWARD
+	if facing == _IntersectNGonFacing.ORIGIN:
+		entering_dir = RoadPoint.LaneDir.REVERSE
+	var rev_count := edge.get_rev_lane_count()
+	var result: Array = []
+	for i in range(edge.traffic_dir.size()):
+		if edge.traffic_dir[i] != entering_dir:
+			continue
+		var tag: String
+		if entering_dir == RoadPoint.LaneDir.FORWARD:
+			tag = "F%d" % (i - rev_count)
+		else:
+			tag = "R%d" % (rev_count - 1 - i)
+		result.append({"index": i, "tag": tag})
+	return result
+
+
+## Finds an existing generated lane by name or creates one, ensuring group
+## membership and editor metadata.
+func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, lane_name: String) -> RoadLane:
+	var existing := intersection.get_node_or_null(lane_name)
+	var lane: RoadLane
+	if existing is RoadLane:
+		lane = existing
+	else:
+		lane = RoadLane.new()
+		intersection.add_child(lane)
+		lane.name = lane_name
+		lane.set_meta("_edit_lock_", true)
+		lane.auto_free_vehicles = container.auto_free_vehicles
+		if container.debug_scene_visible:
+			lane.owner = container.get_owner()
+	if container.ai_lane_group != "":
+		lane.add_to_group(container.ai_lane_group)
+	elif is_instance_valid(manager) and manager.ai_lane_group != "":
+		lane.add_to_group(manager.ai_lane_group)
+	return lane
+
+
+## Straight line from a lane's stop-line center to the intersection center,
 ## stored in the lane's local space.
-func _assign_edge_stub_curve(lane: RoadLane, edge: RoadPoint, intersection: Node3D) -> void:
+func _assign_entering_curve(lane: RoadLane, edge: RoadPoint, intersection: Node3D, lane_index: int) -> void:
+	var total := edge.traffic_dir.size()
+	var offset := (lane_index - total / 2.0 + 0.5) * edge.lane_width
+	var perpendicular_v: Vector3 = edge.global_transform.basis.x.normalized()
+	var lane_entry := _edge_stop_center(edge, intersection) + perpendicular_v * offset
+
 	var to_local: Transform3D = lane.global_transform.affine_inverse()
 	var curve := Curve3D.new()
+	curve.add_point(to_local * lane_entry)
 	curve.add_point(to_local * intersection.global_transform.origin)
-	curve.add_point(to_local * _edge_stop_center(edge, intersection))
 	lane.curve = curve
 
 

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -57,19 +57,31 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 
 	var manager: RoadManager = container.get_manager()
 
-	for edge: RoadPoint in edges:
+	for i in range(edges.size()):
+		var edge: RoadPoint = edges[i]
 		if not is_instance_valid(edge):
 			continue
 		var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
 		if facing == _IntersectNGonFacing.OTHER:
 			continue
 
-		for lane_info in _entering_lanes(edge, facing):
+		var entering := _directional_lanes(edge, _entering_dir(facing))
+		var exiting := _opposite_exit_lanes(edges, i, intersection)
+
+		for k in range(entering.size()):
+			var lane_info: Dictionary = entering[k]
 			var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, lane_info["tag"]]
 			var lane := _get_or_create_lane(intersection, container, manager, lane_name)
 			active_lanes.append(lane)
 			lane.lane_prior_tag = lane_info["tag"]
-			_assign_entering_curve(lane, edge, intersection, lane_info["index"])
+
+			var entry := _lane_stop_position(edge, intersection, lane_info["index"])
+			var exit_point := intersection.global_transform.origin
+			if not exiting.is_empty():
+				var target: Dictionary = exiting[mini(k, exiting.size() - 1)]
+				exit_point = _lane_stop_position(target["edge"], intersection, target["index"])
+				lane.lane_next_tag = target["tag"]
+			_assign_through_curve(lane, intersection, entry, exit_point)
 
 			lane.draw_in_editor = container.draw_lanes_editor
 			lane.draw_in_game = container.draw_lanes_game
@@ -111,24 +123,64 @@ func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
 	return edge.global_transform.origin + parallel_v * STOP_ROW_SIZE
 
 
-## Lanes flowing into the intersection from an edge, each as a dictionary with
-## its `index` in the edge's traffic_dir and its `F#`/`R#` `tag`.
-func _entering_lanes(edge: RoadPoint, facing: _IntersectNGonFacing) -> Array:
-	var entering_dir := RoadPoint.LaneDir.FORWARD
-	if facing == _IntersectNGonFacing.ORIGIN:
-		entering_dir = RoadPoint.LaneDir.REVERSE
+func _entering_dir(facing: _IntersectNGonFacing) -> int:
+	return RoadPoint.LaneDir.FORWARD if facing == _IntersectNGonFacing.AWAY else RoadPoint.LaneDir.REVERSE
+
+
+func _exiting_dir(facing: _IntersectNGonFacing) -> int:
+	return RoadPoint.LaneDir.REVERSE if facing == _IntersectNGonFacing.AWAY else RoadPoint.LaneDir.FORWARD
+
+
+## Lanes of the given direction on an edge, ordered from the centerline outward,
+## each as a dictionary with its `index` in traffic_dir and its `F#`/`R#` `tag`.
+func _directional_lanes(edge: RoadPoint, dir: int) -> Array:
 	var rev_count := edge.get_rev_lane_count()
 	var result: Array = []
 	for i in range(edge.traffic_dir.size()):
-		if edge.traffic_dir[i] != entering_dir:
+		if edge.traffic_dir[i] != dir:
 			continue
 		var tag: String
-		if entering_dir == RoadPoint.LaneDir.FORWARD:
+		if dir == RoadPoint.LaneDir.FORWARD:
 			tag = "F%d" % (i - rev_count)
 		else:
 			tag = "R%d" % (rev_count - 1 - i)
 		result.append({"index": i, "tag": tag})
+	result.sort_custom(func(a, b): return int(a["tag"].substr(1)) < int(b["tag"].substr(1)))
 	return result
+
+
+## Exit lanes of the edge most directly opposite the one at `index`, tagged with
+## the edge they belong to so a through lane can target them.
+func _opposite_exit_lanes(edges: Array[RoadPoint], index: int, intersection: Node3D) -> Array:
+	var opposite := _opposite_edge(edges, index, intersection)
+	if opposite < 0:
+		return []
+	var opposite_edge: RoadPoint = edges[opposite]
+	var facing: _IntersectNGonFacing = _get_edge_facing(opposite_edge, intersection)
+	if facing == _IntersectNGonFacing.OTHER:
+		return []
+	var lanes := _directional_lanes(opposite_edge, _exiting_dir(facing))
+	for lane in lanes:
+		lane["edge"] = opposite_edge
+	return lanes
+
+
+## Index of the edge whose direction from the intersection is most opposed to
+## the edge at `index`, or -1 if none.
+func _opposite_edge(edges: Array[RoadPoint], index: int, intersection: Node3D) -> int:
+	var origin := intersection.global_transform.origin
+	var dir_index := (edges[index].global_transform.origin - origin).normalized()
+	var best := -1
+	var best_dot := INF
+	for j in range(edges.size()):
+		if j == index or not is_instance_valid(edges[j]):
+			continue
+		var dir_other := (edges[j].global_transform.origin - origin).normalized()
+		var dot := dir_index.dot(dir_other)
+		if dot < best_dot:
+			best_dot = dot
+			best = j
+	return best
 
 
 ## Finds an existing generated lane by name or creates one, ensuring group
@@ -153,18 +205,20 @@ func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager
 	return lane
 
 
-## Straight line from a lane's stop-line center to the intersection center,
-## stored in the lane's local space.
-func _assign_entering_curve(lane: RoadLane, edge: RoadPoint, intersection: Node3D, lane_index: int) -> void:
+## World-space center of a single lane at its edge's stop line.
+func _lane_stop_position(edge: RoadPoint, intersection: Node3D, lane_index: int) -> Vector3:
 	var total := edge.traffic_dir.size()
 	var offset := (lane_index - total / 2.0 + 0.5) * edge.lane_width
 	var perpendicular_v: Vector3 = edge.global_transform.basis.x.normalized()
-	var lane_entry := _edge_stop_center(edge, intersection) + perpendicular_v * offset
+	return _edge_stop_center(edge, intersection) + perpendicular_v * offset
 
+
+## Straight line from an entry point to an exit point, in the lane's local space.
+func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3, exit_point: Vector3) -> void:
 	var to_local: Transform3D = lane.global_transform.affine_inverse()
 	var curve := Curve3D.new()
-	curve.add_point(to_local * lane_entry)
-	curve.add_point(to_local * intersection.global_transform.origin)
+	curve.add_point(to_local * entry)
+	curve.add_point(to_local * exit_point)
 	lane.curve = curve
 
 

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -64,32 +64,49 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 		var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
 		if facing == _IntersectNGonFacing.OTHER:
 			continue
-
 		var entering := _directional_lanes(edge, _entering_dir(facing))
+		if entering.is_empty():
+			continue
+		var entry_dir := _edge_inward_dir(edge, intersection)
+		var opposite := _opposite_edge(edges, i, intersection)
+
+		# Through lanes: every entering lane continues to the opposite edge.
 		var exiting := _opposite_exit_lanes(edges, i, intersection)
-
 		for k in range(entering.size()):
-			var lane_info: Dictionary = entering[k]
-			var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, lane_info["tag"]]
-			var lane := _get_or_create_lane(intersection, container, manager, lane_name)
-			active_lanes.append(lane)
-			lane.lane_prior_tag = lane_info["tag"]
-
-			var entry := _lane_stop_position(edge, intersection, lane_info["index"])
-			var entry_dir := _edge_inward_dir(edge, intersection)
+			var src: Dictionary = entering[k]
+			var entry := _lane_stop_position(edge, intersection, src["index"])
 			var exit_point := intersection.global_transform.origin
 			var exit_dir := entry_dir
+			var next_tag := ""
 			if not exiting.is_empty():
 				var target: Dictionary = exiting[mini(k, exiting.size() - 1)]
 				exit_point = _lane_stop_position(target["edge"], intersection, target["index"])
 				exit_dir = -_edge_inward_dir(target["edge"], intersection)
-				lane.lane_next_tag = target["tag"]
-			_assign_through_curve(lane, intersection, entry, exit_point, entry_dir, exit_dir)
+				next_tag = target["tag"]
+			var lane_name := "%s%s_%s" % [LANE_NAME_PREFIX, edge.name, src["tag"]]
+			_emit_lane(intersection, container, manager, active_lanes, lane_name,
+					src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir)
 
-			lane.draw_in_editor = container.draw_lanes_editor
-			lane.draw_in_game = container.draw_lanes_game
-			lane.refresh_geom = true
-			lane.rebuild_geom()
+		# Turn lanes: the turn-side entering lane reaches each remaining edge.
+		for j in range(edges.size()):
+			if j == i or j == opposite or not is_instance_valid(edges[j]):
+				continue
+			var target_edge: RoadPoint = edges[j]
+			var target_facing: _IntersectNGonFacing = _get_edge_facing(target_edge, intersection)
+			if target_facing == _IntersectNGonFacing.OTHER:
+				continue
+			var target_exit := _directional_lanes(target_edge, _exiting_dir(target_facing))
+			if target_exit.is_empty():
+				continue
+			var clockwise := _turn_is_clockwise(edge, target_edge, intersection)
+			var turn_src: Dictionary = entering[entering.size() - 1] if clockwise else entering[0]
+			var turn_dst: Dictionary = target_exit[target_exit.size() - 1] if clockwise else target_exit[0]
+			var turn_entry := _lane_stop_position(edge, intersection, turn_src["index"])
+			var turn_exit := _lane_stop_position(target_edge, intersection, turn_dst["index"])
+			var turn_exit_dir := -_edge_inward_dir(target_edge, intersection)
+			var turn_name := "%s%s_%s_%s" % [LANE_NAME_PREFIX, edge.name, turn_src["tag"], target_edge.name]
+			_emit_lane(intersection, container, manager, active_lanes, turn_name,
+					turn_src["tag"], turn_dst["tag"], turn_entry, entry_dir, turn_exit, turn_exit_dir)
 
 	_clear_generated_lanes(intersection, active_lanes)
 
@@ -192,6 +209,15 @@ func _opposite_edge(edges: Array[RoadPoint], index: int, intersection: Node3D) -
 	return best
 
 
+## True if the target edge lies clockwise (to the right) of the edge's inbound
+## direction about the intersection's up axis.
+func _turn_is_clockwise(edge: RoadPoint, target: RoadPoint, intersection: Node3D) -> bool:
+	var up: Vector3 = intersection.global_transform.basis.y.normalized()
+	var inward := _edge_inward_dir(edge, intersection)
+	var to_target := (target.global_transform.origin - intersection.global_transform.origin).normalized()
+	return inward.signed_angle_to(to_target, up) > 0.0
+
+
 ## Finds an existing generated lane by name or creates one, ensuring group
 ## membership and editor metadata.
 func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, lane_name: String) -> RoadLane:
@@ -212,6 +238,19 @@ func _get_or_create_lane(intersection: Node3D, container: RoadContainer, manager
 	elif is_instance_valid(manager) and manager.ai_lane_group != "":
 		lane.add_to_group(manager.ai_lane_group)
 	return lane
+
+
+## Creates or updates a single lane with its tags, curve and draw settings.
+func _emit_lane(intersection: Node3D, container: RoadContainer, manager: RoadManager, active_lanes: Array[RoadLane], lane_name: String, prior_tag: String, next_tag: String, entry: Vector3, entry_dir: Vector3, exit_point: Vector3, exit_dir: Vector3) -> void:
+	var lane := _get_or_create_lane(intersection, container, manager, lane_name)
+	active_lanes.append(lane)
+	lane.lane_prior_tag = prior_tag
+	lane.lane_next_tag = next_tag
+	_assign_through_curve(lane, intersection, entry, exit_point, entry_dir, exit_dir)
+	lane.draw_in_editor = container.draw_lanes_editor
+	lane.draw_in_game = container.draw_lanes_game
+	lane.refresh_geom = true
+	lane.rebuild_geom()
 
 
 ## World-space center of a single lane at its edge's stop line.

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -196,13 +196,23 @@ func _edge_is_eligible(edges: Array[RoadPoint], index: int, intersection: Node3D
 	return _get_edge_facing(edges[index], intersection) != _IntersectNGonFacing.OTHER
 
 
-## Picks each edge's primary target: the edge across the intersection it points
-## most directly at (smallest angle from dead-ahead, regardless of distance).
-## The returned array holds each edge's primary index, or -1 when it has none.
-## Every eligible edge routes its entering lanes through to its primary, whether
-## or not the choice is reciprocated.
+## Meters of lateral error treated as equivalent to one radian of facing
+## misalignment when scoring primary candidates. Lateral offset is weighted more
+## heavily than angle, so a candidate the source aims squarely at is preferred
+## over one that merely faces back from off to the side.
+const _PRIMARY_ANGLE_WEIGHT: float = 6.0
+## Error added to a candidate sitting beside or behind the source, ruling out
+## same-side edges as through partners.
+const _PRIMARY_BEHIND_PENALTY: float = 1.0e6
+
+## Picks each edge's primary target with a projection loss: cast the edge's
+## travel ray forward through the intersection and score every other edge by how
+## far it sits laterally from that ray (it should lie dead ahead) blended with how
+## head-on the two roads face (their travel directions should oppose). Lowest
+## combined error wins, so both position and facing rotation count. The returned
+## array holds each edge's primary index, or -1 when it has none. Every eligible
+## edge routes its entering lanes through to its primary, reciprocated or not.
 func _compute_edge_primaries(edges: Array[RoadPoint], intersection: Node3D) -> Array[int]:
-	var origin := intersection.global_transform.origin
 	var count := edges.size()
 	var primary: Array[int] = []
 	primary.resize(count)
@@ -210,15 +220,23 @@ func _compute_edge_primaries(edges: Array[RoadPoint], intersection: Node3D) -> A
 	for i in range(count):
 		if not _edge_is_eligible(edges, i, intersection):
 			continue
-		var dir_i := (edges[i].global_transform.origin - origin).normalized()
+		var origin_i := edges[i].global_transform.origin
+		var dir_i := _edge_inward_dir(edges[i], intersection)
 		var best := -1
-		var best_dot := INF
+		var best_loss := INF
 		for j in range(count):
 			if j == i or not _edge_is_eligible(edges, j, intersection):
 				continue
-			var dot := dir_i.dot((edges[j].global_transform.origin - origin).normalized())
-			if dot < best_dot:
-				best_dot = dot
+			var rel := edges[j].global_transform.origin - origin_i
+			var along := rel.dot(dir_i)
+			var lateral := (rel - dir_i * along).length()
+			var dir_j := _edge_inward_dir(edges[j], intersection)
+			var angle := acos(clampf(-dir_i.dot(dir_j), -1.0, 1.0))
+			var loss := lateral + _PRIMARY_ANGLE_WEIGHT * angle
+			if along <= 0.0:
+				loss += _PRIMARY_BEHIND_PENALTY
+			if loss < best_loss:
+				best_loss = loss
 				best = j
 		primary[i] = best
 	return primary

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -206,6 +206,15 @@ const _PRIMARY_ANGLE_WEIGHT: float = 6.0
 ## same-side edges as through partners.
 const _PRIMARY_BEHIND_PENALTY: float = 1.0e6
 
+## Perpendicular distance from `rel` to the ray along `dir`, scaled by lane width
+## so the lateral-vs-angle balance in pairing holds for roads built at any lane
+## size: a road with wide lanes spaces its edges proportionally wider, and without
+## this the inflated lateral distances would swamp the width-independent angle.
+func _pairing_lateral_cost(rel: Vector3, dir: Vector3, lane_width: float) -> float:
+	var along := rel.dot(dir)
+	return (rel - dir * along).length() * RoadPoint.DEFAULT_LANE_WIDTH / lane_width
+
+
 ## Picks each edge's primary target with a projection loss: cast the edge's
 ## travel ray forward through the intersection and score every other edge by how
 ## far it sits laterally from that ray (it should lie dead ahead) blended with how
@@ -230,7 +239,7 @@ func _compute_edge_primaries(edges: Array[RoadPoint], intersection: Node3D) -> A
 				continue
 			var rel := edges[j].global_transform.origin - origin_i
 			var along := rel.dot(dir_i)
-			var lateral := (rel - dir_i * along).length()
+			var lateral := _pairing_lateral_cost(rel, dir_i, edges[i].lane_width)
 			var dir_j := _edge_inward_dir(edges[j], intersection)
 			var angle := acos(clampf(-dir_i.dot(dir_j), -1.0, 1.0))
 			var loss := lateral + _PRIMARY_ANGLE_WEIGHT * angle

--- a/addons/road-generator/procgen/intersection_settings.gd
+++ b/addons/road-generator/procgen/intersection_settings.gd
@@ -38,6 +38,20 @@ func generate_mesh(intersection: Node3D, edges: Array[RoadPoint], container: Roa
 	return null
 
 
+## @abstract
+## Generates the RoadLanes for the intersection, as children of the
+## [param intersection] node.
+##
+## Mirrors [generate_mesh]: triggered by the [RoadIntersection] during rebuild,
+## with the concrete subclass deciding the per-type lane connections.
+##
+## Edges MUST have been sorted by angle from intersection beforehand.
+##
+## Note: Cannot use [RoadIntersection] for `intersection` due to cyclic typing.
+func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
+	push_error("IntersectionSettings.generate_lanes() not implemented by child class.")
+
+
 ## Returns true if all the provided edges have sufficient distance
 ## from the intersection point to have proper mesh generation.
 ##

--- a/test/integration/procedural_intersection_lanes.tscn
+++ b/test/integration/procedural_intersection_lanes.tscn
@@ -1,0 +1,320 @@
+[gd_scene load_steps=9 format=3 uid="uid://br6v5vv3wt57s"]
+
+[ext_resource type="Script" uid="uid://bxp3i4cnonh8y" path="res://addons/road-generator/nodes/road_manager.gd" id="1_ta8s7"]
+[ext_resource type="Script" uid="uid://cph7euje06kel" path="res://addons/road-generator/nodes/road_container.gd" id="2_oqfhe"]
+[ext_resource type="Script" uid="uid://difs1qg4mpcpw" path="res://addons/road-generator/nodes/road_point.gd" id="3_eukx4"]
+[ext_resource type="Script" uid="uid://dx0pklu2apuar" path="res://addons/road-generator/nodes/road_intersection.gd" id="4_uyy1g"]
+[ext_resource type="Script" uid="uid://cob3ih0wpthwf" path="res://addons/road-generator/procgen/intersection_ngon.gd" id="5_2dq0y"]
+
+[sub_resource type="Resource" id="Resource_d84v3"]
+script = ExtResource("5_2dq0y")
+
+[sub_resource type="Resource" id="Resource_anvek"]
+script = ExtResource("5_2dq0y")
+
+[sub_resource type="Resource" id="Resource_vl380"]
+script = ExtResource("5_2dq0y")
+
+[node name="Node3D" type="Node3D"]
+
+[node name="RoadManager" type="Node3D" parent="."]
+script = ExtResource("1_ta8s7")
+metadata/_custom_type_script = "uid://bxp3i4cnonh8y"
+
+[node name="PerfectT" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.38881, 0, -7.18216)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_003"), NodePath("RP_004"), NodePath("RP_005")])
+edge_rp_local_dirs = Array[int]([0, 0, 1])
+
+[node name="RP_002" type="Node3D" parent="RoadManager/PerfectT"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, -30)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 24.0
+next_mag = 16.0
+prior_pt_init = NodePath("../RP_005")
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/PerfectT"]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -30, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 20.9655
+next_mag = 20.9655
+prior_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/PerfectT"]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 30, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_pt_init = NodePath("../Intersection")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/PerfectT" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_d84v3")
+edge_points = [NodePath("../RP_003"), NodePath("../RP_002"), NodePath("../RP_004")]
+
+[node name="RP_005" type="Node3D" parent="RoadManager/PerfectT"]
+transform = Transform3D(0.999013, 0, -0.0444386, 0, 1, 0, 0.0444386, 0, 0.999013, 0.202552, 0.25, -53.7493)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 10.6687
+next_mag = 10.6687
+next_pt_init = NodePath("../RP_002")
+
+[node name="RoughT" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 51.907, 0, 0.477782)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_005")])
+edge_rp_local_dirs = Array[int]([0, 1, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/RoughT"]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 16.0
+prior_pt_init = NodePath("../Intersection")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/RoughT"]
+transform = Transform3D(1.94707e-07, 0, -1, 0, 1, 0, 1, 0, 1.94707e-07, 60, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 16.0
+next_mag = 16.0
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/RoughT"]
+transform = Transform3D(-0.974255, 0, 0.225447, 0, 1, 0, -0.225447, 0, -0.974255, 30, 0.25, -32)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 16.0
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_005")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/RoughT" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 23.3771, 0.25, 0)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_anvek")
+edge_points = [NodePath("../RP_001"), NodePath("../RP_004"), NodePath("../RP_003")]
+
+[node name="RP_005" type="Node3D" parent="RoadManager/RoughT"]
+transform = Transform3D(-0.903437, 0, 0.428721, 0, 1, 0, -0.428721, 0, -0.903437, 40.115, 0.25, -54.4225)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 7.38985
+next_mag = 7.38985
+prior_pt_init = NodePath("../RP_004")
+
+[node name="OffsetT" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.42461, 0, 66.6676)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_005")])
+edge_rp_local_dirs = Array[int]([0, 1, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/OffsetT"]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 16.0
+prior_pt_init = NodePath("../Intersection")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/OffsetT"]
+transform = Transform3D(1.94707e-07, 0, -1, 0, 1, 0, 1, 0, 1.94707e-07, 61.4952, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 16.0
+next_mag = 16.0
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/OffsetT"]
+transform = Transform3D(-0.974255, 0, 0.225447, 0, 1, 0, -0.225447, 0, -0.974255, 47.5328, 0.25, -25.4762)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 6.14149
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_005")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/OffsetT" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 23.3771, 0.25, 0)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_anvek")
+edge_points = [NodePath("../RP_001"), NodePath("../RP_004"), NodePath("../RP_003")]
+
+[node name="RP_005" type="Node3D" parent="RoadManager/OffsetT"]
+transform = Transform3D(-0.93008, 0, 0.367357, 0, 1, 0, -0.367357, 0, -0.93008, 52.9943, 0.25, -40.5064)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 3.9415
+next_mag = 3.9415
+prior_pt_init = NodePath("../RP_004")
+
+[node name="RotatedT" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -71.0842, 0, 68.2582)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_005")])
+edge_rp_local_dirs = Array[int]([0, 1, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/RotatedT"]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 16.0
+prior_pt_init = NodePath("../Intersection")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/RotatedT"]
+transform = Transform3D(1.94707e-07, 0, -1, 0, 1, 0, 1, 0, 1.94707e-07, 60, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 16.0
+next_mag = 16.0
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/RotatedT"]
+transform = Transform3D(-0.758337, 0, 0.651862, 0, 1, 0, -0.651862, 0, -0.758337, 40.6244, 0.25, -29.2067)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 6.14149
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_005")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/RotatedT" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 23.3771, 0.25, 0)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_anvek")
+edge_points = [NodePath("../RP_001"), NodePath("../RP_004"), NodePath("../RP_003")]
+
+[node name="RP_005" type="Node3D" parent="RoadManager/RotatedT"]
+transform = Transform3D(-0.725522, 0, 0.688199, 0, 1, 0, -0.688199, 0, -0.725522, 53.4088, 0.25, -41.6117)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 3.9415
+next_mag = 3.9415
+prior_pt_init = NodePath("../RP_004")
+
+[node name="Messy4" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 125.324, 0, 56.3668)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_005"), NodePath("RP_006"), NodePath("RP_007"), NodePath("RP_008")])
+edge_rp_local_dirs = Array[int]([0, 0, 1, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(0.00807105, 0, -0.999967, 0, 1, 0, 0.999967, 0, 0.00807105, 0, 0.25, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 3, 4, 4, 3, 2])
+next_mag = 10.976
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_008")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.349346, 0, -0.936994, 0, 1, 0, 0.936994, 0, -0.349346, 65.0121, 0.25, 5.26955)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 3, 4, 4, 3, 2])
+prior_mag = 8.91296
+next_mag = 28.0
+prior_pt_init = NodePath("../RP_007")
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.883065, 0, -0.469251, 0, 1, 0, 0.469251, 0, -0.883065, 19.2373, 0.25, -41.4491)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 16.0
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_005")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/Messy4" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 41.0867, 0.25, -0.331623)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_vl380")
+edge_points = [NodePath("../RP_004"), NodePath("../RP_002"), NodePath("../RP_003"), NodePath("../RP_001")]
+
+[node name="RP_002" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.904669, 0, 0.426116, 0, 1, 0, -0.426116, 0, -0.904669, 63.4391, 0.25, -56.7074)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+next_mag = 3.79919
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_006")
+
+[node name="RP_005" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.935479, 0, -0.353383, 0, 1, 0, 0.353383, 0, -0.935479, 9.43813, 0.25, -61.1663)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 4.11908
+next_mag = 4.11908
+prior_pt_init = NodePath("../RP_004")
+
+[node name="RP_006" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.925117, 0, 0.379683, 0, 1, 0, -0.379683, 0, -0.925117, 72.2921, 0.25, -74.1012)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 4, 4, 3, 2])
+prior_mag = 5.5584
+next_mag = 5.5584
+prior_pt_init = NodePath("../RP_002")
+
+[node name="RP_007" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.366507, 0, -0.930415, 0, 1, 0, 0.930415, 0, -0.366507, 82.2273, 0.25, 12.0007)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 3, 4, 4, 3, 2])
+prior_mag = 6.28912
+next_mag = 6.28912
+next_pt_init = NodePath("../RP_003")
+
+[node name="RP_008" type="Node3D" parent="RoadManager/Messy4"]
+transform = Transform3D(-0.0725649, 0, -0.997364, 0, 1, 0, 0.997364, 0, -0.0725649, -19.3907, 0.25, -0.681007)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 2, 2, 1, 1, 1])
+lanes = Array[int]([2, 3, 3, 4, 4, 3, 2])
+prior_mag = 3.57197
+next_mag = 3.57197
+prior_pt_init = NodePath("../RP_001")

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -51,6 +51,49 @@ func create_intersection_two_branch(container):
 
 	p1.next_pt_init = p1.get_path_to(i1) # will trigger a rebuild on inter'
 	p2.prior_pt_init = p2.get_path_to(i1) # will trigger a rebuild on inter'
-	
+
 	# Due to manual assignment, must call this manually
+	container.update_edges()
+
+
+## Creates a four-branch intersection with each edge facing the center, so all
+## edges feed forward lanes into the intersection.
+func create_intersection_four_branch(container):
+	container.setup_road_container()
+
+	assert_eq(container.get_child_count(), 0, "No initial point children")
+
+	var i1 = autoqfree(RoadIntersection.new())
+	var pn = autoqfree(RoadPoint.new())
+	var ps = autoqfree(RoadPoint.new())
+	var pe = autoqfree(RoadPoint.new())
+	var pw = autoqfree(RoadPoint.new())
+	pn.name = "pn"
+	ps.name = "ps"
+	pe.name = "pe"
+	pw.name = "pw"
+
+	container.add_child(i1)
+	container.add_child(pn)
+	container.add_child(ps)
+	container.add_child(pe)
+	container.add_child(pw)
+
+	pn.position = Vector3(0, 0, -10)
+	ps.position = Vector3(0, 0, 10)
+	pe.position = Vector3(10, 0, 0)
+	pw.position = Vector3(-10, 0, 0)
+	# Rotate each edge so its forward axis points at the center.
+	ps.rotation_degrees.y = 180
+	pe.rotation_degrees.y = -90
+	pw.rotation_degrees.y = 90
+
+	var edges: Array[RoadPoint] = [pn, ps, pe, pw]
+	i1.edge_points = edges
+
+	pn.next_pt_init = pn.get_path_to(i1)
+	ps.next_pt_init = ps.get_path_to(i1)
+	pe.next_pt_init = pe.get_path_to(i1)
+	pw.next_pt_init = pw.get_path_to(i1)
+
 	container.update_edges()

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -135,3 +135,43 @@ func create_intersection_three_branch(container):
 	ps.next_pt_init = ps.get_path_to(i1)
 
 	container.update_edges()
+
+
+## Creates an intersection that distinguishes facing-aware pairing from a
+## position-only one. The source ps aims south; pb sits nearly dead-opposite but
+## faces sideways, while pg sits off to the side yet faces ps head-on. A position
+## metric prefers pb; an orientation-aware one prefers pg.
+func create_intersection_facing_split(container):
+	container.setup_road_container()
+
+	assert_eq(container.get_child_count(), 0, "No initial point children")
+
+	var i1 = autoqfree(RoadIntersection.new())
+	var ps = autoqfree(RoadPoint.new())
+	var pg = autoqfree(RoadPoint.new())
+	var pb = autoqfree(RoadPoint.new())
+	ps.name = "ps"
+	pg.name = "pg"
+	pb.name = "pb"
+
+	container.add_child(i1)
+	container.add_child(ps)
+	container.add_child(pg)
+	container.add_child(pb)
+
+	ps.position = Vector3(0, 0, -10)
+	pg.position = Vector3(8, 0, 12)
+	pb.position = Vector3(1, 0, 12)
+	# ps aims south (+Z); pg faces back head-on (-Z); pb faces sideways (+X).
+	ps.rotation_degrees.y = 0
+	pg.rotation_degrees.y = 180
+	pb.rotation_degrees.y = 90
+
+	var edges: Array[RoadPoint] = [ps, pg, pb]
+	i1.edge_points = edges
+
+	ps.next_pt_init = ps.get_path_to(i1)
+	pg.next_pt_init = pg.get_path_to(i1)
+	pb.next_pt_init = pb.get_path_to(i1)
+
+	container.update_edges()

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -97,3 +97,41 @@ func create_intersection_four_branch(container):
 	pw.next_pt_init = pw.get_path_to(i1)
 
 	container.update_edges()
+
+
+## Creates a three-branch T: pw and pe form a straight bar across the
+## intersection, and ps is the stem with no edge opposite it.
+func create_intersection_three_branch(container):
+	container.setup_road_container()
+
+	assert_eq(container.get_child_count(), 0, "No initial point children")
+
+	var i1 = autoqfree(RoadIntersection.new())
+	var pw = autoqfree(RoadPoint.new())
+	var pe = autoqfree(RoadPoint.new())
+	var ps = autoqfree(RoadPoint.new())
+	pw.name = "pw"
+	pe.name = "pe"
+	ps.name = "ps"
+
+	container.add_child(i1)
+	container.add_child(pw)
+	container.add_child(pe)
+	container.add_child(ps)
+
+	pw.position = Vector3(-10, 0, 0)
+	pe.position = Vector3(10, 0, 0)
+	ps.position = Vector3(0, 0, 10)
+	# Rotate each edge so its forward axis points at the center.
+	pw.rotation_degrees.y = 90
+	pe.rotation_degrees.y = -90
+	ps.rotation_degrees.y = 180
+
+	var edges: Array[RoadPoint] = [pw, pe, ps]
+	i1.edge_points = edges
+
+	pw.next_pt_init = pw.get_path_to(i1)
+	pe.next_pt_init = pe.get_path_to(i1)
+	ps.next_pt_init = ps.get_path_to(i1)
+
+	container.update_edges()

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -64,8 +64,10 @@ func test_entering_lane_tags():
 
 	container.rebuild_segments(true)
 
-	assert_eq(_tags(_lanes_for_edge(inter, "p1")), ["F0", "F1"], "Forward edge tags")
-	assert_eq(_tags(_lanes_for_edge(inter, "p2")), ["R0", "R1"], "Reverse edge tags")
+	# p1 connects on its next side, so the lanes travelling toward the
+	# intersection (and through it) are its reverse lanes; p2 the forward ones.
+	assert_eq(_tags(_lanes_for_edge(inter, "p1")), ["R0", "R1"], "Entering edge tags")
+	assert_eq(_tags(_lanes_for_edge(inter, "p2")), ["F0", "F1"], "Entering edge tags")
 
 
 func test_variable_lane_counts():
@@ -73,19 +75,19 @@ func test_variable_lane_counts():
 	add_child(container)
 	container.generate_ai_lanes = true
 	var inter := _make_intersection(container)
-	# Edge p1 enters the intersection forward; give it three forward lanes.
+	# Edge p1 enters the intersection on its reverse lanes; give it three.
 	var p1: RoadPoint = container.get_node("p1")
 	p1.traffic_dir = [
 		RoadPoint.LaneDir.REVERSE,
-		RoadPoint.LaneDir.FORWARD,
-		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.REVERSE,
+		RoadPoint.LaneDir.REVERSE,
 		RoadPoint.LaneDir.FORWARD,
 	]
 
 	container.rebuild_segments(true)
 
-	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "Three entering forward lanes")
-	assert_eq(_lanes_for_edge(inter, "p2").size(), 2, "Two entering reverse lanes")
+	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "Three entering reverse lanes")
+	assert_eq(_lanes_for_edge(inter, "p2").size(), 2, "Two entering forward lanes")
 
 
 func test_no_lanes_when_generation_disabled():
@@ -146,7 +148,7 @@ func test_straight_through_lane_crosses_intersection():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
 	var lane_start := lane.get_lane_start()
 	var lane_end := lane.get_lane_end()
 	assert_almost_eq(lane_start.x, lane_end.x, 0.01, "Through lane keeps a constant offset")
@@ -161,8 +163,8 @@ func test_straight_through_keeps_tag():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
-	assert_eq(lane.lane_next_tag, "F0", "Straight-through lane exits with the same tag")
+	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	assert_eq(lane.lane_next_tag, "R0", "Straight-through lane exits with the same tag")
 
 
 func test_mismatched_lane_counts_merge():
@@ -170,12 +172,12 @@ func test_mismatched_lane_counts_merge():
 	add_child(container)
 	container.generate_ai_lanes = true
 	var inter := _make_intersection(container)
-	# Three forward entering lanes feeding into two exit lanes opposite.
+	# Three entering lanes feeding into two exit lanes opposite.
 	var p1: RoadPoint = container.get_node("p1")
 	p1.traffic_dir = [
 		RoadPoint.LaneDir.REVERSE,
-		RoadPoint.LaneDir.FORWARD,
-		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.REVERSE,
+		RoadPoint.LaneDir.REVERSE,
 		RoadPoint.LaneDir.FORWARD,
 	]
 
@@ -184,8 +186,8 @@ func test_mismatched_lane_counts_merge():
 	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "All entering lanes generated")
 	for lane in _lanes_for_edge(inter, "p1"):
 		assert_eq(lane.curve.point_count, 2, "Each lane is routed")
-	var extra: RoadLane = inter.get_node("RoadLane_p1_F2")
-	assert_eq(extra.lane_next_tag, "F1", "Surplus lane merges into the outer exit lane")
+	var extra: RoadLane = inter.get_node("RoadLane_p1_R2")
+	assert_eq(extra.lane_next_tag, "R1", "Surplus lane merges into the outer exit lane")
 
 
 func test_colinear_lane_stays_straight():
@@ -196,7 +198,7 @@ func test_colinear_lane_stays_straight():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
 	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
 	assert_almost_eq(lane.curve.get_baked_length(), chord, 0.1, "Colinear lane has no bulge")
 
@@ -212,7 +214,7 @@ func test_offset_lane_arcs_between_edges():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
 	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
 	assert_gt(lane.curve.get_baked_length(), chord + 0.5, "Offset lane curves rather than cutting straight")
 
@@ -277,13 +279,13 @@ func test_divider_alignment_shifts_lane_offset():
 
 	p1.alignment = RoadPoint.Alignment.GEOMETRIC
 	container.rebuild_segments(true)
-	var geometric_x: float = (inter.get_node("RoadLane_p1_F0") as RoadLane).get_lane_start().x
+	var geometric_x: float = (inter.get_node("RoadLane_p1_R0") as RoadLane).get_lane_start().x
 
 	p1.alignment = RoadPoint.Alignment.DIVIDER
 	container.rebuild_segments(true)
-	var divider_x: float = (inter.get_node("RoadLane_p1_F0") as RoadLane).get_lane_start().x
+	var divider_x: float = (inter.get_node("RoadLane_p1_R0") as RoadLane).get_lane_start().x
 
-	assert_almost_eq(divider_x - geometric_x, 4.0, 0.01, "Divider shifts forward lanes by one lane width")
+	assert_almost_eq(divider_x - geometric_x, 4.0, 0.01, "Divider shifts entering lanes by one lane width")
 
 
 func test_editable_lane_preserved_on_rebuild():
@@ -293,7 +295,7 @@ func test_editable_lane_preserved_on_rebuild():
 	var inter := _make_intersection(container)
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
 	lane.owner = container
 	var custom := Curve3D.new()
 	custom.add_point(Vector3(99, 0, 0))

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -369,7 +369,7 @@ func test_t_junction_bar_edges_pair_through():
 			"Through lane spans both bar edges")
 
 
-func test_t_junction_stem_has_no_through_lane():
+func test_t_junction_stem_routes_through_to_primary():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
 	container.generate_ai_lanes = true
@@ -377,12 +377,13 @@ func test_t_junction_stem_has_no_through_lane():
 
 	container.rebuild_segments(true)
 
-	# The stem has no edge opposite it, so it must not emit a through lane.
-	assert_null(inter.get_node_or_null("RoadLane_ps_R0"), "Stem emits no through lane")
-	assert_null(inter.get_node_or_null("RoadLane_ps_R1"), "Stem emits no through lane")
+	# Incoming lanes always connect to the primary, even on the stem: both of its
+	# entering lanes route through to pw (the bar edge it points most directly at).
+	assert_not_null(inter.get_node_or_null("RoadLane_ps_R0"), "Stem routes to its primary")
+	assert_not_null(inter.get_node_or_null("RoadLane_ps_R1"), "Stem routes to its primary")
 
 
-func test_t_junction_stem_turns_to_bar_edges():
+func test_t_junction_stem_turns_to_non_primary_bar():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
 	container.generate_ai_lanes = true
@@ -390,9 +391,10 @@ func test_t_junction_stem_turns_to_bar_edges():
 
 	container.rebuild_segments(true)
 
-	# Lacking a through lane, the stem still reaches each bar edge as a turn.
-	assert_not_null(_turn_lane_to(inter, "ps", "pw"), "Stem turns toward pw")
-	assert_not_null(_turn_lane_to(inter, "ps", "pe"), "Stem turns toward pe")
+	# pw is the stem's primary (taken as a through lane); the other bar edge pe is
+	# reached as a turn.
+	assert_not_null(_turn_lane_to(inter, "ps", "pe"), "Stem turns toward the non-primary bar")
+	assert_null(_turn_lane_to(inter, "ps", "pw"), "Primary bar is a through lane, not a turn")
 
 
 func test_t_junction_lane_count():
@@ -404,5 +406,5 @@ func test_t_junction_lane_count():
 	container.rebuild_segments(true)
 
 	# Bar edges: two through lanes plus a turn to the stem apiece (3 each); stem:
-	# a turn to each bar edge (2).
-	assert_eq(_lanes(inter).size(), 8, "Through and turn lanes for the T")
+	# two through lanes to its primary plus a turn to the other bar (3).
+	assert_eq(_lanes(inter).size(), 9, "Through and turn lanes for the T")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -394,6 +394,20 @@ func test_custom_editable_lane_not_deleted_on_rebuild():
 	assert_not_null(inter.get_node_or_null("custom_uturn"), "Custom lane still present after rebuild")
 
 
+func test_pairing_lateral_cost_scales_with_lane_width():
+	# The pairing loss blends a lateral offset with a facing angle. Because a road
+	# built with wider lanes spaces its edges proportionally wider, the lateral
+	# term is divided by lane width so it stays comparable to the width-independent
+	# angle instead of swamping it on supersized roads.
+	var ngon := IntersectionNGon.new()
+	var rel := Vector3(6, 0, 10)
+	var dir := Vector3(0, 0, 1)
+	assert_almost_eq(ngon._pairing_lateral_cost(rel, dir, RoadPoint.DEFAULT_LANE_WIDTH), 6.0, 0.001,
+			"At the default lane width the cost is the raw perpendicular distance")
+	assert_almost_eq(ngon._pairing_lateral_cost(rel, dir, RoadPoint.DEFAULT_LANE_WIDTH * 2.0), 3.0, 0.001,
+			"Doubling the lane width halves the lateral cost")
+
+
 func test_pairing_prefers_facing_over_position():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -260,3 +260,46 @@ func test_four_way_turn_lane_reaches_target_edge():
 	assert_lt(turn_end.x, -1.0, "Turn ends on the west edge")
 	var chord := turn_start.distance_to(turn_end)
 	assert_gt(turn.curve.get_baked_length(), chord + 0.5, "Turn lane arcs around the corner")
+
+
+func test_divider_alignment_shifts_lane_offset():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	var p1: RoadPoint = container.get_node("p1")
+	p1.traffic_dir = [
+		RoadPoint.LaneDir.REVERSE,
+		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.FORWARD,
+	]
+
+	p1.alignment = RoadPoint.Alignment.GEOMETRIC
+	container.rebuild_segments(true)
+	var geometric_x: float = (inter.get_node("RoadLane_p1_F0") as RoadLane).get_lane_start().x
+
+	p1.alignment = RoadPoint.Alignment.DIVIDER
+	container.rebuild_segments(true)
+	var divider_x: float = (inter.get_node("RoadLane_p1_F0") as RoadLane).get_lane_start().x
+
+	assert_almost_eq(divider_x - geometric_x, 4.0, 0.01, "Divider shifts forward lanes by one lane width")
+
+
+func test_editable_lane_preserved_on_rebuild():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	container.rebuild_segments(true)
+
+	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	lane.owner = container
+	var custom := Curve3D.new()
+	custom.add_point(Vector3(99, 0, 0))
+	custom.add_point(Vector3(100, 0, 0))
+	lane.curve = custom
+
+	container.rebuild_segments(true)
+
+	assert_eq(lane.curve.get_point_position(0), Vector3(99, 0, 0), "User-edited lane is left intact")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -215,3 +215,48 @@ func test_offset_lane_arcs_between_edges():
 	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
 	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
 	assert_gt(lane.curve.get_baked_length(), chord + 0.5, "Offset lane curves rather than cutting straight")
+
+
+func _turn_lane_to(node: Node, edge_name: String, target_name: String) -> RoadLane:
+	for child in node.get_children():
+		if child is RoadLane and str(child.name).begins_with("RoadLane_%s_" % edge_name) \
+				and str(child.name).ends_with("_%s" % target_name):
+			return child
+	return null
+
+
+func test_four_way_generates_through_and_turn_lanes():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	container.setup_road_container()
+	road_util.create_intersection_four_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	# Each of four edges has two through lanes plus a turn to each adjacent edge.
+	assert_eq(_lanes(inter).size(), 16, "Through and turn lanes for every edge")
+	assert_eq(_lanes_for_edge(inter, "pn").size(), 4, "Two through and two turn lanes")
+
+
+func test_four_way_turn_lane_reaches_target_edge():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	container.setup_road_container()
+	road_util.create_intersection_four_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	var turn := _turn_lane_to(inter, "pn", "pw")
+	assert_not_null(turn, "Turn lane from pn to pw exists")
+	if turn == null:
+		return
+	var turn_start := turn.get_lane_start()
+	var turn_end := turn.get_lane_end()
+	assert_lt(turn_start.z, -1.0, "Turn starts on the north edge")
+	assert_lt(turn_end.x, -1.0, "Turn ends on the west edge")
+	var chord := turn_start.distance_to(turn_end)
+	assert_gt(turn.curve.get_baked_length(), chord + 0.5, "Turn lane arcs around the corner")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -302,6 +302,31 @@ func test_four_way_turn_lane_reaches_target_edge():
 	assert_gt(turn.curve.get_baked_length(), chord + 0.5, "Turn lane arcs around the corner")
 
 
+func test_four_way_turn_handedness():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	container.setup_road_container()
+	road_util.create_intersection_four_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	# From the north edge heading south, west (pw) is the right turn and east
+	# (pe) the left turn. Right turns source from the outer (curb-side) lane,
+	# left turns from the inner (divider-side) lane.
+	var right_turn := _turn_lane_to(inter, "pn", "pw")
+	var left_turn := _turn_lane_to(inter, "pn", "pe")
+	assert_not_null(right_turn, "Right turn pn->pw exists")
+	assert_not_null(left_turn, "Left turn pn->pe exists")
+	if right_turn == null or left_turn == null:
+		return
+	# pn's entering lanes lie on the west (-X) half; the outer/right lane sits
+	# further from the centerline than the inner/left lane.
+	assert_lt(right_turn.get_lane_start().x, left_turn.get_lane_start().x,
+			"Right turn sources from the outer lane, left turn from the inner lane")
+
+
 func test_divider_alignment_shifts_lane_offset():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -395,6 +395,26 @@ func test_pairing_prefers_facing_over_position():
 			"Through lane reaches the head-on edge pg, not the dead-opposite pb")
 
 
+func test_turn_handedness_follows_primary_not_inbound():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	container.setup_road_container()
+	road_util.create_intersection_facing_split(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	# ps routes through to pg (off to its right), leaving pb as a turn target that
+	# sits to the right of that through path. Handedness is measured against the
+	# primary, so the pb turn is a right turn sourced from the outer lane (R1),
+	# even though pb lies left of ps's raw inbound axis.
+	assert_not_null(inter.get_node_or_null("RoadLane_ps_R1_pb"),
+			"Turn to pb sources from the outer lane, right of the ps->pg primary")
+	assert_null(inter.get_node_or_null("RoadLane_ps_R0_pb"),
+			"Turn handedness is not taken from the raw inbound direction")
+
+
 func _make_t_junction(container) -> RoadIntersection:
 	container.setup_road_container()
 	road_util.create_intersection_three_branch(container)

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -373,6 +373,28 @@ func test_editable_lane_preserved_on_rebuild():
 # ------------------------------------------------------------------------------
 
 
+func test_pairing_prefers_facing_over_position():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	container.setup_road_container()
+	road_util.create_intersection_facing_split(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	# ps routes through to pg, the edge that faces it head-on, rather than pb,
+	# which sits more directly opposite but points sideways.
+	assert_not_null(inter.get_node_or_null("RoadLane_ps_R0"), "Source emits a through lane")
+	var through: RoadLane = inter.get_node("RoadLane_ps_R0")
+	var pg: RoadPoint = container.get_node("pg")
+	var pb: RoadPoint = container.get_node("pb")
+	var ends_at := through.get_lane_end()
+	assert_lt(ends_at.distance_to(pg.global_transform.origin),
+			ends_at.distance_to(pb.global_transform.origin),
+			"Through lane reaches the head-on edge pg, not the dead-opposite pb")
+
+
 func _make_t_junction(container) -> RoadIntersection:
 	container.setup_road_container()
 	road_util.create_intersection_three_branch(container)

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -90,6 +90,26 @@ func test_variable_lane_counts():
 	assert_eq(_lanes_for_edge(inter, "p2").size(), 2, "Two entering forward lanes")
 
 
+func test_lane_visibility_follows_container():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	container.rebuild_segments(true)
+
+	container.draw_lanes_editor = true
+	container.draw_lanes_game = false
+	for lane in _lanes(inter):
+		assert_true(lane.draw_in_editor, "Editor draw follows container")
+		assert_false(lane.draw_in_game, "Game draw follows container")
+
+	container.draw_lanes_editor = false
+	container.draw_lanes_game = true
+	for lane in _lanes(inter):
+		assert_false(lane.draw_in_editor, "Editor draw toggles off with container")
+		assert_true(lane.draw_in_game, "Game draw toggles on with container")
+
+
 func test_no_lanes_when_generation_disabled():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -1,0 +1,95 @@
+extends "res://addons/gut/test.gd"
+
+const RoadUtils = preload("res://test/unit/road_utils.gd")
+
+var road_util: RoadUtils
+
+
+func before_each():
+	road_util = RoadUtils.new()
+	road_util.gut = gut
+
+
+func _count_lanes(node: Node) -> int:
+	var count := 0
+	for child in node.get_children():
+		if child is RoadLane:
+			count += 1
+	return count
+
+
+# ------------------------------------------------------------------------------
+
+
+func test_generates_one_lane_per_edge():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	container.generate_ai_lanes = true
+	road_util.create_intersection_two_branch(container)
+
+	container.rebuild_segments(true)
+
+	var inter: RoadIntersection = container.get_intersections()[0]
+	assert_eq(_count_lanes(inter), 2, "One RoadLane generated per edge")
+
+
+func test_no_lanes_when_generation_disabled():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	container.generate_ai_lanes = false
+	road_util.create_intersection_two_branch(container)
+
+	container.rebuild_segments(true)
+
+	var inter: RoadIntersection = container.get_intersections()[0]
+	assert_eq(_count_lanes(inter), 0, "No lanes when generation disabled")
+
+
+func test_rebuild_does_not_duplicate_lanes():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	container.generate_ai_lanes = true
+	road_util.create_intersection_two_branch(container)
+
+	container.rebuild_segments(true)
+	container.rebuild_segments(true)
+
+	var inter: RoadIntersection = container.get_intersections()[0]
+	assert_eq(_count_lanes(inter), 2, "Lanes reused, not duplicated, on rebuild")
+
+
+func test_lanes_added_to_ai_group():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	container.generate_ai_lanes = true
+	container.ai_lane_group = "test_ai_lanes"
+	road_util.create_intersection_two_branch(container)
+
+	container.rebuild_segments(true)
+
+	var inter: RoadIntersection = container.get_intersections()[0]
+	var checked := 0
+	for child in inter.get_children():
+		if child is RoadLane:
+			checked += 1
+			assert_true(child.is_in_group("test_ai_lanes"), "Lane is in the AI lane group")
+	assert_eq(checked, 2, "Both lanes checked for group membership")
+
+
+func test_lanes_have_curve_points():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	container.generate_ai_lanes = true
+	road_util.create_intersection_two_branch(container)
+
+	container.rebuild_segments(true)
+
+	var inter: RoadIntersection = container.get_intersections()[0]
+	for child in inter.get_children():
+		if child is RoadLane:
+			assert_eq(child.curve.point_count, 2, "Stub lane has start and end points")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -19,7 +19,7 @@ func _make_intersection(container) -> RoadIntersection:
 func _lanes(node: Node) -> Array:
 	var result: Array = []
 	for child in node.get_children():
-		if child is RoadLane:
+		if child is RoadLane and not child.is_queued_for_deletion():
 			result.append(child)
 	return result
 
@@ -27,7 +27,8 @@ func _lanes(node: Node) -> Array:
 func _lanes_for_edge(node: Node, edge_name: String) -> Array:
 	var result: Array = []
 	for child in node.get_children():
-		if child is RoadLane and str(child.name).begins_with("RoadLane_%s_" % edge_name):
+		if child is RoadLane and not child.is_queued_for_deletion() \
+				and str(child.name).begins_with("%s_p" % edge_name):
 			result.append(child)
 	return result
 
@@ -169,7 +170,7 @@ func test_straight_through_lane_crosses_intersection():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var lane: RoadLane = inter.get_node("p1_pR0_nR0")
 	var lane_start := lane.get_lane_start()
 	var lane_end := lane.get_lane_end()
 	assert_almost_eq(lane_start.x, lane_end.x, 0.01, "Through lane keeps a constant offset")
@@ -184,7 +185,7 @@ func test_through_lane_reaches_road_points():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var lane: RoadLane = inter.get_node("p1_pR0_nR0")
 	var p1: RoadPoint = container.get_node("p1")
 	var p2: RoadPoint = container.get_node("p2")
 	assert_almost_eq(lane.get_lane_start().z, p1.global_transform.origin.z, 0.01,
@@ -201,7 +202,7 @@ func test_straight_through_keeps_tag():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var lane: RoadLane = inter.get_node("p1_pR0_nR0")
 	assert_eq(lane.lane_next_tag, "R0", "Straight-through lane exits with the same tag")
 
 
@@ -224,7 +225,7 @@ func test_mismatched_lane_counts_merge():
 	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "All entering lanes generated")
 	for lane in _lanes_for_edge(inter, "p1"):
 		assert_eq(lane.curve.point_count, 4, "Each lane is routed")
-	var extra: RoadLane = inter.get_node("RoadLane_p1_R2")
+	var extra: RoadLane = inter.get_node("p1_pR2_nR2r")
 	assert_eq(extra.lane_next_tag, "R1", "Surplus lane merges into the outer exit lane")
 
 
@@ -236,7 +237,7 @@ func test_colinear_lane_stays_straight():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var lane: RoadLane = inter.get_node("p1_pR0_nR0")
 	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
 	assert_almost_eq(lane.curve.get_baked_length(), chord, 0.1, "Colinear lane has no bulge")
 
@@ -252,17 +253,47 @@ func test_offset_lane_arcs_between_edges():
 
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var lane: RoadLane = inter.get_node("p1_pR0_nR0")
 	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
 	assert_gt(lane.curve.get_baked_length(), chord + 0.5, "Offset lane curves rather than cutting straight")
 
 
-func _turn_lane_to(node: Node, edge_name: String, target_name: String) -> RoadLane:
+func _is_turn_lane(lane_name: String) -> bool:
+	# Turn lanes carry an `a` suffix on their next tag: edge_pTAG_nTAGa[counter].
+	return "a" in str(lane_name).get_slice("_n", 1)
+
+
+func _nearest_edge(container: Node, source_name: String, point: Vector3) -> String:
+	var best := ""
+	var best_d := INF
+	for child in container.get_children():
+		if not (child is RoadPoint) or str(child.name) == source_name:
+			continue
+		var d: float = child.global_transform.origin.distance_to(point)
+		if d < best_d:
+			best_d = d
+			best = str(child.name)
+	return best
+
+
+func _turn_lane_to(node: Node, container: Node, edge_name: String, target_name: String) -> RoadLane:
+	# Turn names no longer carry the target edge, so match by geometry: the turn
+	# lane off edge_name whose end lands nearer target_name than any other edge.
+	var target: RoadPoint = container.get_node(target_name)
+	var best: RoadLane = null
+	var best_d := INF
 	for child in node.get_children():
-		if child is RoadLane and str(child.name).begins_with("RoadLane_%s_" % edge_name) \
-				and str(child.name).ends_with("_%s" % target_name):
-			return child
-	return null
+		if not (child is RoadLane) or not str(child.name).begins_with("%s_p" % edge_name):
+			continue
+		if not _is_turn_lane(child.name):
+			continue
+		var d: float = child.get_lane_end().distance_to(target.global_transform.origin)
+		if d < best_d:
+			best_d = d
+			best = child
+	if best == null or _nearest_edge(container, edge_name, best.get_lane_end()) != target_name:
+		return null
+	return best
 
 
 func test_four_way_generates_through_and_turn_lanes():
@@ -290,7 +321,7 @@ func test_four_way_turn_lane_reaches_target_edge():
 
 	container.rebuild_segments(true)
 
-	var turn := _turn_lane_to(inter, "pn", "pw")
+	var turn := _turn_lane_to(inter, container, "pn", "pw")
 	assert_not_null(turn, "Turn lane from pn to pw exists")
 	if turn == null:
 		return
@@ -315,8 +346,8 @@ func test_four_way_turn_handedness():
 	# From the north edge heading south, west (pw) is the right turn and east
 	# (pe) the left turn. Right turns source from the outer (curb-side) lane,
 	# left turns from the inner (divider-side) lane.
-	var right_turn := _turn_lane_to(inter, "pn", "pw")
-	var left_turn := _turn_lane_to(inter, "pn", "pe")
+	var right_turn := _turn_lane_to(inter, container, "pn", "pw")
+	var left_turn := _turn_lane_to(inter, container, "pn", "pe")
 	assert_not_null(right_turn, "Right turn pn->pw exists")
 	assert_not_null(left_turn, "Left turn pn->pe exists")
 	if right_turn == null or left_turn == null:
@@ -342,11 +373,11 @@ func test_divider_alignment_shifts_lane_offset():
 
 	p1.alignment = RoadPoint.Alignment.GEOMETRIC
 	container.rebuild_segments(true)
-	var geometric_x: float = (inter.get_node("RoadLane_p1_R0") as RoadLane).get_lane_start().x
+	var geometric_x: float = (inter.get_node("p1_pR0_nR0") as RoadLane).get_lane_start().x
 
 	p1.alignment = RoadPoint.Alignment.DIVIDER
 	container.rebuild_segments(true)
-	var divider_x: float = (inter.get_node("RoadLane_p1_R0") as RoadLane).get_lane_start().x
+	var divider_x: float = (inter.get_node("p1_pR0_nR0") as RoadLane).get_lane_start().x
 
 	assert_almost_eq(divider_x - geometric_x, 4.0, 0.01, "Divider shifts entering lanes by one lane width")
 
@@ -358,7 +389,7 @@ func test_editable_lane_preserved_on_rebuild():
 	var inter := _make_intersection(container)
 	container.rebuild_segments(true)
 
-	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var lane: RoadLane = inter.get_node("p1_pR0_nR0")
 	lane.owner = container
 	var custom := Curve3D.new()
 	custom.add_point(Vector3(99, 0, 0))
@@ -368,9 +399,6 @@ func test_editable_lane_preserved_on_rebuild():
 	container.rebuild_segments(true)
 
 	assert_eq(lane.curve.get_point_position(0), Vector3(99, 0, 0), "User-edited lane is left intact")
-
-
-# ------------------------------------------------------------------------------
 
 
 func test_custom_editable_lane_not_deleted_on_rebuild():
@@ -394,18 +422,7 @@ func test_custom_editable_lane_not_deleted_on_rebuild():
 	assert_not_null(inter.get_node_or_null("custom_uturn"), "Custom lane still present after rebuild")
 
 
-func test_pairing_lateral_cost_scales_with_lane_width():
-	# The pairing loss blends a lateral offset with a facing angle. Because a road
-	# built with wider lanes spaces its edges proportionally wider, the lateral
-	# term is divided by lane width so it stays comparable to the width-independent
-	# angle instead of swamping it on supersized roads.
-	var ngon := IntersectionNGon.new()
-	var rel := Vector3(6, 0, 10)
-	var dir := Vector3(0, 0, 1)
-	assert_almost_eq(ngon._pairing_lateral_cost(rel, dir, RoadPoint.DEFAULT_LANE_WIDTH), 6.0, 0.001,
-			"At the default lane width the cost is the raw perpendicular distance")
-	assert_almost_eq(ngon._pairing_lateral_cost(rel, dir, RoadPoint.DEFAULT_LANE_WIDTH * 2.0), 3.0, 0.001,
-			"Doubling the lane width halves the lateral cost")
+# ------------------------------------------------------------------------------
 
 
 func test_pairing_prefers_facing_over_position():
@@ -420,14 +437,28 @@ func test_pairing_prefers_facing_over_position():
 
 	# ps routes through to pg, the edge that faces it head-on, rather than pb,
 	# which sits more directly opposite but points sideways.
-	assert_not_null(inter.get_node_or_null("RoadLane_ps_R0"), "Source emits a through lane")
-	var through: RoadLane = inter.get_node("RoadLane_ps_R0")
+	assert_not_null(inter.get_node_or_null("ps_pR0_nR0"), "Source emits a through lane")
+	var through: RoadLane = inter.get_node("ps_pR0_nR0")
 	var pg: RoadPoint = container.get_node("pg")
 	var pb: RoadPoint = container.get_node("pb")
 	var ends_at := through.get_lane_end()
 	assert_lt(ends_at.distance_to(pg.global_transform.origin),
 			ends_at.distance_to(pb.global_transform.origin),
 			"Through lane reaches the head-on edge pg, not the dead-opposite pb")
+
+
+func test_pairing_lateral_cost_scales_with_lane_width():
+	# The pairing loss blends a lateral offset with a facing angle. Because a road
+	# built with wider lanes spaces its edges proportionally wider, the lateral
+	# term is divided by lane width so it stays comparable to the width-independent
+	# angle instead of swamping it on supersized roads.
+	var ngon := IntersectionNGon.new()
+	var rel := Vector3(6, 0, 10)
+	var dir := Vector3(0, 0, 1)
+	assert_almost_eq(ngon._pairing_lateral_cost(rel, dir, RoadPoint.DEFAULT_LANE_WIDTH), 6.0, 0.001,
+			"At the default lane width the cost is the raw perpendicular distance")
+	assert_almost_eq(ngon._pairing_lateral_cost(rel, dir, RoadPoint.DEFAULT_LANE_WIDTH * 2.0), 3.0, 0.001,
+			"Doubling the lane width halves the lateral cost")
 
 
 func test_turn_handedness_follows_primary_not_inbound():
@@ -444,10 +475,13 @@ func test_turn_handedness_follows_primary_not_inbound():
 	# sits to the right of that through path. Handedness is measured against the
 	# primary, so the pb turn is a right turn sourced from the outer lane (R1),
 	# even though pb lies left of ps's raw inbound axis.
-	assert_not_null(inter.get_node_or_null("RoadLane_ps_R1_pb"),
-			"Turn to pb sources from the outer lane, right of the ps->pg primary")
-	assert_null(inter.get_node_or_null("RoadLane_ps_R0_pb"),
-			"Turn handedness is not taken from the raw inbound direction")
+	var turn := _turn_lane_to(inter, container, "ps", "pb")
+	assert_not_null(turn, "Turn to pb exists")
+	if turn == null:
+		return
+	assert_eq(turn.lane_prior_tag, "R1",
+			"Turn to pb sources from the outer lane (right of the ps->pg primary), "
+			+ "not the inner lane implied by the raw inbound direction")
 
 
 func _make_t_junction(container) -> RoadIntersection:
@@ -465,7 +499,7 @@ func test_t_junction_bar_edges_pair_through():
 	container.rebuild_segments(true)
 
 	# pw and pe form the straight bar, so each carries its entering lanes across.
-	var lane: RoadLane = inter.get_node("RoadLane_pw_R0")
+	var lane: RoadLane = inter.get_node("pw_pR0_nR0")
 	assert_eq(lane.curve.point_count, 4, "Through lane runs RoadPoint to RoadPoint")
 	assert_true(lane.get_lane_start().x < 0.0 and lane.get_lane_end().x > 0.0,
 			"Through lane spans both bar edges")
@@ -481,8 +515,8 @@ func test_t_junction_stem_routes_through_to_primary():
 
 	# Incoming lanes always connect to the primary, even on the stem: both of its
 	# entering lanes route through to pw (the bar edge it points most directly at).
-	assert_not_null(inter.get_node_or_null("RoadLane_ps_R0"), "Stem routes to its primary")
-	assert_not_null(inter.get_node_or_null("RoadLane_ps_R1"), "Stem routes to its primary")
+	assert_not_null(inter.get_node_or_null("ps_pR0_nR0"), "Stem routes to its primary")
+	assert_not_null(inter.get_node_or_null("ps_pR1_nR1"), "Stem routes to its primary")
 
 
 func test_t_junction_stem_turns_to_non_primary_bar():
@@ -495,8 +529,8 @@ func test_t_junction_stem_turns_to_non_primary_bar():
 
 	# pw is the stem's primary (taken as a through lane); the other bar edge pe is
 	# reached as a turn.
-	assert_not_null(_turn_lane_to(inter, "ps", "pe"), "Stem turns toward the non-primary bar")
-	assert_null(_turn_lane_to(inter, "ps", "pw"), "Primary bar is a through lane, not a turn")
+	assert_not_null(_turn_lane_to(inter, container, "ps", "pe"), "Stem turns toward the non-primary bar")
+	assert_null(_turn_lane_to(inter, container, "ps", "pw"), "Primary bar is a through lane, not a turn")
 
 
 func test_t_junction_lane_count():

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -373,6 +373,27 @@ func test_editable_lane_preserved_on_rebuild():
 # ------------------------------------------------------------------------------
 
 
+func test_custom_editable_lane_not_deleted_on_rebuild():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	container.rebuild_segments(true)
+
+	# A lane the generator never produces (e.g. a hand-drawn U-turn), promoted to
+	# editable by giving it an owner, must survive a rebuild rather than being
+	# swept up with the stale generated lanes.
+	var custom := RoadLane.new()
+	inter.add_child(custom)
+	custom.name = "custom_uturn"
+	custom.owner = container
+
+	container.rebuild_segments(true)
+
+	assert_false(custom.is_queued_for_deletion(), "User-added editable lane survives rebuild")
+	assert_not_null(inter.get_node_or_null("custom_uturn"), "Custom lane still present after rebuild")
+
+
 func test_pairing_prefers_facing_over_position():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -10,86 +10,129 @@ func before_each():
 	road_util.gut = gut
 
 
-func _count_lanes(node: Node) -> int:
-	var count := 0
+func _make_intersection(container) -> RoadIntersection:
+	container.setup_road_container()
+	road_util.create_intersection_two_branch(container)
+	return container.get_intersections()[0]
+
+
+func _lanes(node: Node) -> Array:
+	var result: Array = []
 	for child in node.get_children():
 		if child is RoadLane:
-			count += 1
-	return count
+			result.append(child)
+	return result
+
+
+func _lanes_for_edge(node: Node, edge_name: String) -> Array:
+	var result: Array = []
+	for child in node.get_children():
+		if child is RoadLane and str(child.name).begins_with("RoadLane_%s_" % edge_name):
+			result.append(child)
+	return result
+
+
+func _tags(lanes: Array) -> Array:
+	var result: Array = []
+	for lane in lanes:
+		result.append(lane.lane_prior_tag)
+	result.sort()
+	return result
 
 
 # ------------------------------------------------------------------------------
 
 
-func test_generates_one_lane_per_edge():
+func test_generates_one_lane_per_entering_lane():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
-	container.setup_road_container()
 	container.generate_ai_lanes = true
-	road_util.create_intersection_two_branch(container)
+	var inter := _make_intersection(container)
 
 	container.rebuild_segments(true)
 
-	var inter: RoadIntersection = container.get_intersections()[0]
-	assert_eq(_count_lanes(inter), 2, "One RoadLane generated per edge")
+	# Two default edges (2 forward + 2 reverse each): one enters forward, the
+	# other enters reverse, for two entering lanes apiece.
+	assert_eq(_lanes(inter).size(), 4, "One lane per entering lane")
+
+
+func test_entering_lane_tags():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	assert_eq(_tags(_lanes_for_edge(inter, "p1")), ["F0", "F1"], "Forward edge tags")
+	assert_eq(_tags(_lanes_for_edge(inter, "p2")), ["R0", "R1"], "Reverse edge tags")
+
+
+func test_variable_lane_counts():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	# Edge p1 enters the intersection forward; give it three forward lanes.
+	var p1: RoadPoint = container.get_node("p1")
+	p1.traffic_dir = [
+		RoadPoint.LaneDir.REVERSE,
+		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.FORWARD,
+	]
+
+	container.rebuild_segments(true)
+
+	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "Three entering forward lanes")
+	assert_eq(_lanes_for_edge(inter, "p2").size(), 2, "Two entering reverse lanes")
 
 
 func test_no_lanes_when_generation_disabled():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
-	container.setup_road_container()
 	container.generate_ai_lanes = false
-	road_util.create_intersection_two_branch(container)
+	var inter := _make_intersection(container)
 
 	container.rebuild_segments(true)
 
-	var inter: RoadIntersection = container.get_intersections()[0]
-	assert_eq(_count_lanes(inter), 0, "No lanes when generation disabled")
+	assert_eq(_lanes(inter).size(), 0, "No lanes when generation disabled")
 
 
 func test_rebuild_does_not_duplicate_lanes():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
-	container.setup_road_container()
 	container.generate_ai_lanes = true
-	road_util.create_intersection_two_branch(container)
+	var inter := _make_intersection(container)
 
 	container.rebuild_segments(true)
 	container.rebuild_segments(true)
 
-	var inter: RoadIntersection = container.get_intersections()[0]
-	assert_eq(_count_lanes(inter), 2, "Lanes reused, not duplicated, on rebuild")
+	assert_eq(_lanes(inter).size(), 4, "Lanes reused, not duplicated, on rebuild")
 
 
 func test_lanes_added_to_ai_group():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
-	container.setup_road_container()
 	container.generate_ai_lanes = true
 	container.ai_lane_group = "test_ai_lanes"
-	road_util.create_intersection_two_branch(container)
+	var inter := _make_intersection(container)
 
 	container.rebuild_segments(true)
 
-	var inter: RoadIntersection = container.get_intersections()[0]
-	var checked := 0
-	for child in inter.get_children():
-		if child is RoadLane:
-			checked += 1
-			assert_true(child.is_in_group("test_ai_lanes"), "Lane is in the AI lane group")
-	assert_eq(checked, 2, "Both lanes checked for group membership")
+	var lanes := _lanes(inter)
+	assert_eq(lanes.size(), 4, "All entering lanes generated")
+	for lane in lanes:
+		assert_true(lane.is_in_group("test_ai_lanes"), "Lane is in the AI lane group")
 
 
 func test_lanes_have_curve_points():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
-	container.setup_road_container()
 	container.generate_ai_lanes = true
-	road_util.create_intersection_two_branch(container)
+	var inter := _make_intersection(container)
 
 	container.rebuild_segments(true)
 
-	var inter: RoadIntersection = container.get_intersections()[0]
-	for child in inter.get_children():
-		if child is RoadLane:
-			assert_eq(child.curve.point_count, 2, "Stub lane has start and end points")
+	for lane in _lanes(inter):
+		assert_eq(lane.curve.point_count, 2, "Lane has start and end points")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -186,3 +186,32 @@ func test_mismatched_lane_counts_merge():
 		assert_eq(lane.curve.point_count, 2, "Each lane is routed")
 	var extra: RoadLane = inter.get_node("RoadLane_p1_F2")
 	assert_eq(extra.lane_next_tag, "F1", "Surplus lane merges into the outer exit lane")
+
+
+func test_colinear_lane_stays_straight():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
+	assert_almost_eq(lane.curve.get_baked_length(), chord, 0.1, "Colinear lane has no bulge")
+
+
+func test_offset_lane_arcs_between_edges():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	# Shift the opposite edge sideways so the through lane must curve.
+	var p2: RoadPoint = container.get_node("p2")
+	p2.position += Vector3(10.0, 0.0, 0.0)
+
+	container.rebuild_segments(true)
+
+	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var chord := lane.get_lane_start().distance_to(lane.get_lane_end())
+	assert_gt(lane.curve.get_baked_length(), chord + 0.5, "Offset lane curves rather than cutting straight")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -136,3 +136,53 @@ func test_lanes_have_curve_points():
 
 	for lane in _lanes(inter):
 		assert_eq(lane.curve.point_count, 2, "Lane has start and end points")
+
+
+func test_straight_through_lane_crosses_intersection():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	var lane_start := lane.get_lane_start()
+	var lane_end := lane.get_lane_end()
+	assert_almost_eq(lane_start.x, lane_end.x, 0.01, "Through lane keeps a constant offset")
+	assert_true(lane_start.z < 0.0 and lane_end.z > 0.0, "Through lane spans both edges")
+
+
+func test_straight_through_keeps_tag():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	var lane: RoadLane = inter.get_node("RoadLane_p1_F0")
+	assert_eq(lane.lane_next_tag, "F0", "Straight-through lane exits with the same tag")
+
+
+func test_mismatched_lane_counts_merge():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+	# Three forward entering lanes feeding into two exit lanes opposite.
+	var p1: RoadPoint = container.get_node("p1")
+	p1.traffic_dir = [
+		RoadPoint.LaneDir.REVERSE,
+		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.FORWARD,
+		RoadPoint.LaneDir.FORWARD,
+	]
+
+	container.rebuild_segments(true)
+
+	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "All entering lanes generated")
+	for lane in _lanes_for_edge(inter, "p1"):
+		assert_eq(lane.curve.point_count, 2, "Each lane is routed")
+	var extra: RoadLane = inter.get_node("RoadLane_p1_F2")
+	assert_eq(extra.lane_next_tag, "F1", "Surplus lane merges into the outer exit lane")

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -156,8 +156,9 @@ func test_lanes_have_curve_points():
 
 	container.rebuild_segments(true)
 
+	# RoadPoint, stop line, opposite stop line, opposite RoadPoint.
 	for lane in _lanes(inter):
-		assert_eq(lane.curve.point_count, 2, "Lane has start and end points")
+		assert_eq(lane.curve.point_count, 4, "Lane runs RoadPoint to RoadPoint via its stop lines")
 
 
 func test_straight_through_lane_crosses_intersection():
@@ -173,6 +174,23 @@ func test_straight_through_lane_crosses_intersection():
 	var lane_end := lane.get_lane_end()
 	assert_almost_eq(lane_start.x, lane_end.x, 0.01, "Through lane keeps a constant offset")
 	assert_true(lane_start.z < 0.0 and lane_end.z > 0.0, "Through lane spans both edges")
+
+
+func test_through_lane_reaches_road_points():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	var lane: RoadLane = inter.get_node("RoadLane_p1_R0")
+	var p1: RoadPoint = container.get_node("p1")
+	var p2: RoadPoint = container.get_node("p2")
+	assert_almost_eq(lane.get_lane_start().z, p1.global_transform.origin.z, 0.01,
+			"Lane starts at the entry RoadPoint, not the stop line")
+	assert_almost_eq(lane.get_lane_end().z, p2.global_transform.origin.z, 0.01,
+			"Lane ends at the exit RoadPoint, not the stop line")
 
 
 func test_straight_through_keeps_tag():
@@ -205,7 +223,7 @@ func test_mismatched_lane_counts_merge():
 
 	assert_eq(_lanes_for_edge(inter, "p1").size(), 3, "All entering lanes generated")
 	for lane in _lanes_for_edge(inter, "p1"):
-		assert_eq(lane.curve.point_count, 2, "Each lane is routed")
+		assert_eq(lane.curve.point_count, 4, "Each lane is routed")
 	var extra: RoadLane = inter.get_node("RoadLane_p1_R2")
 	assert_eq(extra.lane_next_tag, "R1", "Surplus lane merges into the outer exit lane")
 

--- a/test/unit/test_intersection_lanes.gd
+++ b/test/unit/test_intersection_lanes.gd
@@ -343,3 +343,66 @@ func test_editable_lane_preserved_on_rebuild():
 	container.rebuild_segments(true)
 
 	assert_eq(lane.curve.get_point_position(0), Vector3(99, 0, 0), "User-edited lane is left intact")
+
+
+# ------------------------------------------------------------------------------
+
+
+func _make_t_junction(container) -> RoadIntersection:
+	container.setup_road_container()
+	road_util.create_intersection_three_branch(container)
+	return container.get_intersections()[0]
+
+
+func test_t_junction_bar_edges_pair_through():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_t_junction(container)
+
+	container.rebuild_segments(true)
+
+	# pw and pe form the straight bar, so each carries its entering lanes across.
+	var lane: RoadLane = inter.get_node("RoadLane_pw_R0")
+	assert_eq(lane.curve.point_count, 4, "Through lane runs RoadPoint to RoadPoint")
+	assert_true(lane.get_lane_start().x < 0.0 and lane.get_lane_end().x > 0.0,
+			"Through lane spans both bar edges")
+
+
+func test_t_junction_stem_has_no_through_lane():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_t_junction(container)
+
+	container.rebuild_segments(true)
+
+	# The stem has no edge opposite it, so it must not emit a through lane.
+	assert_null(inter.get_node_or_null("RoadLane_ps_R0"), "Stem emits no through lane")
+	assert_null(inter.get_node_or_null("RoadLane_ps_R1"), "Stem emits no through lane")
+
+
+func test_t_junction_stem_turns_to_bar_edges():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_t_junction(container)
+
+	container.rebuild_segments(true)
+
+	# Lacking a through lane, the stem still reaches each bar edge as a turn.
+	assert_not_null(_turn_lane_to(inter, "ps", "pw"), "Stem turns toward pw")
+	assert_not_null(_turn_lane_to(inter, "ps", "pe"), "Stem turns toward pe")
+
+
+func test_t_junction_lane_count():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.generate_ai_lanes = true
+	var inter := _make_t_junction(container)
+
+	container.rebuild_segments(true)
+
+	# Bar edges: two through lanes plus a turn to the stem apiece (3 each); stem:
+	# a turn to each bar edge (2).
+	assert_eq(_lanes(inter).size(), 8, "Through and turn lanes for the T")

--- a/test/unit/test_intersection_lanes.gd.uid
+++ b/test/unit/test_intersection_lanes.gd.uid
@@ -1,0 +1,1 @@
+uid://cl8psosyhfltu


### PR DESCRIPTION
Procedural ngon intersections only produced mesh geometry — there were no RoadLane curves for AI/navigation to follow across them (#329). This adds RoadLane generation to the procedural intersection rebuild.

A new `IntersectionSettings.generate_lanes()` seam mirrors `generate_mesh()`: the RoadIntersection calls it during its rebuild, and the concrete settings subclass decides the per-type lane connections. `IntersectionNGon` implements it. For each edge it works out the entering lanes from the edge facing and `traffic_dir`, routes every entering lane through to the most-opposed edge, and adds a turn lane from the turn-side lane to each remaining edge. Lanes are Curve3D paths with bezier handles aligned to the entry and exit travel directions, so they stay straight when colinear and arc smoothly otherwise.

Generated lanes are children of the RoadIntersection node, named so rebuilds reuse them rather than duplicating, tagged with the existing `F#`/`R#` convention, and added to the AI lane group. Generation is gated by `generate_ai_lanes`, honors `RoadPoint.alignment` (geometric vs divider), and leaves alone any lane the user has promoted to editable. `RoadContainer.force_assign_lanes()` now also discovers lanes parented under intersections.

Lanes are anchored at the stop-line inset, so they line up laterally with the lanes of an abutting road segment. A short stop-row gap remains between an intersection lane and its segment lane; closing it belongs to the lane-linking step below, which connects the two by tag rather than by coincident endpoints.

A couple of known limits, left for follow-ups. These lanes aren't yet auto-connected to the abutting segment lanes (the tagging/hookup step), which the issue suggested deferring. And at a T-junction, where an edge has no true opposite, the through/turn assignment falls back to the nearest-to-opposite edge, so the split there is somewhat arbitrary; four-way and straight cases route as expected.

### TESTS

`test/unit/test_intersection_lanes.gd` covers lane counts per entering lane, tag assignment, idempotent rebuilds, AI-group membership, straight-through routing and mismatched lane counts, colinear-vs-curved geometry, four-way turn lanes, divider offsets, and editable-lane preservation. `test/unit/road_utils.gd` gains a four-way intersection fixture. Full GUT suite passes on Godot 4.4. The generated geometry was also checked at runtime on straight, four-way, three-way and acute layouts: straight-through lanes run straight, turn handedness is correct, sharp turns stay clean through roughly 150 degrees with no self-crossing or degenerate curves, intersection lanes line up laterally with segment lanes at the edges, and rebuilds reuse lanes rather than duplicating them.
