### PR TITLE
Prevent mismatch between lanes and traffic dir

### DIFF
--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -445,7 +445,7 @@ func emit_transform(low_poly=false):
 	if _is_internal_updating:
 		# Special internal update should bypass emit_transform, such as moving two edges in parallel
 		return
-	if auto_lanes:
+	if auto_lanes or lanes.size() != traffic_dir.size():
 		assign_lanes()
 	var _gizmos:Array[Node3DGizmo] = get_gizmos()
 	if !_gizmos.is_empty():
@@ -647,10 +647,10 @@ func get_last_rp(direction: int):
 	return self
 
 
-# Goal is to assign the appropriate sequence of textures for this lane.
-#
-# This will intelligently construct the sequence of left-right textures, knowing
-# where to apply middle vs outter vs inner lanes.
+## Goal is to assign the appropriate sequence of textures for this lane.
+##
+## This will intelligently construct the sequence of left-right textures, knowing
+## where to apply middle vs outter vs inner lanes.
 func assign_lanes():
 	lanes.clear()
 	if len(traffic_dir) == 1:
@@ -761,14 +761,18 @@ func update_traffic_dir(traffic_update):
 	# Add/remove lanes. But, always make sure at least one remains.
 	match traffic_update:
 		TrafficUpdate.ADD_FORWARD:
+			lanes.append(LaneType.SLOW) # change this first to avoid reset on traffic_dir change
 			traffic_dir.append(LaneDir.FORWARD)
 		TrafficUpdate.ADD_REVERSE:
+			lanes.insert(0, LaneType.SLOW) # change this first to avoid reset on traffic_dir change
 			traffic_dir.push_front(LaneDir.REVERSE)
 		TrafficUpdate.REM_FORWARD:
 			if lane_count > 1 and fwd_lane_count > 0:
+				lanes.pop_back()
 				traffic_dir.pop_back()
 		TrafficUpdate.REM_REVERSE:
 			if lane_count > 1 and rev_lane_count > 0:
+				lanes.pop_front()
 				traffic_dir.pop_front()
 		TrafficUpdate.MOVE_DIVIDER_LEFT:
 			pass
@@ -784,8 +788,8 @@ func update_traffic_dir(traffic_update):
 func copy_settings_from(ref_road_point: RoadPoint, copy_transform: bool = true) -> void:
 	var tmp_auto_lane = ref_road_point.auto_lanes
 	auto_lanes = false
-	lanes = ref_road_point.lanes.duplicate(true)
 	traffic_dir = ref_road_point.traffic_dir.duplicate(true)
+	lanes = ref_road_point.lanes.duplicate(true)
 	auto_lanes = tmp_auto_lane
 	lane_width = ref_road_point.lane_width
 	shoulder_width_l = ref_road_point.shoulder_width_l

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -442,7 +442,7 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 			return Mesh.new() # Empty mesh.
 		
 		var lane_width: float = edge.lane_width
-		var lanes_count = edge.lanes.size()
+		var lanes_count = edge.traffic_dir.size() # use traffic_dir over lanes for consistency with segment generation
 		var lanes_tot_width: float = lane_width * lanes_count
 		var shoulder_offset_l: float = edge.shoulder_width_l
 		var shoulder_offset_r: float = edge.shoulder_width_r


### PR DESCRIPTION
This can happen if auto lanes is turned off, and then you later resize the number of lanes to be more or less. See #383 for more details, but the fact that intersections (till now) relied on a different convention than the road segments for source of truth of lane size could lead to a mismatch:

<img width="1636" height="994" alt="image" src="https://github.com/user-attachments/assets/67ff28bd-df73-4ea5-9957-053d44d69ed6" />

This is now fixed, and also improves the editor experience slightly so that when you add/remove lanes, it attempts to more or less keep the custom lane setup you already had (chopping off whichever side you just increased/reduced, or just adding an extra slow lane if expanding). But if this fails or data ever ends up in a bad state, it self corrects by assigning default lanes when there's a mismatch without resorting to turning auto lanes back on.

Works with both the 3D gizmo and RoadPoint editor panel (nevermind the weird state that happened while recording, where it was like shift was stuck on/linked to prior point). The key thing here is that the points did _not_ revert to using the double yellow center line despite the changes.

https://github.com/user-attachments/assets/4e96644f-259e-4e6b-9496-513b095abdd5

