### PR TITLE
Implement intersection edge curves

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -485,9 +485,13 @@ func _set_create_edge_curves(value: bool) -> void:
 	if create_edge_curves:
 		for seg in get_segments():
 			seg.generate_edge_curves()
+		for inter in get_intersections():
+			inter.generate_edge_curves()
 	else:
 		for seg in get_segments():
 			seg.clear_edge_curves()
+		for inter in get_intersections():
+			inter.clear_edge_curves()
 
 
 # ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -226,6 +226,24 @@ func sort_branches() -> void:
 		_sort_edges_clockwise()
 
 
+## Generate this intersection's exterior edge curves, respecting the container's
+## create_edge_curves toggle. Mirrors [method RoadSegment.generate_edge_curves].
+func generate_edge_curves() -> void:
+	if not is_instance_valid(settings) or not is_instance_valid(container):
+		return
+	if not container.create_edge_curves:
+		clear_edge_curves()
+		return
+	settings.generate_edge_curves(self, edge_points, container)
+
+
+## Remove this intersection's generated edge curves.
+func clear_edge_curves() -> void:
+	if not is_instance_valid(settings) or not is_instance_valid(container):
+		return
+	settings.clear_edge_curves(self, edge_points, container)
+
+
 ## Match the draw settings of generated lanes to the container's settings.
 func update_lane_visibility() -> void:
 	for child in get_children():
@@ -278,6 +296,7 @@ func _rebuild() -> void:
 	container._create_collisions(_mesh)
 
 	settings.generate_lanes(self, edge_points, container)
+	generate_edge_curves()
 
 
 func _do_roadmesh_creation():

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -128,9 +128,11 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 
 
 ## Builds one exterior edge curve per branch, spanning from each edge to its
