### PR TITLE
Add road lane visibility performance test option

### DIFF
--- a/road_demos/performance_stress_test/performance_stress_test.gd
+++ b/road_demos/performance_stress_test/performance_stress_test.gd
@@ -4,6 +4,7 @@ extends Node3D
 @onready var manager:RoadManager = $RoadManager
 @onready var edges_btn := %edges
 @onready var lanes_btn := %lanes
+@onready var lane_visual_btn := %lane_visual
 @onready var geo_btn := %geo
 @onready var underside_btn := %underside
 @onready var update_btn := %update
@@ -24,6 +25,8 @@ func update_settings() -> void:
 	for _node in containers:
 		var rc := _node as RoadContainer
 		rc.generate_ai_lanes = lanes_btn.button_pressed
+		rc.draw_lanes_editor = lane_visual_btn.button_pressed
+		rc.draw_lanes_game = lane_visual_btn.button_pressed
 		rc.create_edge_curves = edges_btn.button_pressed
 		rc.create_geo = geo_btn.button_pressed
 		rc.underside_thickness = 2 if underside_btn.button_pressed else -1
@@ -55,8 +58,9 @@ func run_rebuild() -> void:
 	for _sample in samples:
 		total_sample_time += _sample
 	
-	var settings_txt := "%s, %s, %s, %s" % [
+	var settings_txt := "%s (%s), %s, %s, %s" % [
 		"AI lanes" if lanes_btn.button_pressed else "no AI lanes",
+		"visible" if lane_visual_btn.button_pressed else "not visible",
 		"edge curves" if edges_btn.button_pressed else "no edge curves",
 		"geo" if geo_btn.button_pressed else "no geo",
 		"underside" if underside_btn.button_pressed else "no underside",

--- a/road_demos/performance_stress_test/performance_stress_test.tscn
+++ b/road_demos/performance_stress_test/performance_stress_test.tscn
@@ -150,6 +150,12 @@ layout_mode = 2
 toggle_mode = true
 text = "AI Lanes"
 
+[node name="lane_visual" type="Button" parent="UI/MarginContainer/VBoxContainer/options"]
+unique_name_in_owner = true
+layout_mode = 2
+toggle_mode = true
+text = "Visual lanes"
+
 [node name="spacer2" type="Control" parent="UI/MarginContainer/VBoxContainer"]
 layout_mode = 2
 


### PR DESCRIPTION
This adds a small additional option to the performance test scene for drawing RoadLane fins, which was used to help validate/prove that https://github.com/TheDuckCow/godot-road-generator/pull/404 was not going to cause overhead.

New options: Visual lanes

<img width="951" height="534" alt="Screenshot 2026-08-16 at 4 15 30 PM" src="https://github.com/user-attachments/assets/d23af3d9-7c6b-4f7f-a76b-221fd8db3582" />


(To get the benefit, both AI Lanes and Visual lanes have to be enabled)