### PR TITLE
Resolve size invariant intersection stop lines and RoadLane placement

### DIFF
--- a/addons/road-generator/plugin.gd
+++ b/addons/road-generator/plugin.gd
@@ -1060,7 +1060,7 @@ func convert_to_intersection_with_new_roadpoint(rp_init: RoadPoint, pos: Vector3
 	undo_redo.add_do_property(rp, "global_transform", new_transform)
 	undo_redo.add_do_method(rp, "look_at", rp_init.global_transform.origin, new_transform.basis.y)
 	undo_redo.add_do_property(rp, "global_transform.basis.y", new_transform.basis.y)
-	
+	rp.copy_settings_from(rp_init)
 	undo_redo.add_do_reference(rp)
 	
 	var inter = subaction_create_intersection(rp_init, rp, undo_redo)

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -95,6 +95,9 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 					exit_dir = -_edge_inward_dir(target["edge"], intersection)
 					next_tag = target["tag"]
 				var lane_name := _tagged_lane_name(used_names, edge.name, src["tag"], "r" if merged else "")
+				# entry/exit_dir has magnitude to indicate the offset amount
+				entry_dir = entry_dir.normalized() * edge.lane_width / RoadPoint.DEFAULT_LANE_WIDTH
+				exit_dir = exit_dir.normalized() * edge.lane_width / RoadPoint.DEFAULT_LANE_WIDTH
 				_emit_lane(intersection, container, manager, active_lanes, lane_name,
 						src["tag"], next_tag, entry, entry_dir, exit_point, exit_dir,
 						not exiting.is_empty())
@@ -118,6 +121,9 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 			var turn_exit := _lane_stop_position(target_edge, intersection, turn_dst["index"])
 			var turn_exit_dir := -_edge_inward_dir(target_edge, intersection)
 			var turn_name := _tagged_lane_name(used_names, edge.name, turn_src["tag"], "a")
+			# entry/exit_dir has magnitude to indicate the offset amount
+			entry_dir = entry_dir.normalized() * reference_edge.lane_width / RoadPoint.DEFAULT_LANE_WIDTH
+			turn_exit_dir = turn_exit_dir.normalized() * reference_edge.lane_width / RoadPoint.DEFAULT_LANE_WIDTH
 			_emit_lane(intersection, container, manager, active_lanes, turn_name,
 					turn_src["tag"], turn_dst["tag"], turn_entry, entry_dir, turn_exit, turn_exit_dir)
 
@@ -159,7 +165,7 @@ func _edge_inward_dir(edge: RoadPoint, intersection: Node3D) -> Vector3:
 
 ## World-space center of an edge's stop line, where its lanes meet the intersection.
 func _edge_stop_center(edge: RoadPoint, intersection: Node3D) -> Vector3:
-	return edge.global_transform.origin + _edge_inward_dir(edge, intersection) * STOP_ROW_SIZE
+	return edge.global_transform.origin + _edge_inward_dir(edge, intersection) * STOP_ROW_SIZE * edge.lane_width / RoadPoint.DEFAULT_LANE_WIDTH
 
 
 func _entering_dir(facing: _IntersectNGonFacing) -> int:
@@ -340,24 +346,29 @@ func _lane_stop_position(edge: RoadPoint, intersection: Node3D, lane_index: int)
 ## across the intersection with bezier handles aligned to the entry and exit
 ## travel directions (staying straight when those directions are colinear). With
 ## no exit edge to reach, the lane simply ends at the stop line.
+##
+## Note: entry_dir and exit_dir are NOT normalized, so we can pull out .length()
+## which matches the corresponding edge RP lane_width
 func _assign_through_curve(lane: RoadLane, intersection: Node3D, entry: Vector3, exit_point: Vector3, entry_dir: Vector3, exit_dir: Vector3, extend_exit: bool = true) -> void:
 	var to_local: Transform3D = lane.global_transform.affine_inverse()
 	var dir_in := (to_local.basis * entry_dir).normalized()
 	var dir_out := (to_local.basis * exit_dir).normalized()
 	var entry_stop := to_local * entry
 	var exit_stop := to_local * exit_point
-	var lead := dir_in * (STOP_ROW_SIZE / 3.0)
+	var entry_stopsize := STOP_ROW_SIZE * entry_dir.length() # / RoadPoint.DEFAULT_LANE_WIDTH
+	var lead := dir_in * (entry_stopsize / 3.0) # TODO: fix non lane-width aware row size
 	var handle := entry_stop.distance_to(exit_stop) / 3.0
 
 	var curve := Curve3D.new()
 	# Lead in from the entry RoadPoint to its stop line, then arc across.
-	curve.add_point(entry_stop - dir_in * STOP_ROW_SIZE, Vector3.ZERO, lead)
+	curve.add_point(entry_stop - dir_in * entry_stopsize, Vector3.ZERO, lead)
 	curve.add_point(entry_stop, -lead, dir_in * handle)
 	if extend_exit:
 		# Arc to the exit stop line, then lead out to the exit RoadPoint.
-		var out_lead := dir_out * (STOP_ROW_SIZE / 3.0)
+		var exit_stopsize := STOP_ROW_SIZE * exit_dir.length() # / RoadPoint.DEFAULT_LANE_WIDTH
+		var out_lead := dir_out * (exit_stopsize / 3.0) # TODO: fix non lane-width aware row size
 		curve.add_point(exit_stop, -dir_out * handle, out_lead)
-		curve.add_point(exit_stop + dir_out * STOP_ROW_SIZE, -out_lead, Vector3.ZERO)
+		curve.add_point(exit_stop + dir_out * exit_stopsize, -out_lead, Vector3.ZERO) # TODO: fix non lane-width aware row size
 	else:
 		curve.add_point(exit_stop, -dir_out * handle, Vector3.ZERO)
 	lane.curve = curve
@@ -439,7 +450,7 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 		
 		# Aim for real-world texture proportions width:height of 2:1 matching texture,
 		# but then the hight of 1 full UV is half the with across all lanes, so another 2x
-		var uv_height := STOP_ROW_SIZE / lane_width / 8.0 # ratio of 1/4th down vs width of image to be square
+		var uv_height := STOP_ROW_SIZE / lane_width / RoadPoint.DEFAULT_LANE_WIDTH / 2 # ratio of 1/4th down vs width of image to be square
 
 		var perpendicular_v: Vector3 = (edge.transform.basis.x).normalized()
 		var up_vector: Vector3 = (edge.transform.basis.y).normalized()
@@ -461,12 +472,14 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 		if facing == _IntersectNGonFacing.ORIGIN:	
 			parallel_v = -parallel_v
 
-		var shoulder_l_stop: Vector3 = shoulder_l + parallel_v * STOP_ROW_SIZE
-		var shoulder_r_stop: Vector3 = shoulder_r + parallel_v * STOP_ROW_SIZE
-		var gutter_l_stop: Vector3 = gutter_l + parallel_v * STOP_ROW_SIZE
-		var gutter_r_stop: Vector3 = gutter_r + parallel_v * STOP_ROW_SIZE
-		var road_side_l_stop: Vector3 = road_side_l + parallel_v * STOP_ROW_SIZE
-		var road_side_r_stop: Vector3 = road_side_r + parallel_v * STOP_ROW_SIZE
+		var stopsize := STOP_ROW_SIZE * edge.lane_width / RoadPoint.DEFAULT_LANE_WIDTH
+
+		var shoulder_l_stop: Vector3 = shoulder_l + parallel_v * stopsize
+		var shoulder_r_stop: Vector3 = shoulder_r + parallel_v * stopsize
+		var gutter_l_stop: Vector3 = gutter_l + parallel_v * stopsize
+		var gutter_r_stop: Vector3 = gutter_r + parallel_v * stopsize
+		var road_side_l_stop: Vector3 = road_side_l + parallel_v * stopsize
+		var road_side_r_stop: Vector3 = road_side_r + parallel_v * stopsize
 
 		if facing == _IntersectNGonFacing.ORIGIN:	
 			edge_shoulders.append([shoulder_l_stop, shoulder_r_stop])
@@ -535,8 +548,8 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 				current_perpendicular_v = -perpendicular_v
 			var lane_left_side: Vector3 = road_side_l + current_perpendicular_v * (lane_width * i)
 			var lane_right_side: Vector3 = road_side_l + current_perpendicular_v * (lane_width * (i + 1))
-			var lane_left_side_stop: Vector3 = lane_left_side + parallel_v * STOP_ROW_SIZE
-			var lane_right_side_stop: Vector3 = lane_right_side + parallel_v * STOP_ROW_SIZE
+			var lane_left_side_stop: Vector3 = lane_left_side + parallel_v * stopsize
+			var lane_right_side_stop: Vector3 = lane_right_side + parallel_v * stopsize
 
 			# Lane quad
 			var u_near := uv_width*6

--- a/test/integration/procedural_intersection_lanes.tscn
+++ b/test/integration/procedural_intersection_lanes.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://br6v5vv3wt57s"]
+[gd_scene load_steps=12 format=3 uid="uid://br6v5vv3wt57s"]
 
 [ext_resource type="Script" uid="uid://bxp3i4cnonh8y" path="res://addons/road-generator/nodes/road_manager.gd" id="1_ta8s7"]
 [ext_resource type="Script" uid="uid://cph7euje06kel" path="res://addons/road-generator/nodes/road_container.gd" id="2_oqfhe"]
@@ -15,6 +15,15 @@ script = ExtResource("5_2dq0y")
 [sub_resource type="Resource" id="Resource_vl380"]
 script = ExtResource("5_2dq0y")
 
+[sub_resource type="Resource" id="Resource_rsonp"]
+script = ExtResource("5_2dq0y")
+
+[sub_resource type="Resource" id="Resource_oqfhe"]
+script = ExtResource("5_2dq0y")
+
+[sub_resource type="Resource" id="Resource_ta8s7"]
+script = ExtResource("5_2dq0y")
+
 [node name="Node3D" type="Node3D"]
 
 [node name="RoadManager" type="Node3D" parent="."]
@@ -26,6 +35,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.38881, 0, -7.18216)
 script = ExtResource("2_oqfhe")
 use_lowpoly_preview = true
 generate_ai_lanes = true
+draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_target_dirs = Array[int]([-1, -1, -1])
@@ -78,6 +88,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 51.907, 0, 0.477782)
 script = ExtResource("2_oqfhe")
 use_lowpoly_preview = true
 generate_ai_lanes = true
+draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_target_dirs = Array[int]([-1, -1, -1])
@@ -130,6 +141,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.42461, 0, 66.6676)
 script = ExtResource("2_oqfhe")
 use_lowpoly_preview = true
 generate_ai_lanes = true
+draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_target_dirs = Array[int]([-1, -1, -1])
@@ -182,6 +194,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -71.0842, 0, 68.2582)
 script = ExtResource("2_oqfhe")
 use_lowpoly_preview = true
 generate_ai_lanes = true
+draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
 edge_rp_target_dirs = Array[int]([-1, -1, -1])
@@ -197,7 +210,7 @@ next_mag = 16.0
 prior_pt_init = NodePath("../Intersection")
 
 [node name="RP_003" type="Node3D" parent="RoadManager/RotatedT"]
-transform = Transform3D(1.94707e-07, 0, -1, 0, 1, 0, 1, 0, 1.94707e-07, 60, 0.25, 0)
+transform = Transform3D(1.94707e-07, 0, -1, 0, 1, 0, 1, 0, 1.94707e-07, 58.3198, 0.25, 0)
 script = ExtResource("3_eukx4")
 traffic_dir = Array[int]([2, 2, 2, 1, 1, 1])
 lanes = Array[int]([2, 3, 4, 4, 3, 2])
