### PR TITLE
Add underside geometry support for RoadIntersections

### DIFF
--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -56,12 +56,6 @@ signal on_transform(node: Node3D, low_poly: bool) # TODO in abstract?
 ## To work, the RoadContainer must also have flatten_terrain enabled.
 @export var flatten_terrain: bool = true
 
-## Defines the thickness in meters of the underside part of the intersection.[br][br]
-##
-## A value of -1 indicates the thickness of the RoadContainer will be used, or the
-## underside will not be generated at all.
-@export var underside_thickness: float = -1.0: set = _set_thickness
-
 @export_group("Internal")
 
 @export var edge_points: Array[RoadPoint] = []: get = _get_edge_points, set = _set_edge_points
@@ -96,13 +90,6 @@ func _get_settings() -> IntersectionSettings:
 func _set_settings(value: IntersectionSettings) -> void:
 	settings = value
 	# TODO emit transform?
-
-
-func _set_thickness(value: float) -> void:
-	underside_thickness = value
-	if not is_instance_valid(container):
-		return  # Might not be initialized yet.
-	emit_transform()
 
 
 # ------------------------------------------------------------------------------
@@ -263,18 +250,6 @@ func update_lane_visibility() -> void:
 		if child is RoadLane:
 			child.draw_in_editor = container.draw_lanes_editor
 			child.draw_in_game = container.draw_lanes_game
-
-
-## Effective underside thickness, falling back to the container then the manager.
-func get_thickness() -> float:
-	if underside_thickness != -1.0:
-		return underside_thickness
-	if is_instance_valid(container) and container.underside_thickness != -1.0:
-		return container.underside_thickness
-	if is_instance_valid(container) and is_instance_valid(container.get_manager()) \
-			and container.get_manager().underside_thickness != -1.0:
-		return container.get_manager().underside_thickness
-	return -1.0
 
 
 ## Check if mesh needs to be rebuilt.[br][br]

--- a/addons/road-generator/nodes/road_intersection.gd
+++ b/addons/road-generator/nodes/road_intersection.gd
@@ -56,6 +56,12 @@ signal on_transform(node: Node3D, low_poly: bool) # TODO in abstract?
 ## To work, the RoadContainer must also have flatten_terrain enabled.
 @export var flatten_terrain: bool = true
 
+## Defines the thickness in meters of the underside part of the intersection.[br][br]
+##
+## A value of -1 indicates the thickness of the RoadContainer will be used, or the
+## underside will not be generated at all.
+@export var underside_thickness: float = -1.0: set = _set_thickness
+
 @export_group("Internal")
 
 @export var edge_points: Array[RoadPoint] = []: get = _get_edge_points, set = _set_edge_points
@@ -90,6 +96,13 @@ func _get_settings() -> IntersectionSettings:
 func _set_settings(value: IntersectionSettings) -> void:
 	settings = value
 	# TODO emit transform?
+
+
+func _set_thickness(value: float) -> void:
+	underside_thickness = value
+	if not is_instance_valid(container):
+		return  # Might not be initialized yet.
+	emit_transform()
 
 
 # ------------------------------------------------------------------------------
@@ -250,6 +263,18 @@ func update_lane_visibility() -> void:
 		if child is RoadLane:
 			child.draw_in_editor = container.draw_lanes_editor
 			child.draw_in_game = container.draw_lanes_game
+
+
+## Effective underside thickness, falling back to the container then the manager.
+func get_thickness() -> float:
+	if underside_thickness != -1.0:
+		return underside_thickness
+	if is_instance_valid(container) and container.underside_thickness != -1.0:
+		return container.underside_thickness
+	if is_instance_valid(container) and is_instance_valid(container.get_manager()) \
+			and container.get_manager().underside_thickness != -1.0:
+		return container.get_manager().underside_thickness
+	return -1.0
 
 
 ## Check if mesh needs to be rebuilt.[br][br]

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -570,6 +570,11 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 	var edge_gutters: Array[Array] = []
 	## Array[Array[Vector3][2]]
 	var edge_road_sides: Array[Array] = []
