### PR TITLE
Warn on invalid RoadPoint lane setups instead of rendering no mesh

### DIFF
--- a/addons/road-generator/nodes/road_point.gd
+++ b/addons/road-generator/nodes/road_point.gd
@@ -56,6 +56,7 @@ enum Alignment {
 }
 
 const RoadSegment = preload("res://addons/road-generator/nodes/road_segment.gd")
+const SegGeo = preload("res://addons/road-generator/procgen/segment_geo.gd")
 const UI_TIMEOUT = 50 # Time in ms to delay further refresh updates.
 const COLOR_YELLOW = Color(0.7, 0.7, 0,7)
 const COLOR_RED = Color(0.7, 0.3, 0.3)
@@ -254,7 +255,32 @@ func _get_configuration_warnings() -> PackedStringArray:
 	#if not par is RoadContainer:
 	if not par.has_method("is_road_container"):
 		return ["Must be a child of a RoadContainer"]
-	return []
+
+	# Flag lane setups that match no lanes and so render no road mesh, so the
+	# user sees a warning instead of a silently missing segment.
+	var warnings: PackedStringArray = []
+	if traffic_dir.is_empty():
+		return warnings
+
+	var flip_data: Array = SegGeo._get_lane_flip_data(traffic_dir, true)
+	if flip_data[0] == -1:
+		# Malformed order: a FORWARD lane appears before a REVERSE one.
+		warnings.append("Invalid lane directions: list all REVERSE lanes before FORWARD lanes.")
+		return warnings
+
+	var this_dir: int = flip_data[1]
+	for neighbor in [get_prior_road_node(true), get_next_road_node(true)]:
+		if not is_instance_valid(neighbor) or not neighbor.has_method("is_road_point"):
+			continue
+		if neighbor.traffic_dir.is_empty():
+			continue
+		var other_flip: Array = SegGeo._get_lane_flip_data(neighbor.traffic_dir, true)
+		if other_flip[0] == -1:
+			continue # The neighbour carries its own malformed-order warning.
+		if not SegGeo.is_valid_lane_transition(this_dir, other_flip[1]):
+			warnings.append(("Lane setup does not match connected RoadPoint " +
+				"'%s': a one-way to two-way transition renders no road mesh.") % neighbor.name)
+	return warnings
 
 
 # Workaround for cyclic typing
@@ -453,6 +479,14 @@ func emit_transform(low_poly=false):
 		if is_instance_valid(_gizmo):
 			_gizmo.get_plugin().refresh_gizmo(_gizmo)
 	on_transform.emit(self, low_poly)
+
+	# Refresh lane-transition warnings on this point and its neighbours, since a
+	# lane change here can validate or invalidate the transition on either side.
+	if Engine.is_editor_hint():
+		update_configuration_warnings()
+		for neighbor in [get_prior_road_node(true), get_next_road_node(true)]:
+			if is_instance_valid(neighbor) and neighbor.has_method("is_road_point"):
+				neighbor.update_configuration_warnings()
 
 
 # ------------------------------------------------------------------------------

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -1473,7 +1473,6 @@ func _match_lanes() -> Array:
 	if start_flip_offset == -1 or end_flip_offset == -1:
 		return []
 
-	# Check for additional invalid lane configurations (one-way <-> two-way).
 	if not SegGeo.is_valid_lane_transition(start_traffic_dir, end_traffic_dir):
 		push_warning("Warning: Unable to match lanes on start_point %s (parent: %s)" % [start_point, start_point.get_parent()])
 		return []

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -1473,17 +1473,8 @@ func _match_lanes() -> Array:
 	if start_flip_offset == -1 or end_flip_offset == -1:
 		return []
 
-	# Check for additional invalid lane configurations
-	if (
-		(start_traffic_dir == RoadPoint.LaneDir.REVERSE
-			and end_traffic_dir == RoadPoint.LaneDir.BOTH)
-		or (start_traffic_dir == RoadPoint.LaneDir.FORWARD
-			and end_traffic_dir == RoadPoint.LaneDir.BOTH)
-		or (start_traffic_dir == RoadPoint.LaneDir.BOTH
-			and end_traffic_dir == RoadPoint.LaneDir.REVERSE)
-		or (start_traffic_dir == RoadPoint.LaneDir.BOTH
-			and end_traffic_dir == RoadPoint.LaneDir.FORWARD)
-	):
+	# Check for additional invalid lane configurations (one-way <-> two-way).
+	if not SegGeo.is_valid_lane_transition(start_traffic_dir, end_traffic_dir):
 		push_warning("Warning: Unable to match lanes on start_point %s (parent: %s)" % [start_point, start_point.get_parent()])
 		return []
 