-## clockwise neighbour, and sweeps away curves whose branch is gone. Edges MUST
-## have been sorted beforehand; the neighbour is simply the next sorted edge, so a
-## removed branch's curve is dropped and its neighbour regenerated automatically.
+## counter-clockwise neighbour so the curve named after an edge hugs that edge's
+## right-hand side (drive-on-right), the intuitive parent for right-side decoration
+## like sidewalks. Sweeps away curves whose branch is gone. Edges MUST have been
+## sorted beforehand; the neighbour is simply the previous sorted edge, so a removed
+## branch's curve is dropped and its neighbour regenerated automatically.
 func generate_edge_curves(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
 	# A lone branch has no exterior span to bound.
 	if edges.size() < 2:
@@ -141,7 +143,7 @@ func generate_edge_curves(intersection: Node3D, edges: Array[RoadPoint], contain
 	var count := edges.size()
 	for i in range(count):
 		var edge: RoadPoint = edges[i]
-		var neighbor: RoadPoint = edges[(i + 1) % count]
+		var neighbor: RoadPoint = edges[(i - 1 + count) % count]
 		if not is_instance_valid(edge) or not is_instance_valid(neighbor):
 			continue
 		if _get_edge_facing(edge, intersection) == _IntersectNGonFacing.OTHER:
@@ -152,9 +154,11 @@ func generate_edge_curves(intersection: Node3D, edges: Array[RoadPoint], contain
 		var path := _get_or_create_edge_curve(intersection, EDGE_PREFIX + edge.name)
 		active.append(path)
 
+		# Anchor at this edge's s1 (right-hand) corner and run to the neighbour's s0,
+		# putting the named curve on the edge's right rather than its left.
 		var here := _edge_exterior_corners(edge, intersection)
 		var there := _edge_exterior_corners(neighbor, intersection)
-		_assign_edge_curve(path, here["s0"], here["s0_stop"], there["s1_stop"], there["s1"])
+		_assign_edge_curve(path, here["s1"], here["s1_stop"], there["s0_stop"], there["s0"])
 
 	_clear_generated_edge_curves(intersection, active)
 

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -21,6 +21,9 @@ const SegGeo := preload("res://addons/road-generator/procgen/segment_geo.gd")
 
 const STOP_ROW_SIZE: float = 2.0  # TODO: make proportional to density
 
+## Prefix for generated edge-curve nodes, named `edge_{starting RoadPoint name}`.
+const EDGE_PREFIX := "edge_"
+
 ## Meters of lateral error treated as equivalent to one radian of facing
 ## misalignment when scoring primary candidates. Lateral offset is weighted more
 ## heavily than angle, so a candidate the source aims squarely at is preferred
@@ -122,6 +125,42 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 					turn_src["tag"], turn_dst["tag"], turn_entry, entry_dir, turn_exit, turn_exit_dir)
 
 	_clear_generated_lanes(intersection, active_lanes)
+
+
+## Builds one exterior edge curve per branch, spanning from each edge to its
+## clockwise neighbour, and sweeps away curves whose branch is gone. Edges MUST
+## have been sorted beforehand; the neighbour is simply the next sorted edge, so a
+## removed branch's curve is dropped and its neighbour regenerated automatically.
+func generate_edge_curves(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
+	# A lone branch has no exterior span to bound.
+	if edges.size() < 2:
+		_clear_generated_edge_curves(intersection, [])
+		return
+
+	var active: Array[Path3D] = []
+	var count := edges.size()
+	for i in range(count):
+		var edge: RoadPoint = edges[i]
+		var neighbor: RoadPoint = edges[(i + 1) % count]
+		if not is_instance_valid(edge) or not is_instance_valid(neighbor):
+			continue
+		if _get_edge_facing(edge, intersection) == _IntersectNGonFacing.OTHER:
+			continue
+		if _get_edge_facing(neighbor, intersection) == _IntersectNGonFacing.OTHER:
+			continue
+
+		var path := _get_or_create_edge_curve(intersection, EDGE_PREFIX + edge.name)
+		active.append(path)
+
+		var here := _edge_exterior_corners(edge, intersection)
+		var there := _edge_exterior_corners(neighbor, intersection)
+		_assign_edge_curve(path, here["s0"], here["s0_stop"], there["s1_stop"], there["s1"])
+
+	_clear_generated_edge_curves(intersection, active)
+
+
+func clear_edge_curves(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
+	_clear_generated_edge_curves(intersection, [])
 
 
 # ------------------------------------------------------------------------------
@@ -377,6 +416,103 @@ func _tagged_lane_name(used: Dictionary, edge_name: String, tag: String, suffix:
 		counter += 1
 	used[lane_name] = true
 	return lane_name
+
+
+## World-space outer gutter corners of an edge, matching the intersection mesh's
+## exterior border. Returns the two facing-normalised sides (`s0`/`s1`, ordered as
+## the mesh stores them in edge_gutters) each at the RoadPoint (`s0`/`s1`) and at
+## the stop line (`s0_stop`/`s1_stop`). Held in the road plane (no vertical gutter
+## drop) and offset like the [RoadSegment] edge curves so the two line up across
+## the RoadPoint. Divider-aligned edges split their offset by direction to match
+## the segment edge curves rather than the mesh's geometric centreline.
+func _edge_exterior_corners(edge: RoadPoint, intersection: Node3D) -> Dictionary:
+	var facing: _IntersectNGonFacing = _get_edge_facing(edge, intersection)
+	var perpendicular_v: Vector3 = edge.global_transform.basis.x.normalized()
+	var parallel_v: Vector3 = edge.global_transform.basis.z.normalized()
+	if facing == _IntersectNGonFacing.ORIGIN:
+		parallel_v = -parallel_v
+	var origin: Vector3 = edge.global_transform.origin
+
+	var offset_l: float
+	var offset_r: float
+	if edge.alignment == RoadPoint.Alignment.GEOMETRIC:
+		var half_width: float = edge.lanes.size() * edge.lane_width * 0.5
+		offset_l = half_width
+		offset_r = half_width
+	else:
+		offset_l = edge.get_rev_lane_count() * edge.lane_width
+		offset_r = edge.get_fwd_lane_count() * edge.lane_width
+	offset_l += edge.shoulder_width_l + edge.gutter_profile[0]
+	offset_r += edge.shoulder_width_r + edge.gutter_profile[0]
+
+	var gutter_l: Vector3 = origin - perpendicular_v * offset_l
+	var gutter_r: Vector3 = origin + perpendicular_v * offset_r
+	var stop: Vector3 = parallel_v * STOP_ROW_SIZE
+
+	if facing == _IntersectNGonFacing.ORIGIN:
+		return {
+			"s0": gutter_l, "s0_stop": gutter_l + stop,
+			"s1": gutter_r, "s1_stop": gutter_r + stop,
+		}
+	return {
+		"s0": gutter_r, "s0_stop": gutter_r + stop,
+		"s1": gutter_l, "s1_stop": gutter_l + stop,
+	}
+
+
+## Finds an existing edge curve by name or creates one, mirroring the editor
+## metadata of [RoadSegment] edge curves. The existing node is always reused so
+## any children the user has parented to it survive regeneration.
+func _get_or_create_edge_curve(intersection: Node3D, edge_name: String) -> Path3D:
+	var existing := intersection.get_node_or_null(edge_name)
+	if existing is Path3D:
+		return existing
+	var path := Path3D.new()
+	intersection.add_child(path)
+	path.name = edge_name
+	path.owner = intersection.owner
+	path.set_meta("_edit_lock_", true)
+	return path
+
+
+## Writes the four-point exterior boundary curve for one edge into `path`, in its
+## local space: from the edge's outer RoadPoint corner along its gutter to the
+## stop line, across to the neighbour's stop line, then out to the neighbour's
+## RoadPoint corner. Handles are sharp (non-aligned) at the two bends, pointing
+## straight at the source corner and the opposite corner, matching the low-poly
+## [RoadSegment] edge-curve profile. A fresh [Curve3D] is assigned rather than the
+## node replaced, so the path node and its children persist.
+func _assign_edge_curve(path: Path3D, p0: Vector3, p1: Vector3, p2: Vector3, p3: Vector3) -> void:
+	var to_local: Transform3D = path.global_transform.affine_inverse()
+	var l0: Vector3 = to_local * p0
+	var l1: Vector3 = to_local * p1
+	var l2: Vector3 = to_local * p2
+	var l3: Vector3 = to_local * p3
+
+	var curve := Curve3D.new()
+	curve.add_point(l0, Vector3.ZERO, (l1 - l0) / 3.0)
+	curve.add_point(l1, (l0 - l1) / 3.0, (l2 - l1) / 3.0)
+	curve.add_point(l2, (l1 - l2) / 3.0, (l3 - l2) / 3.0)
+	curve.add_point(l3, (l2 - l3) / 3.0, Vector3.ZERO)
+	path.curve = curve
+
+
+## Frees previously generated edge curves that are no longer active, identified by
+## the `edge_` prefix. RoadLanes (also Path3D children) are left untouched. Nodes
+## are detached before being freed, mirroring [method RoadSegment.clear_edge_curves],
+## so their names are released immediately rather than on the deferred free.
+func _clear_generated_edge_curves(intersection: Node3D, keep: Array) -> void:
+	for child in intersection.get_children():
+		if child is RoadLane:
+			continue
+		if not (child is Path3D):
+			continue
+		if not str(child.name).begins_with(EDGE_PREFIX):
+			continue
+		if keep.has(child):
+			continue
+		intersection.remove_child(child)
+		child.queue_free()
 
 
 ## Frees previously generated lanes that are no longer active.

--- a/addons/road-generator/procgen/intersection_settings.gd
+++ b/addons/road-generator/procgen/intersection_settings.gd
@@ -52,6 +52,27 @@ func generate_lanes(intersection: Node3D, edges: Array[RoadPoint], container: Ro
 	push_error("IntersectionSettings.generate_lanes() not implemented by child class.")
 
 
+## @abstract
+## Generates the exterior edge curves for the intersection, as children of the
+## [param intersection] node, one [Path3D] per branch named `edge_{RoadPoint name}`.
+##
+## Mirrors [generate_lanes]: triggered by the [RoadIntersection] during rebuild,
+## with the concrete subclass building the boundary geometry so the curves line
+## up with the adjoining [RoadSegment] edge curves.
+##
+## Edges MUST have been sorted by angle from intersection beforehand.
+##
+## Note: Cannot use [RoadIntersection] for `intersection` due to cyclic typing.
+func generate_edge_curves(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
+	push_error("IntersectionSettings.generate_edge_curves() not implemented by child class.")
+
+
+## @abstract
+## Removes all generated edge curves from the [param intersection] node.
+func clear_edge_curves(intersection: Node3D, edges: Array[RoadPoint], container: RoadContainer) -> void:
+	push_error("IntersectionSettings.clear_edge_curves() not implemented by child class.")
+
+
 ## Returns true if all the provided edges have sufficient distance
 ## from the intersection point to have proper mesh generation.
 ##

--- a/test/unit/test_intersection_edge_curves.gd
+++ b/test/unit/test_intersection_edge_curves.gd
@@ -121,18 +121,6 @@ func test_edge_curves_independent_of_ai_lanes():
 		assert_eq(edge.curve.point_count, 4, "Edge curve is fully built without AI lanes")
 
 
-func test_rebuild_does_not_duplicate_edge_curves():
-	var container = autoqfree(RoadContainer.new())
-	add_child(container)
-	container.create_edge_curves = true
-	var inter := _make_intersection(container)
-
-	container.rebuild_segments(true)
-	container.rebuild_segments(true)
-
-	assert_eq(_edge_curves(inter).size(), 2, "Edge curves reused, not duplicated, on rebuild")
-
-
 func test_edge_curve_node_reused_on_rebuild():
 	var container = autoqfree(RoadContainer.new())
 	add_child(container)
@@ -145,6 +133,7 @@ func test_edge_curve_node_reused_on_rebuild():
 	var after: Path3D = inter.get_node("edge_p1")
 
 	assert_eq(before, after, "The Path3D node itself is reused, only its curve rewritten")
+	assert_eq(_edge_curves(inter).size(), 2, "Edge curves reused, not duplicated, on rebuild")
 
 
 func test_edge_curve_children_survive_rebuild():
@@ -201,7 +190,7 @@ func test_removing_a_branch_deletes_its_edge_and_regenerates():
 	container.rebuild_segments(true)
 
 	# The orphaned edge is swept away and the survivors regenerate to their new
-	# clockwise neighbours, leaving one curve per remaining branch.
+	# neighbours, leaving one curve per remaining branch.
 	assert_eq(_edge_curves(inter).size(), 3, "Removed branch drops one edge curve")
 	assert_null(inter.get_node_or_null("edge_pw"), "The removed branch's edge curve is gone")
 

--- a/test/unit/test_intersection_edge_curves.gd
+++ b/test/unit/test_intersection_edge_curves.gd
@@ -224,3 +224,19 @@ func test_adding_a_branch_creates_an_edge():
 
 	assert_eq(_edge_curves(inter).size(), 3, "New branch adds an edge curve")
 	assert_not_null(inter.get_node_or_null("edge_p3"), "The new branch's edge curve exists")
+
+
+func test_container_toggle_generates_and_clears_edges():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	var inter := _make_intersection(container)
+	container.rebuild_segments(true)
+	assert_eq(_edge_curves(inter).size(), 0, "No edge curves while the toggle is off")
+
+	# Flipping the container toggle drives the intersection edges directly, without
+	# waiting for a rebuild, in parallel with how it drives segment edge curves.
+	container.create_edge_curves = true
+	assert_eq(_edge_curves(inter).size(), 2, "Enabling the toggle generates intersection edges")
+
+	container.create_edge_curves = false
+	assert_eq(_edge_curves(inter).size(), 0, "Disabling the toggle clears intersection edges")

--- a/test/unit/test_intersection_edge_curves.gd
+++ b/test/unit/test_intersection_edge_curves.gd
@@ -1,0 +1,226 @@
+extends "res://addons/gut/test.gd"
+
+const RoadUtils = preload("res://test/unit/road_utils.gd")
+
+var road_util: RoadUtils
+
+
+func before_each():
+	road_util = RoadUtils.new()
+	road_util.gut = gut
+
+
+func _make_intersection(container) -> RoadIntersection:
+	container.setup_road_container()
+	road_util.create_intersection_two_branch(container)
+	return container.get_intersections()[0]
+
+
+## Generated edge curves: Path3D children carrying the edge_ prefix. RoadLanes are
+## also Path3D, so they are filtered out explicitly.
+func _edge_curves(node: Node) -> Array:
+	var result: Array = []
+	for child in node.get_children():
+		if child is RoadLane:
+			continue
+		if child is Path3D and not child.is_queued_for_deletion() \
+				and str(child.name).begins_with("edge_"):
+			result.append(child)
+	return result
+
+
+func _edge_names(node: Node) -> Array:
+	var result: Array = []
+	for edge in _edge_curves(node):
+		result.append(str(edge.name))
+	result.sort()
+	return result
+
+
+# ------------------------------------------------------------------------------
+
+
+func test_generates_one_edge_curve_per_branch():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	# Two branches bound two exterior spans, one curve owned by each edge.
+	assert_eq(_edge_curves(inter).size(), 2, "One edge curve per branch")
+	assert_eq(_edge_names(inter), ["edge_p1", "edge_p2"], "Named after their starting RoadPoint")
+
+
+func test_edge_curve_count_matches_four_branches():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	container.setup_road_container()
+	road_util.create_intersection_four_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	assert_eq(_edge_curves(inter).size(), 4, "One exterior edge curve per branch")
+
+
+func test_edge_curve_count_matches_three_branches():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	container.setup_road_container()
+	road_util.create_intersection_three_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	assert_eq(_edge_curves(inter).size(), 3, "One exterior edge curve per branch")
+
+
+func test_no_edge_curves_when_disabled():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = false
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	assert_eq(_edge_curves(inter).size(), 0, "No edge curves when the toggle is off")
+
+
+func test_edge_curve_has_four_points():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	# RoadPoint corner, stop-line corner, neighbour stop-line corner, neighbour
+	# RoadPoint corner: the same point count as the outermost RoadLane.
+	for edge in _edge_curves(inter):
+		assert_eq(edge.curve.point_count, 4, "Edge curve runs RoadPoint to RoadPoint via both stop lines")
+
+
+func test_edge_curves_independent_of_ai_lanes():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	container.generate_ai_lanes = false
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+
+	# Edge curves derive from RoadPoint geometry, not emitted lanes, so they exist
+	# even with AI lane generation switched off.
+	var edges := _edge_curves(inter)
+	assert_eq(edges.size(), 2, "Edge curves generate without AI lanes")
+	for edge in edges:
+		assert_eq(edge.curve.point_count, 4, "Edge curve is fully built without AI lanes")
+
+
+func test_rebuild_does_not_duplicate_edge_curves():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+	container.rebuild_segments(true)
+
+	assert_eq(_edge_curves(inter).size(), 2, "Edge curves reused, not duplicated, on rebuild")
+
+
+func test_edge_curve_node_reused_on_rebuild():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	var inter := _make_intersection(container)
+
+	container.rebuild_segments(true)
+	var before: Path3D = inter.get_node("edge_p1")
+	container.rebuild_segments(true)
+	var after: Path3D = inter.get_node("edge_p1")
+
+	assert_eq(before, after, "The Path3D node itself is reused, only its curve rewritten")
+
+
+func test_edge_curve_children_survive_rebuild():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	var inter := _make_intersection(container)
+	container.rebuild_segments(true)
+
+	# The user is expected to parent decoration nodes to the edge curve; a rebuild
+	# rewrites the curve resource but must not free the node or its children.
+	var edge: Path3D = inter.get_node("edge_p1")
+	var decoration := Node3D.new()
+	edge.add_child(decoration)
+	decoration.name = "decoration"
+	decoration.owner = container
+
+	container.rebuild_segments(true)
+
+	assert_false(decoration.is_queued_for_deletion(), "User-added child survives rebuild")
+	assert_not_null(edge.get_node_or_null("decoration"), "Child still parented to the edge curve")
+
+
+func test_edge_curve_bends_have_sharp_handles():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	container.setup_road_container()
+	road_util.create_intersection_four_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+
+	# At a 90-degree corner the in/out handles point at different neighbours, so
+	# they are non-aligned (sharp) rather than colinear (smooth).
+	var edge: Path3D = inter.get_node("edge_pn")
+	var in_handle := edge.curve.get_point_in(1)
+	var out_handle := edge.curve.get_point_out(1)
+	assert_gt(in_handle.cross(out_handle).length(), 0.01, "Bend handles are sharp, not aligned")
+
+
+func test_removing_a_branch_deletes_its_edge_and_regenerates():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	container.setup_road_container()
+	road_util.create_intersection_four_branch(container)
+	var inter: RoadIntersection = container.get_intersections()[0]
+	container.rebuild_segments(true)
+	assert_eq(_edge_curves(inter).size(), 4, "Four edges to begin with")
+
+	var pw: RoadPoint = container.get_node("pw")
+	inter.remove_branch(pw)
+	container.rebuild_segments(true)
+
+	# The orphaned edge is swept away and the survivors regenerate to their new
+	# clockwise neighbours, leaving one curve per remaining branch.
+	assert_eq(_edge_curves(inter).size(), 3, "Removed branch drops one edge curve")
+	assert_null(inter.get_node_or_null("edge_pw"), "The removed branch's edge curve is gone")
+
+
+func test_adding_a_branch_creates_an_edge():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.create_edge_curves = true
+	var inter := _make_intersection(container)
+	container.rebuild_segments(true)
+	assert_eq(_edge_curves(inter).size(), 2, "Two edges to begin with")
+
+	var p3 = autoqfree(RoadPoint.new())
+	p3.name = "p3"
+	container.add_child(p3)
+	p3.position = Vector3(10, 0, 0)
+	inter.add_branch(p3)
+
+	container.rebuild_segments(true)
+
+	assert_eq(_edge_curves(inter).size(), 3, "New branch adds an edge curve")
+	assert_not_null(inter.get_node_or_null("edge_p3"), "The new branch's edge curve exists")


### PR DESCRIPTION
This PR should fulfill the requirements of #387. Most of the implementation semantics were discussed in that issue and this PR is faithful to the thread's agreed semantics with one notable exception:

When a RoadPoint is renamed, its edge implicitly becomes `edge_{newname}`. Under the hood, this creates a new edge, and sweeps the old one. This also means any of the `edge_{oldname}`'s children are swept. This also happens on a remove/re-add (when removed, the edge is simply disposed, so upon re-add there's nothing left to persist).

TECHNICALLY this isn't anything new since RoadLanes are keyed and work the same way, but edges can have more custom work put into them so it's worth calling out for potential user frustration.