@@ -234,6 +247,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 125.324, 0, 56.3668)
 script = ExtResource("2_oqfhe")
 use_lowpoly_preview = true
 generate_ai_lanes = true
+draw_lanes_editor = true
 edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath(""), NodePath("")])
 edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath(""), NodePath("")])
 edge_rp_target_dirs = Array[int]([-1, -1, -1, -1])
@@ -318,3 +332,258 @@ lanes = Array[int]([2, 3, 3, 4, 4, 3, 2])
 prior_mag = 3.57197
 next_mag = 3.57197
 prior_pt_init = NodePath("../RP_001")
+
+[node name="TinyRoad" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -150.916, 0, 68.3782)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_003"), NodePath("RP_004"), NodePath("RP_002")])
+edge_rp_local_dirs = Array[int]([1, 0, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/TinyRoad"]
+transform = Transform3D(-0.0215323, -2.19655e-06, -0.999768, 0, 1, -2.19706e-06, 0.999768, -4.73079e-08, -0.0215323, 17.958, 0, 0.256)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 0.914917
+next_mag = 2.94268
+lane_width = 0.4
+shoulder_width_l = 0.2
+shoulder_width_r = 0.2
+gutter_profile = Vector2(0.2, -0.05)
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_002")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/TinyRoad"]
+transform = Transform3D(-0.00630033, 4.58987e-15, -0.99998, 2.13138e-13, 1, 3.24709e-15, 0.99998, -2.13113e-13, -0.00630033, 25.896, 0, 1.182)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 2.04749
+next_mag = 2.04749
+lane_width = 0.4
+shoulder_width_l = 0.2
+shoulder_width_r = 0.2
+gutter_profile = Vector2(0.2, -0.05)
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/TinyRoad"]
+transform = Transform3D(-0.898215, -3.50159e-14, 0.439556, -3.89838e-14, 1, 8.64847e-22, -0.439556, -1.71356e-14, -0.898215, 22.542, 0, -3.069)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 0.5
+next_mag = 0.5
+lane_width = 0.4
+shoulder_width_l = 0.2
+shoulder_width_r = 0.2
+gutter_profile = Vector2(0.2, -0.05)
+prior_pt_init = NodePath("../Intersection")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/TinyRoad" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 21.427, 0, 0.67)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_rsonp")
+edge_points = [NodePath("../RP_001"), NodePath("../RP_004"), NodePath("../RP_003")]
+
+[node name="RP_002" type="Node3D" parent="RoadManager/TinyRoad"]
+transform = Transform3D(-0.141107, -2.19655e-06, -0.989994, -2.63114e-07, 1, -2.18125e-06, 0.989994, -4.73079e-08, -0.141107, 11.599, 0, 0.714)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 2.94268
+next_mag = 2.94268
+lane_width = 0.4
+shoulder_width_l = 0.2
+shoulder_width_r = 0.2
+gutter_profile = Vector2(0.2, -0.05)
+prior_pt_init = NodePath("../RP_001")
+
+[node name="BigRoad" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -603.011, 0, 144.771)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_001"), NodePath("RP_003"), NodePath("RP_004")])
+edge_rp_local_dirs = Array[int]([0, 1, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/BigRoad"]
+transform = Transform3D(0.604544, 8.46355e-08, -0.796572, 0, 1, 1.0625e-07, 0.796572, -6.42327e-08, 0.604544, 39.867, 0, 22.998)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+next_mag = 71.8062
+lane_width = 40.0
+shoulder_width_l = 10.0
+shoulder_width_r = 10.0
+gutter_profile = Vector2(10, -5)
+prior_pt_init = NodePath("../Intersection")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/BigRoad"]
+transform = Transform3D(-0.0325264, 6.98368e-15, -0.999471, 4.2826e-15, 1, 6.84801e-15, 0.999471, -4.05759e-15, -0.0325264, 411.256, 0, -128.13)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 160.0
+next_mag = 160.0
+lane_width = 40.0
+shoulder_width_l = 10.0
+shoulder_width_r = 10.0
+gutter_profile = Vector2(10, -5)
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/BigRoad"]
+transform = Transform3D(-0.976732, 1.67009e-15, -0.214463, 1.70987e-15, 1, 0, 0.214463, -3.66704e-16, -0.976732, 139.123, 0, -319.335)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 160.0
+next_mag = 71.8062
+lane_width = 40.0
+shoulder_width_l = 10.0
+shoulder_width_r = 10.0
+gutter_profile = Vector2(10, -5)
+prior_pt_init = NodePath("../Intersection")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/BigRoad" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 182.252, 0, -99.3219)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_oqfhe")
+edge_points = [NodePath("../RP_004"), NodePath("../RP_003"), NodePath("../RP_001")]
+
+[node name="SixWay" type="Node3D" parent="RoadManager"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -127.061, 0, -20.6972)
+script = ExtResource("2_oqfhe")
+use_lowpoly_preview = true
+generate_ai_lanes = true
+draw_lanes_editor = true
+edge_containers = Array[NodePath]([NodePath(""), NodePath(""), NodePath(""), NodePath(""), NodePath(""), NodePath("")])
+edge_rp_targets = Array[NodePath]([NodePath(""), NodePath(""), NodePath(""), NodePath(""), NodePath(""), NodePath("")])
+edge_rp_target_dirs = Array[int]([-1, -1, -1, -1, -1, -1])
+edge_rp_locals = Array[NodePath]([NodePath("RP_001"), NodePath("RP_006"), NodePath("RP_009"), NodePath("RP_010"), NodePath("RP_011"), NodePath("RP_012")])
+edge_rp_local_dirs = Array[int]([0, 0, 0, 0, 1, 0])
+
+[node name="RP_001" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.018245, 0, -0.999834, 0, 1, 0, 0.999834, 0, -0.018245, -6.73793, 0, 0)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+next_mag = 12.0
+prior_pt_init = NodePath("../RP_002")
+
+[node name="RP_002" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.018245, 0, -0.999834, 0, 1, 0, 0.999834, 0, -0.018245, 16.784, 0, 0.306274)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+prior_mag = 14.397
+next_mag = 12.0
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_001")
+
+[node name="RP_004" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.23594, 0, -0.971768, 0, 1, 0, 0.971768, 0, -0.23594, 71.3035, 0, -2.87852)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+prior_mag = 12.0
+next_mag = 14.6406
+prior_pt_init = NodePath("../RP_011")
+next_pt_init = NodePath("../Intersection")
+
+[node name="RP_005" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.785457, 0, -0.618917, 0, 1, 0, 0.618917, 0, -0.785457, 22.3029, 0, -28.7365)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+prior_mag = 14.6406
+next_mag = 8.43943
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_006")
+
+[node name="Intersection" type="Node3D" parent="RoadManager/SixWay" node_paths=PackedStringArray("edge_points")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 45.7947, 0, -10.4888)
+script = ExtResource("4_uyy1g")
+settings = SubResource("Resource_ta8s7")
+edge_points = [NodePath("../RP_005"), NodePath("../RP_003"), NodePath("../RP_007"), NodePath("../RP_004"), NodePath("../RP_008"), NodePath("../RP_002")]
+
+[node name="RP_006" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.691474, 0, -0.722401, 0, 1, 0, 0.722401, 0, -0.691474, 9.67622, 0, -41.2123)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+prior_mag = 7.35703
+next_mag = 12.0
+prior_pt_init = NodePath("../RP_005")
+
+[node name="RP_003" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.999767, 0, 0.0216032, 0, 1, 0, -0.0216032, 0, -0.999767, 46.4419, 0, -39.3734)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+next_mag = 5.47509
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_010")
+
+[node name="RP_007" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.80315, 0, 0.595777, 0, 1, 0, -0.595777, 0, -0.80315, 68.0061, 0, -29.444)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+next_mag = 6.23105
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_009")
+
+[node name="RP_008" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(0.632261, 0, 0.774756, 0.0187938, 0.999706, -0.0153372, -0.774528, 0.0242577, 0.632074, 61.4934, 0, 13.1956)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+next_mag = 16.0
+prior_pt_init = NodePath("../Intersection")
+next_pt_init = NodePath("../RP_012")
+
+[node name="RP_009" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.934801, 0, 0.355171, 0, 1, 0, -0.355171, 0, -0.934801, 75.4894, 0, -43.9087)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+prior_mag = 6.17099
+next_mag = 6.17099
+prior_pt_init = NodePath("../RP_007")
+
+[node name="RP_010" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.9299, 0, -0.367813, 0, 1, 0, 0.367813, 0, -0.9299, 42.5482, 0, -55.5803)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1])
+lanes = Array[int]([5, 5])
+prior_mag = 8.0
+next_mag = 8.0
+prior_pt_init = NodePath("../RP_003")
+
+[node name="RP_011" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(-0.060389, 0, -0.998175, 0, 1, 0, 0.998175, 0, -0.060389, 89.9205, 0, -0.524181)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 1, 1])
+lanes = Array[int]([5, 4, 2])
+prior_mag = 5.04084
+next_mag = 5.04084
+next_pt_init = NodePath("../RP_004")
+
+[node name="RP_012" type="Node3D" parent="RoadManager/SixWay"]
+transform = Transform3D(0.680968, -0.00109829, 0.732312, -0.0169983, 0.999706, 0.0173059, -0.732116, -0.0242328, 0.680749, 78.1189, -0.134766, 27.9337)
+script = ExtResource("3_eukx4")
+traffic_dir = Array[int]([2, 2, 1, 1])
+lanes = Array[int]([2, 4, 4, 2])
+prior_mag = 4.3841
+next_mag = 4.3841
+prior_pt_init = NodePath("../RP_008")