--- a/addons/road-generator/procgen/segment_geo.gd
+++ b/addons/road-generator/procgen/segment_geo.gd
@@ -122,7 +122,9 @@ static func _flip_traffic_dir(lanes: Array[int]) -> Array:
 ## from REVERSE to FORWARD. Return -1 if no flip was found. Also, return the
 ## overall traffic direction of the RoadPoint.
 ## Returns: Array[int, RoadPoint.LaneDir]
-static func _get_lane_flip_data(traffic_dir: Array) -> Array:
+## quiet suppresses the malformed-config warning for callers that only validate
+## (e.g. RoadPoint configuration warnings), which run on every editor edit.
+static func _get_lane_flip_data(traffic_dir: Array, quiet: bool = false) -> Array:
 	# Get lane FORWARD flip offset. If a flip occurs more than once, give
 	# warning.
 	var flip_offset = 0
@@ -141,7 +143,8 @@ static func _get_lane_flip_data(traffic_dir: Array) -> Array:
 				traffic_dir[i] == RoadPoint.LaneDir.REVERSE
 				and flip_count > 0
 		):
-			push_warning("Warning: Unable to detect lane flip on road_point with traffic dirs %s" % traffic_dir)
+			if not quiet:
+				push_warning("Warning: Unable to detect lane flip on road_point with traffic dirs %s" % [traffic_dir])
 			return [-1, RoadPoint.LaneDir.NONE]
 		elif flip_count == 0 and i == len(traffic_dir) - 1:
 			# This must be a REVERSE-only road point
@@ -152,6 +155,17 @@ static func _get_lane_flip_data(traffic_dir: Array) -> Array:
 			flip_offset = len(traffic_dir) - 1
 			return [flip_offset, RoadPoint.LaneDir.FORWARD]
 	return [flip_offset, RoadPoint.LaneDir.BOTH]
+
+
+## Whether two connected road points can form a road. A one-way (FORWARD or
+## REVERSE) to two-way (BOTH) transition matches no lanes and so produces no
+## mesh. start_dir/end_dir are overall directions from _get_lane_flip_data.
+static func is_valid_lane_transition(start_dir: int, end_dir: int) -> bool:
+	if start_dir == RoadPoint.LaneDir.BOTH and end_dir != RoadPoint.LaneDir.BOTH:
+		return false
+	if end_dir == RoadPoint.LaneDir.BOTH and start_dir != RoadPoint.LaneDir.BOTH:
+		return false
+	return true
 
 
 #endregion

--- a/test/unit/test_match_lanes.gd
+++ b/test/unit/test_match_lanes.gd
@@ -353,3 +353,34 @@ func test_flipped_dirs(params=use_parameters(flipped_dir_setup)):
 	var target = params[3]
 	var result = seg._match_lanes()
 	assert_eq(result, target, "Flipped lanes %s" % params[4])
+
+
+## Invalid one-way <-> two-way transitions match no lanes. Both rows share the
+## first-lane direction so they pass the opposing-direction guard and exercise
+## is_valid_lane_transition specifically.
+var invalid_transition_setup = [
+	[
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
+		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
+		"BOTH > REVERSE",
+	],
+	[
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE],
+		[RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD],
+		[RoadPoint.LaneType.FAST, RoadPoint.LaneType.FAST],
+		"REVERSE > BOTH",
+	],
+]
+
+func test_invalid_lane_transition(params=use_parameters(invalid_transition_setup)):
+	var seg = autoqfree(RoadSegment.new(null))
+
+	seg.start_point = autoqfree(RoadPoint.new())
+	seg.end_point = autoqfree(RoadPoint.new())
+	seg.start_point.traffic_dir.assign(params[0])
+	seg.end_point.traffic_dir.assign(params[1])
+	seg.start_point.lanes.assign(params[2])
+
+	var result = seg._match_lanes()
+	assert_eq(result, [], "No lanes matched for %s" % params[3])

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -102,6 +102,44 @@ func test_error_no_traffic_dir():
 	pass_test('nothing tested, passing')
 
 