+	## RoadPoint-side counterparts of the stop-line arrays, for the underside.
+	var edge_shoulders_rp: Array[Array] = []
+	var edge_gutters_rp: Array[Array] = []
+	## Per-edge up vector, to drop the underside by thickness.
+	var edge_ups: Array[Vector3] = []
 	
 	const uv_width := 0.125 # 1/8 for breakdown of texture.
 	const uv_gutter_width := uv_width * SegGeo.UV_MID_SHOULDER
@@ -626,14 +631,19 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 		var road_side_l_stop: Vector3 = road_side_l + parallel_v * stopsize
 		var road_side_r_stop: Vector3 = road_side_r + parallel_v * stopsize
 
-		if facing == _IntersectNGonFacing.ORIGIN:	
+		if facing == _IntersectNGonFacing.ORIGIN:
 			edge_shoulders.append([shoulder_l_stop, shoulder_r_stop])
 			edge_gutters.append([gutter_l_stop, gutter_r_stop])
 			edge_road_sides.append([road_side_l_stop, road_side_r_stop])
+			edge_shoulders_rp.append([shoulder_l, shoulder_r])
+			edge_gutters_rp.append([gutter_l, gutter_r])
 		else: # facing == _IntersectNGonFacing.AWAY
 			edge_shoulders.append([shoulder_r_stop, shoulder_l_stop])
 			edge_gutters.append([gutter_r_stop, gutter_l_stop])
 			edge_road_sides.append([road_side_r_stop, road_side_l_stop])
+			edge_shoulders_rp.append([shoulder_r, shoulder_l])
+			edge_gutters_rp.append([gutter_r, gutter_l])
+		edge_ups.append(up_vector)
 
 		# swap sides if needed
 		if facing == _IntersectNGonFacing.ORIGIN:
@@ -840,7 +850,103 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 	surface_tool.generate_normals()
 	var mesh: ArrayMesh = surface_tool.commit()  # should be MeshInstance3D?
 	#mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+
+	var thickness: float = intersection.get_thickness()
+	if thickness >= 0.0 and edges.size() >= 2:
+		surface_tool.begin(Mesh.PRIMITIVE_TRIANGLES)
+		# Min thickness prevents Z-fighting, matching segment undersides
+		_insert_underside_geo(surface_tool, maxf(thickness, 0.001), parent_transform,
+				edge_shoulders_rp, edge_shoulders, edge_gutters_rp, edge_gutters, edge_ups)
+		surface_tool.index()
+		var underside_material: Material = container.effective_underside_material()
+		if underside_material:
+			surface_tool.set_material(underside_material)
+		surface_tool.generate_normals()
+		surface_tool.commit(mesh)
 	return mesh