### PR DESCRIPTION
Previously, the "stop line" of intersections was a hard coded constant, so if you had a tiny road (aka where RoadPoint.lane_width is small), things would look strange.

This does *not* solve the subtle issue of RoadLane's debug draw in game/editor visual scaling with RoadLanes. At the moment, RoadLanes don't formally have a connection to RoadPoints, which makes it tricky to determine the right RoadLane width to consider - particularly for lanes within intersections, which on their own don't have a RoadWidth concept.

Most likely, we simply need to introduce start/end point references on RoadLanes, helpful for various snapping purposes and also calculating branching nodes / calculating overall traffic graphs. For another time.

## Before (small road), notice the wide gap between where the double yellow ends and the real intersection starts:

<img width="722" height="384" alt="Screenshot 2026-07-08 at 9 07 48 PM" src="https://github.com/user-attachments/assets/a49bf187-84ec-4c1e-8e0f-f41423bfadc2" />

## After (small road)

<img width="652" height="428" alt="Screenshot 2026-07-08 at 9 06 18 PM" src="https://github.com/user-attachments/assets/6d042c92-7137-40cb-861e-8a2f8a04a36d" />

## Also adds "tiny" and "big" and "6-point" intersection variants:

<img width="1134" height="448" alt="Screenshot 2026-07-08 at 9 04 22 PM" src="https://github.com/user-attachments/assets/96ccf959-2165-417d-ab7b-67e4c3424fbe" />
