### PR TITLE
Regenerate road geometry when a RoadContainer re-enters the tree

### DIFF
--- a/addons/road-generator/nodes/road_container.gd
+++ b/addons/road-generator/nodes/road_container.gd
@@ -265,7 +265,15 @@ func _ready():
 
 
 func _enter_tree() -> void:
-	pass
+	# On the first tree entry _ready() has not run yet (is_node_ready() is
+	# false), so let _ready() own the initial build. On any later re-entry
+	# (e.g. returning to a scene tab in the editor) _ready() will not fire
+	# again, so regenerate the runtime-only lanes/segments here. Without this
+	# the non-serialized RoadLanes stay hidden until a manual Refresh Roads.
+	if not Engine.is_editor_hint():
+		return
+	if is_node_ready():
+		rebuild_segments.call_deferred(true)
 
 
 ## Cleanup the road segments specifically, in case they aren't children.


### PR DESCRIPTION
Fixes #385.

Auto-generated RoadLanes and their fin geometry are runtime-only. They're rebuilt only from RoadContainer._ready() (or an explicit refresh), and _ready() fires once per node lifetime. On scene re-entry _ready() doesn't run again and _enter_tree() was a no-op, so nothing regenerated the lanes.

The fix:
RoadContainer._enter_tree() now kicks a deferred rebuild_segments(true) on re-entry. The very first entry (before _ready()) is skipped via is_node_ready(), so the initial build is still owned by _ready(). It's guarded to the editor since at runtime the nodes persist across tree removal/re-add anyway.

clear_existing = true also cleans up the segments orphaned when _exit_tree() wipes segid_map, so re-entry doesn't duplicate geometry.

Testing
Verified manually in the editor.

Fins visible → switch scene tabs away and back → they reappear on their own, no manual refresh.
Same for close-and-reopen.
No duplicated lanes after re-entry.
First open, Refresh Roads, and the draw-lane toggles all unchanged.


Not tested: a RoadContainer instanced as a nested sub-scene — flagging in case there are nesting/ownership semantics there that warrant a closer look.