+
+
+## Generates the underside as a second surface: a triangle fan over the exterior
+## shoulder perimeter dropped by thickness, plus rim quads rising back up to the
+## top surface's gutter lip. Deliberately less detailed than the top side.
+## The crossings at each RoadPoint line stay open so the underside profile mates
+## with the adjoining [RoadSegment] underside (flat bottom spanning the
+## shoulders, then a slope out to the gutter lip).
+## Point arrays follow the facing-normalised [s0, s1] ordering of the top-side
+## arrays; edges MUST have been sorted beforehand.
+func _insert_underside_geo(
+		st: SurfaceTool,
+		thickness: float,
+		parent_transform: Transform3D,
+		shoulders_rp: Array[Array],
+		shoulders_stop: Array[Array],
+		gutters_rp: Array[Array],
+		gutters_stop: Array[Array],
+		ups: Array[Vector3]) -> void:
+	const UNDERSIDE_RIM_SMOOTHING_GROUP = 1
+	# Match segment undersides: one UV tile spans four default-width lanes.
+	var uv_scale := 1.0 / (4.0 * RoadPoint.DEFAULT_LANE_WIDTH)
+	var origin := parent_transform.origin
+
+	# Perimeter walk per branch: from the s1 stop corner out to the RoadPoint,
+	# across the RP line, back in along s0 to its stop corner, then over to the
+	# next branch. Bottom points are shoulder corners dropped by thickness; rim
+	# tops are the matching gutter corners on the top surface.
+	var bottom: Array[Vector3] = []
+	var rim_top: Array[Vector3] = []
+	var has_rim: Array[bool] = []
+	for i in range(shoulders_rp.size()):
+		var drop: Vector3 = -ups[i] * thickness
+		bottom.append(shoulders_stop[i][1] + drop - origin)
+		bottom.append(shoulders_rp[i][1] + drop - origin)
+		bottom.append(shoulders_rp[i][0] + drop - origin)
+		bottom.append(shoulders_stop[i][0] + drop - origin)
+		rim_top.append(gutters_stop[i][1] - origin)
+		rim_top.append(gutters_rp[i][1] - origin)
+		rim_top.append(gutters_rp[i][0] - origin)
+		rim_top.append(gutters_stop[i][0] - origin)
+		has_rim.append(true)   # s1 lateral side
+		has_rim.append(false)  # RP line, left open to mate with the segment
+		has_rim.append(true)   # s0 lateral side
+		has_rim.append(true)   # connection toward the next branch
+
+	# Bottom fan from the dropped center, wound to face down.
+	var center: Vector3 = -parent_transform.basis.y.normalized() * thickness
+	var count := bottom.size()
+	for k in range(count):
+		var pt_a: Vector3 = bottom[k]
+		var pt_b: Vector3 = bottom[(k + 1) % count]
+		st.set_smooth_group(0)
+		st.set_uv(Vector2(center.x, center.z) * uv_scale)
+		st.add_vertex(center)
+		st.set_uv(Vector2(pt_b.x, pt_b.z) * uv_scale)
+		st.add_vertex(pt_b)
+		st.set_uv(Vector2(pt_a.x, pt_a.z) * uv_scale)
+		st.add_vertex(pt_a)
+
+	# Rim quads from the bottom perimeter up to the gutter lip, U continuing
+	# along the perimeter, V spanning the slant height.
+	var run := 0.0
+	for k in range(count):
+		var k_next := (k + 1) % count
+		var g1: Vector3 = rim_top[k]
+		var g2: Vector3 = rim_top[k_next]
+		var width := (g2 - g1).length()
+		if not has_rim[k]:
+			run += width
+			continue
+		var b1: Vector3 = bottom[k]
+		var b2: Vector3 = bottom[k_next]
+		SegGeo.quad(st,
+			[
+				Vector2((run + width) * uv_scale, 0.0),
+				Vector2(run * uv_scale, 0.0),
+				Vector2(run * uv_scale, (g1 - b1).length() * uv_scale),
+				Vector2((run + width) * uv_scale, (g2 - b2).length() * uv_scale),
+			],
+			[g2, g1, b1, b2],
+			UNDERSIDE_RIM_SMOOTHING_GROUP)
+		run += width
 
 
 #endregion

--- a/addons/road-generator/procgen/intersection_ngon.gd
+++ b/addons/road-generator/procgen/intersection_ngon.gd
@@ -575,6 +575,8 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 	var edge_gutters_rp: Array[Array] = []
 	## Per-edge up vector, to drop the underside by thickness.
 	var edge_ups: Array[Vector3] = []
+	## Per-edge underside thickness resolved from each RoadPoint.
+	var edge_thicknesses: Array[float] = []
 	
 	const uv_width := 0.125 # 1/8 for breakdown of texture.
 	const uv_gutter_width := uv_width * SegGeo.UV_MID_SHOULDER
@@ -644,6 +646,7 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 			edge_shoulders_rp.append([shoulder_r, shoulder_l])
 			edge_gutters_rp.append([gutter_r, gutter_l])
 		edge_ups.append(up_vector)
+		edge_thicknesses.append(edge.get_thickness())
 
 		# swap sides if needed
 		if facing == _IntersectNGonFacing.ORIGIN:
@@ -851,11 +854,11 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 	var mesh: ArrayMesh = surface_tool.commit()  # should be MeshInstance3D?
 	#mesh.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