+## A one-way <-> two-way transition renders no mesh, so the connected RoadPoints
+## should surface a configuration warning instead of silently failing.
+func test_config_warning_invalid_lane_transition():
+	var container = add_child_autofree(RoadContainer.new())
+	container._auto_refresh = false
+	var points = create_unconnected_container(container)
+	var p1 = points[0]
+	var p2 = points[1]
+	p1.next_pt_init = p1.get_path_to(p2)
+	p2.prior_pt_init = p2.get_path_to(p1)
+
+	# Invalid: p1 two-way (BOTH), p2 one-way (REVERSE), sharing the first dir.
+	p1.traffic_dir.assign([RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD])
+	p2.traffic_dir.assign([RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.REVERSE])
+	assert_gt(p1._get_configuration_warnings().size(), 0, "p1 warns on invalid transition")
+	assert_gt(p2._get_configuration_warnings().size(), 0, "p2 warns on invalid transition")
+
+	# Valid: both two-way -> transition warning clears.
+	p2.traffic_dir.assign([RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD])
+	assert_eq(p1._get_configuration_warnings().size(), 0, "p1 clear when transition valid")
+	assert_eq(p2._get_configuration_warnings().size(), 0, "p2 clear when transition valid")
+
+
+## A malformed lane order (a FORWARD lane before a REVERSE one) renders no mesh,
+## so the RoadPoint should warn on its own without a neighbour.
+func test_config_warning_malformed_lane_order():
+	var container = add_child_autofree(RoadContainer.new())
+	container._auto_refresh = false
+	var pt = create_unconnected_container(container)[0]
+
+	pt.traffic_dir.assign([RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD])
+	assert_gt(pt._get_configuration_warnings().size(), 0, "Warns on malformed lane order")
+
+	# REVERSE-before-FORWARD order is valid and clears the warning.
+	pt.traffic_dir.assign([RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.FORWARD])
+	assert_eq(pt._get_configuration_warnings().size(), 0, "Clear on valid lane order")
+
+
 func test_autofix_noncyclic_added_next():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false


### PR DESCRIPTION
Addresses #232.

Some lane configurations can't be matched into a road and so `_build_geo()` commits an empty mesh. The road simply disappears with no indication of why. Two cases:

- **Malformed order** on a single RoadPoint (a FORWARD lane listed before a REVERSE one; the addon expects all REVERSE lanes before all FORWARD lanes).
- **One-way <-> two-way transition** between connected RoadPoints (a BOTH direction meeting a one-way FORWARD/REVERSE neighbour).

With this PR, RoadPoints now surface a `_get_configuration_warnings()` entry for both cases, so the editor shows the yellow warning triangle explaining the empty segment instead of failing silently. `emit_transform()` refreshes the warning on the point and its same-container neighbours (editor only) so it appears and clears live as lanes change.

The one-way/two-way guard in `RoadSegment._match_lanes()` was extracted into a shared `SegGeo.is_valid_lane_transition()` used by both the mesh path and the warning, so they can't drift apart.

Also fixes a pre-existing format-string bug in `SegGeo._get_lane_flip_data()` (`"%s" % array` errored on the malformed-config path) and adds a `quiet` flag so the per-edit validation path doesn't spam the console with `push_warning`.

This surfaces the warning only. Rendering a best-effort/degraded mesh for an invalid config (rather than an empty one) is intentionally left out per the earlier scoping.


**Testing**

- Unit: added cases to `test_match_lanes` (invalid transition returns no lanes) and `test_road_point` (warning present on malformed order / invalid transition, clears when fixed). Full suite green.
- Manual (editor): set a RoadPoint in the existing `intersection_demo.tscn` to `[Forward, Reverse, Forward]` -> warning appears, no console errors; fix the order -> warning clears. Same for a two-way point connected to a one-way neighbour.