-	var thickness: float = intersection.get_thickness()
-	if thickness >= 0.0 and edges.size() >= 2:
+	# Underside only when every edge resolves a thickness, so e.g. a raised ramp
+	# leading into a ground-level intersection does not force underside geo.
+	if edges.size() >= 2 and edge_thicknesses.min() >= 0.0:
 		surface_tool.begin(Mesh.PRIMITIVE_TRIANGLES)
-		# Min thickness prevents Z-fighting, matching segment undersides
-		_insert_underside_geo(surface_tool, maxf(thickness, 0.001), parent_transform,
+		_insert_underside_geo(surface_tool, edge_thicknesses, parent_transform,
 				edge_shoulders_rp, edge_shoulders, edge_gutters_rp, edge_gutters, edge_ups)
 		surface_tool.index()
 		var underside_material: Material = container.effective_underside_material()
@@ -866,9 +869,13 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 	return mesh
 
 
-## Generates the underside as a second surface: a triangle fan over the exterior
-## shoulder perimeter dropped by thickness, plus rim quads rising back up to the
-## top surface's gutter lip. Deliberately less detailed than the top side.
+## Generates the underside as a second surface: a triangle fan over the
+## stop-line perimeter, one quad per branch out to its RoadPoint line, and rim
+## quads rising back up to the top surface's gutter lip. Deliberately less
+## detailed than the top side, but folding at the same stop line so top and
+## underside shear at the same point.
+## Thickness comes from each edge RoadPoint (caller ensures all are >= 0),
+## interpolating across connections, with the center at the average depth.
 ## The crossings at each RoadPoint line stay open so the underside profile mates
 ## with the adjoining [RoadSegment] underside (flat bottom spanning the
 ## shoulders, then a slope out to the gutter lip).
@@ -876,7 +883,7 @@ func _generate_debug_mesh(intersection: Node3D, edges: Array[RoadPoint], contain
 ## arrays; edges MUST have been sorted beforehand.
 func _insert_underside_geo(
 		st: SurfaceTool,
-		thickness: float,
+		thicknesses: Array[float],
 		parent_transform: Transform3D,
 		shoulders_rp: Array[Array],
 		shoulders_stop: Array[Array],
@@ -884,18 +891,22 @@ func _insert_underside_geo(
 		gutters_stop: Array[Array],
 		ups: Array[Vector3]) -> void:
 	const UNDERSIDE_RIM_SMOOTHING_GROUP = 1
+	const MIN_THICKNESS = 0.001 # Prevents Z-fighting, matching segment undersides
 	# Match segment undersides: one UV tile spans four default-width lanes.
 	var uv_scale := 1.0 / (4.0 * RoadPoint.DEFAULT_LANE_WIDTH)
 	var origin := parent_transform.origin
 
 	# Perimeter walk per branch: from the s1 stop corner out to the RoadPoint,
 	# across the RP line, back in along s0 to its stop corner, then over to the
-	# next branch. Bottom points are shoulder corners dropped by thickness; rim
-	# tops are the matching gutter corners on the top surface.
+	# next branch. Bottom points are shoulder corners dropped by the edge's own
+	# thickness; rim tops are the matching gutter corners on the top surface.
 	var bottom: Array[Vector3] = []
 	var rim_top: Array[Vector3] = []
 	var has_rim: Array[bool] = []
+	var avg_thickness := 0.0
 	for i in range(shoulders_rp.size()):
+		var thickness: float = maxf(thicknesses[i], MIN_THICKNESS)
+		avg_thickness += thickness / shoulders_rp.size()
 		var drop: Vector3 = -ups[i] * thickness
 		bottom.append(shoulders_stop[i][1] + drop - origin)
 		bottom.append(shoulders_rp[i][1] + drop - origin)
@@ -910,19 +921,31 @@ func _insert_underside_geo(
 		has_rim.append(true)   # s0 lateral side
 		has_rim.append(true)   # connection toward the next branch
 
-	# Bottom fan from the dropped center, wound to face down.
-	var center: Vector3 = -parent_transform.basis.y.normalized() * thickness
+	# Bottom fan from the dropped center over the stop-line corners only, so the
+	# underside folds at the stop line like the top surface. Wound to face down.
+	var center: Vector3 = -parent_transform.basis.y.normalized() * avg_thickness
 	var count := bottom.size()
-	for k in range(count):
-		var pt_a: Vector3 = bottom[k]
-		var pt_b: Vector3 = bottom[(k + 1) % count]
-		st.set_smooth_group(0)
-		st.set_uv(Vector2(center.x, center.z) * uv_scale)
-		st.add_vertex(center)
-		st.set_uv(Vector2(pt_b.x, pt_b.z) * uv_scale)
-		st.add_vertex(pt_b)
-		st.set_uv(Vector2(pt_a.x, pt_a.z) * uv_scale)
-		st.add_vertex(pt_a)
+	st.set_smooth_group(0)
+	for k in range(0, count, 4):
+		var s1_stop: Vector3 = bottom[k]
+		var s0_stop: Vector3 = bottom[k + 3]
+		var next_s1_stop: Vector3 = bottom[(k + 4) % count]
+		# Wedge across this branch's stop line, then to the next branch.
+		for tri in [[s0_stop, s1_stop], [next_s1_stop, s0_stop]]:
+			st.set_uv(Vector2(center.x, center.z) * uv_scale)
+			st.add_vertex(center)
+			st.set_uv(Vector2(tri[0].x, tri[0].z) * uv_scale)
+			st.add_vertex(tri[0])
+			st.set_uv(Vector2(tri[1].x, tri[1].z) * uv_scale)
+			st.add_vertex(tri[1])
+
+	# One quad per branch from its stop line out to the RoadPoint line.
+	for k in range(0, count, 4):
+		var pts: Array = [bottom[k + 3], bottom[k + 2], bottom[k + 1], bottom[k]]
+		var uvs: Array = []
+		for pt in pts:
+			uvs.append(Vector2(pt.x, pt.z) * uv_scale)
+		SegGeo.quad(st, uvs, pts)
 
 	# Rim quads from the bottom perimeter up to the gutter lip, U continuing
 	# along the perimeter, V spanning the slant height.

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -101,7 +101,9 @@ func create_intersection_four_branch(container):
 
 ## Creates a three-branch T: pw and pe form a straight bar across the
 ## intersection, and ps is the stem with no edge opposite it.
-func create_intersection_three_branch(container):
+## dist spaces the branches from the center; the default keeps branch
+## footprints overlapping (historic), pass ~30 for non-overlapping geometry.
+func create_intersection_three_branch(container, dist: float = 10.0):
 	container.setup_road_container()
 
 	assert_eq(container.get_child_count(), 0, "No initial point children")
@@ -119,9 +121,9 @@ func create_intersection_three_branch(container):
 	container.add_child(pe)
 	container.add_child(ps)
 
-	pw.position = Vector3(-10, 0, 0)
-	pe.position = Vector3(10, 0, 0)
-	ps.position = Vector3(0, 0, 10)
+	pw.position = Vector3(-dist, 0, 0)
+	pe.position = Vector3(dist, 0, 0)
+	ps.position = Vector3(0, 0, dist)
 	# Rotate each edge so its forward axis points at the center.
 	pw.rotation_degrees.y = 90
 	pe.rotation_degrees.y = -90

--- a/test/unit/test_road_intersection.gd
+++ b/test/unit/test_road_intersection.gd
@@ -156,7 +156,8 @@ func test_intersection_underside_generation():
 	container.rebuild_segments(true)
 	assert_eq(inter._mesh.mesh.get_surface_count(), 1, "No underside surface by default")
 
-	inter.underside_thickness = 0.5
+	for rp in container.get_roadpoints():
+		rp.underside_thickness = 0.5
 	container.rebuild_segments(true)
 	assert_eq(inter._mesh.mesh.get_surface_count(), 2, "Underside adds a second surface")
 
@@ -186,8 +187,20 @@ func test_intersection_underside_container_fallback():
 
 	container.underside_thickness = 0.5
 	container.rebuild_segments(true)
-	assert_eq(inter.get_thickness(), 0.5, "Intersection inherits container thickness")
 	assert_eq(inter._mesh.mesh.get_surface_count(), 2, "Underside generated via container thickness")
+
+
+func test_intersection_underside_skipped_on_mixed_thickness():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	road_util.create_intersection_three_branch(container, 30.0)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	# Only one edge resolves a thickness: skip the whole underside.
+	container.get_roadpoints()[0].underside_thickness = 0.5
+	container.rebuild_segments(true)
+	assert_eq(inter._mesh.mesh.get_surface_count(), 1, "Underside skipped when an edge lacks thickness")
 
 
 func test_intersection_remove_branch():

--- a/test/unit/test_road_intersection.gd
+++ b/test/unit/test_road_intersection.gd
@@ -145,6 +145,51 @@ func test_intersection_add_branch():
 	_validate_edges(container, 3)
 
 
+func test_intersection_underside_generation():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	# Spaced out so branch footprints do not overlap
+	road_util.create_intersection_three_branch(container, 30.0)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.rebuild_segments(true)
+	assert_eq(inter._mesh.mesh.get_surface_count(), 1, "No underside surface by default")
+
+	inter.underside_thickness = 0.5
+	container.rebuild_segments(true)
+	assert_eq(inter._mesh.mesh.get_surface_count(), 2, "Underside adds a second surface")
+
+	# All underside faces should aim downward or sideways, never up.
+	var arrays: Array = inter._mesh.mesh.surface_get_arrays(1)
+	var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
+	assert_gt(normals.size(), 0, "Underside surface has normals")
+	var max_y := -1.0
+	for normal in normals:
+		max_y = maxf(max_y, normal.y)
+	assert_lt(max_y, 0.1, "No underside normal points upward")
+
+	# The bottom fan should sit at underside_thickness below the road plane.
+	var verts: PackedVector3Array = arrays[Mesh.ARRAY_VERTEX]
+	var min_y := 0.0
+	for vert in verts:
+		min_y = minf(min_y, vert.y)
+	assert_almost_eq(min_y, -0.5, 0.001, "Underside dropped by thickness")
+
+
+func test_intersection_underside_container_fallback():
+	var container = autoqfree(RoadContainer.new())
+	add_child(container)
+	container.setup_road_container()
+	road_util.create_intersection_three_branch(container, 30.0)
+	var inter: RoadIntersection = container.get_intersections()[0]
+
+	container.underside_thickness = 0.5
+	container.rebuild_segments(true)
+	assert_eq(inter.get_thickness(), 0.5, "Intersection inherits container thickness")
+	assert_eq(inter._mesh.mesh.get_surface_count(), 2, "Underside generated via container thickness")
+
+
 func test_intersection_remove_branch():
 	var container:RoadContainer = autoqfree(RoadContainer.new())
 	add_child(container)


### PR DESCRIPTION
Resolves #330

Adds underside geometry to procedural RoadIntersections, mirroring the existing RoadPoint/segment feature: a new `underside_thickness` export on RoadIntersection (-1 = off) that falls back to the container then manager value, with the underside emitted as a second mesh surface using the effective underside material.

The geometry follows the "simpler triangle fans on the bottom" idea from the issue: a bottom fan over the shoulder perimeter dropped by the thickness, plus rim quads rising to the top surface's gutter lip. The crossings at each RoadPoint line are left open so the profile mates flush with the adjoining segment underside. Collisions pick up the new surface automatically.

Tests cover the surface count toggling with thickness, underside normals never pointing upward, and the bottom sitting at exactly -thickness (78/78 passing). Manually verified in the editor on road_museum's ProcIntersection, including mating with segment undersides and toggling back to -1.

One note: when branches sit close enough that their footprints overlap, the underside perimeter self-intersects and some triangles flip. The existing top mesh degenerates the same way in that case (hidden since the overlapping quads are coplanar), so this is a pre-existing limitation.
