### PR TITLE
Fix missing roadlanes with prior-prior connections

### DIFF
--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -382,10 +382,12 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 		suffix = ""  # default case, no need to differentiate
 	elif _par == start_point:
 		suffix = "_prior"
-	elif _par == end_point and  start_point.get_prior_road_node(true) == start_point:
+	elif _par == end_point and start_point.get_prior_road_node(true) == start_point:
 		suffix = "_next"  # Doesn't occur in practice
+		push_warning("Lane parent unexpected to be end point for segment %s" % get_id())
 	else:
 		suffix = "_other"  # Shouldn't occur in practice
+		push_warning("Lane parent unexpected for segment %s" % get_id())
 
 	var _tmppar = _par.get_children()
 	for this_match in _matched_lanes:

--- a/addons/road-generator/nodes/road_segment.gd
+++ b/addons/road-generator/nodes/road_segment.gd
@@ -376,11 +376,21 @@ func generate_lane_segments(_debug: bool = false) -> bool:
 	# additions and substractions to calculate which lanes are going to get merged.
 	# Only expecting additions or substractions, not both at the same time (for each direction separately)
 	var lane_shift := {"reverse": 0, "forward": 0}
+	
+	var suffix := ""
+	if _par == start_point and start_point.get_next_road_node(true) == end_point:
+		suffix = ""  # default case, no need to differentiate
+	elif _par == start_point:
+		suffix = "_prior"
+	elif _par == end_point and  start_point.get_prior_road_node(true) == start_point:
+		suffix = "_next"  # Doesn't occur in practice
+	else:
+		suffix = "_other"  # Shouldn't occur in practice
 
 	var _tmppar = _par.get_children()
 	for this_match in _matched_lanes:
 		# Reusable name to check for and re-use, based on "tagged names".
-		var ln_name = "p%s_n%s" % [this_match[2], this_match[3]]
+		var ln_name = "p%s_n%s%s" % [this_match[2], this_match[3], suffix]
 
 		var ln_type: int = this_match[0] # Enum RoadPoint.LaneType
 		var ln_dir: int = this_match[1] # Enum RoadPoint.LaneDir

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -35,6 +35,7 @@ func create_rp_line(container:RoadContainer, count:int, connect:bool, set_positi
 	assert_eq(container.get_child_count(), 0, "No initial point children")
 	for idx in range(count):
 		var rp:RoadPoint = autoqfree(RoadPoint.new())
+		rp.name = "RP%s" % [str(idx+1).pad_zeros(3)]
 		container.add_child(rp)
 		rps.append(rp)
 		if set_position:

--- a/test/unit/road_utils.gd
+++ b/test/unit/road_utils.gd
@@ -1,23 +1,71 @@
 extends "res://addons/gut/test.gd"
 
-## Utility to create a single segment container (2 points)
-func create_oneseg_container(container):
+
+func _set_owner(node: Node, new_owner: Node) -> void:
+	if node != new_owner:
+		node.owner = new_owner
+	for child in node.get_children():
+		_set_owner(child, new_owner)
+
+
+## For debugging purposes, save a given test scene to a file to inspect
+##
+## If filename is not provided, will use the function name of the parent caller
+func save_testscene_to_file(parent: Node, filename: String = "") -> Error:
+	# Must mark all children with intended owner
+	_set_owner(parent, parent)
+
+	# Save out scene as-is to file
+	var current_dir_path = self.get_script().resource_path.get_base_dir()
+	var scene := PackedScene.new()
+	scene.pack(parent)
+	if filename == "":
+		filename = get_stack()[1]["function"] # could also prefix with "source" base name potentially
+	var res := ResourceSaver.save(scene, "%s/%s.tscn" % [current_dir_path, filename])
+	return res
+
+
+## Utility to create several RoadPoints in a row
+func create_rp_line(container:RoadContainer, count:int, connect:bool, set_position:bool) -> Array[RoadPoint]:
+	var rps: Array[RoadPoint] = []
+	if count < 1:
+		fail_test("Cannot create RP line, fewer than 1 RPs")
+		return rps
 	container.setup_road_container()
-	
 	assert_eq(container.get_child_count(), 0, "No initial point children")
+	for idx in range(count):
+		var rp:RoadPoint = autoqfree(RoadPoint.new())
+		container.add_child(rp)
+		rps.append(rp)
+		if set_position:
+			rp.global_position = Vector3(0, 0, 10) * idx
+	
+	assert_eq(container.get_child_count(), count, "All RPs added")
+	if not connect:
+		return rps
+	
+	for idx in range(count - 1):
+		var rpa:RoadPoint = rps[idx]
+		var rpb:RoadPoint = rps[idx + 1]
+		#rpa.connect_roadpoint(RoadPoint.PointInit.NEXT, rpb, RoadPoint.PointInit.PRIOR)
+		# Alt, lower level:
+		rpa.next_pt_init = rpa.get_path_to(rpb)
+		rpb.prior_pt_init = rpb.get_path_to(rpa)
+	
+	return rps
 
-	var p1 = autoqfree(RoadPoint.new())
-	var p2 = autoqfree(RoadPoint.new())
 
-	container.add_child(p1)
-	container.add_child(p2)
-	assert_eq(container.get_child_count(), 2, "Both RPs added")
-
-	p1.next_pt_init = p1.get_path_to(p2)
-	p2.prior_pt_init = p2.get_path_to(p1)
+## Utility to create a single segment container (2 points)
+func create_unconnected_container(container) -> Array[RoadPoint]:
+	return create_rp_line(container, 2, false, true)
 
 
-func create_two_containers(container_a, container_b):
+## Utility to create a single segment container (2 points)
+func create_oneseg_container(container:RoadContainer) -> void:
+	create_rp_line(container, 2, true, false)
+
+
+func create_two_containers(container_a:RoadContainer, container_b:RoadContainer) -> void:
 	create_oneseg_container(container_a)
 	create_oneseg_container(container_b)
 
@@ -27,7 +75,7 @@ func create_two_containers(container_a, container_b):
 	#container_b.update_edges() # should be auto-called
 
 
-func create_intersection_two_branch(container):
+func create_intersection_two_branch(container:RoadContainer) -> void:
 	container.setup_road_container()
 
 	assert_eq(container.get_child_count(), 0, "No initial point children")
@@ -58,7 +106,7 @@ func create_intersection_two_branch(container):
 
 ## Creates a four-branch intersection with each edge facing the center, so all
 ## edges feed forward lanes into the intersection.
-func create_intersection_four_branch(container):
+func create_intersection_four_branch(container: RoadContainer) -> void:
 	container.setup_road_container()
 
 	assert_eq(container.get_child_count(), 0, "No initial point children")
@@ -103,7 +151,7 @@ func create_intersection_four_branch(container):
 ## intersection, and ps is the stem with no edge opposite it.
 ## dist spaces the branches from the center; the default keeps branch
 ## footprints overlapping (historic), pass ~30 for non-overlapping geometry.
-func create_intersection_three_branch(container, dist: float = 10.0):
+func create_intersection_three_branch(container:RoadContainer, dist: float = 10.0) -> void:
 	container.setup_road_container()
 
 	assert_eq(container.get_child_count(), 0, "No initial point children")
@@ -143,7 +191,7 @@ func create_intersection_three_branch(container, dist: float = 10.0):
 ## position-only one. The source ps aims south; pb sits nearly dead-opposite but
 ## faces sideways, while pg sits off to the side yet faces ps head-on. A position
 ## metric prefers pb; an orientation-aware one prefers pg.
-func create_intersection_facing_split(container):
+func create_intersection_facing_split(container:RoadContainer) -> void:
 	container.setup_road_container()
 
 	assert_eq(container.get_child_count(), 0, "No initial point children")

--- a/test/unit/test_intersection_edge_curves.gd.uid
+++ b/test/unit/test_intersection_edge_curves.gd.uid
@@ -1,0 +1,1 @@
+uid://cwk2v8pnlf25w

--- a/test/unit/test_road_point.gd
+++ b/test/unit/test_road_point.gd
@@ -1,34 +1,13 @@
 extends "res://addons/gut/test.gd"
 
+const RoadUtils = preload("res://test/unit/road_utils.gd")
+
+var road_util: RoadUtils
+
 
 func before_each():
-	gut.p("ran setup", 2)
-
-func after_each():
-	gut.p("ran teardown", 2)
-
-func before_all():
-	gut.p("ran run setup", 2)
-
-func after_all():
-	gut.p("ran run teardown", 2)
-
-# ------------------------------------------------------------------------------
-
-
-## Utility to create a single segment container (2 points)
-func create_unconnected_container(container) -> Array:
-	container.setup_road_container()
-	assert_eq(container.get_child_count(), 0, "No initial point children")
-
-	var p1 = autoqfree(RoadPoint.new())
-	var p2 = autoqfree(RoadPoint.new())
-
-	container.add_child(p1)
-	container.add_child(p2)
-	assert_eq(container.get_child_count(), 2, "Both RPs added")
-
-	return [p1, p2]
+	road_util = RoadUtils.new()
+	road_util.gut = gut
 
 
 # ------------------------------------------------------------------------------
@@ -107,7 +86,7 @@ func test_error_no_traffic_dir():
 func test_config_warning_invalid_lane_transition():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
-	var points = create_unconnected_container(container)
+	var points = road_util.create_unconnected_container(container)
 	var p1 = points[0]
 	var p2 = points[1]
 	p1.next_pt_init = p1.get_path_to(p2)
@@ -130,7 +109,7 @@ func test_config_warning_invalid_lane_transition():
 func test_config_warning_malformed_lane_order():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
-	var pt = create_unconnected_container(container)[0]
+	var pt = road_util.create_unconnected_container(container)[0]
 
 	pt.traffic_dir.assign([RoadPoint.LaneDir.FORWARD, RoadPoint.LaneDir.REVERSE, RoadPoint.LaneDir.FORWARD])
 	assert_gt(pt._get_configuration_warnings().size(), 0, "Warns on malformed lane order")
@@ -144,7 +123,7 @@ func test_autofix_noncyclic_added_next():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
 
-	var points = create_unconnected_container(container)
+	var points = road_util.create_unconnected_container(container)
 	var p1 = points[0]
 	var p2 = points[1]
 
@@ -172,7 +151,7 @@ func test_junction_validate_init_path_just_removed():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
 
-	var points = create_unconnected_container(container)
+	var points = road_util.create_unconnected_container(container)
 	var p1 = points[0]
 	var p2 = points[1]
 
@@ -204,7 +183,7 @@ func test_on_road_updated_pt_transform():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
 
-	var points = create_unconnected_container(container)
+	var points = road_util.create_unconnected_container(container)
 	var p1 = points[0]
 	var p2 = points[1]
 
@@ -235,7 +214,7 @@ func test_connect_roadpoint():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
 
-	var points = create_unconnected_container(container)
+	var points = road_util.create_unconnected_container(container)
 	var p1 = points[0]
 	var p2 = points[1]
 
@@ -252,7 +231,7 @@ func test_roadpoint_disconnection():
 	var container = add_child_autofree(RoadContainer.new())
 	container._auto_refresh = false
 
-	var points = create_unconnected_container(container)
+	var points = road_util.create_unconnected_container(container)
 	var p1 = points[0]
 	var p2 = points[1]
 

--- a/test/unit/test_segment_lanes.gd
+++ b/test/unit/test_segment_lanes.gd
@@ -50,11 +50,11 @@ func test_lanes_next_to_prior():
 	var container:RoadContainer = add_child_autofree(RoadContainer.new())
 	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
 	# No flipping, already in a next-to-prior config
-	
 	container.generate_ai_lanes = true
 	container.draw_lanes_editor = true
+	container.rebuild_segments(true)
 	ensure_roadlanes_exist(container)
-	road_util.save_testscene_to_file(container)# "test_lanes_next_to_prior")
+	#road_util.save_testscene_to_file(container)
 
 
 ## Checkes that two RoadPoints pointing away from each other produces good lanes
@@ -70,7 +70,7 @@ func test_lanes_prior_to_prior():
 	container.draw_lanes_editor = true
 	container.rebuild_segments(true)
 	ensure_roadlanes_exist(container)
-	road_util.save_testscene_to_file(container)# "test_lanes_prior_to_prior")
+	#road_util.save_testscene_to_file(container)
 	
 
 ## Checkes that two RoadPoints pointing towards each other produces good lanes
@@ -85,4 +85,4 @@ func test_lanes_next_to_next():
 	container.draw_lanes_editor = true
 	container.rebuild_segments(true)
 	ensure_roadlanes_exist(container)
-	road_util.save_testscene_to_file(container)
+	#road_util.save_testscene_to_file(container)

--- a/test/unit/test_segment_lanes.gd
+++ b/test/unit/test_segment_lanes.gd
@@ -1,0 +1,85 @@
+extends "res://addons/gut/test.gd"
+
+const RoadUtils = preload("res://test/unit/road_utils.gd")
+
+var road_util: RoadUtils
+
+
+func before_each():
+	road_util = RoadUtils.new()
+	road_util.gut = gut
+
+
+func ensure_roadlanes_exist(container:RoadContainer, segs: int = 3):
+	var lanes = []
+	for _ch in container.get_roadpoints():
+		var rp: RoadPoint = _ch as RoadPoint
+		for ln in rp.get_children():
+			if not ln is RoadLane:
+				continue
+			lanes.append(ln)
+	var expected: int = 4*segs
+	assert_eq(lanes.size(), expected, "Should create exactly %s lanes" % expected)
+
+
+## Function for flipping a RoadPoint 180 and reversing connections
+##
+## Unforutnately, we can't directly use the high level addon flip operator due
+## to current structure, when that is abstracted in the future, use that instead:
+## plugin.subaction_flip_roadpoint
+func simple_flip_roadpoint(rp: RoadPoint) -> void:
+	var flipped_transform = rp.transform
+	flipped_transform = flipped_transform.rotated_local(Vector3.UP, PI)
+	rp.set_internal_updating(true)
+	rp.prior_pt_init = rp.next_pt_init
+	rp.next_pt_init = rp.prior_pt_init
+	rp.shoulder_width_l = rp.shoulder_width_r
+	rp.shoulder_width_r = rp.shoulder_width_l
+	#rp.traffic_dir = _new_traffic_dirs # they are mirrored anyways
+	rp.prior_mag = rp.next_mag
+	rp.next_mag = rp.prior_mag
+	rp.transform = flipped_transform
+	rp.set_internal_updating(false)
+
+
+# ------------------------------------------------------------------------------
+
+
+## Checkes that two RoadPoints pointing in the same direction produces good lanes
+func test_lanes_next_to_prior():
+	var container:RoadContainer = add_child_autofree(RoadContainer.new())
+	container.generate_ai_lanes = true
+	container.draw_lanes_editor = true
+	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
+	# No flipping, already in a next-to-prior config
+	ensure_roadlanes_exist(container)
+	road_util.save_testscene_to_file(container)# "test_lanes_next_to_prior")
+
+
+## Checkes that two RoadPoints pointing away from each other produces good lanes
+func test_lanes_prior_to_prior():
+	var container:RoadContainer = add_child_autofree(RoadContainer.new())
+	container.generate_ai_lanes = true
+	container.draw_lanes_editor = true
+	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
+	# Flip first two roadpoints
+	for idx in [0, 1]:
+		var rp:RoadPoint = points[idx]
+		simple_flip_roadpoint(rp)
+	container.rebuild_segments(true)
+	ensure_roadlanes_exist(container)
+	road_util.save_testscene_to_file(container)# "test_lanes_prior_to_prior")
+	
+
+## Checkes that two RoadPoints pointing towards each other produces good lanes
+func test_lanes_next_to_next():
+	var container:RoadContainer = add_child_autofree(RoadContainer.new())
+	container.generate_ai_lanes = true
+	container.draw_lanes_editor = true
+	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
+	for idx in [2, 3]:
+		var rp:RoadPoint = points[idx]
+		simple_flip_roadpoint(rp)
+	container.rebuild_segments(true)
+	ensure_roadlanes_exist(container)
+	road_util.save_testscene_to_file(container)

--- a/test/unit/test_segment_lanes.gd
+++ b/test/unit/test_segment_lanes.gd
@@ -31,13 +31,13 @@ func simple_flip_roadpoint(rp: RoadPoint) -> void:
 	var flipped_transform = rp.transform
 	flipped_transform = flipped_transform.rotated_local(Vector3.UP, PI)
 	rp.set_internal_updating(true)
+	var tmpinit = rp.prior_pt_init
 	rp.prior_pt_init = rp.next_pt_init
-	rp.next_pt_init = rp.prior_pt_init
-	rp.shoulder_width_l = rp.shoulder_width_r
-	rp.shoulder_width_r = rp.shoulder_width_l
+	rp.next_pt_init = tmpinit
 	#rp.traffic_dir = _new_traffic_dirs # they are mirrored anyways
+	var tmpmag = rp.prior_mag
 	rp.prior_mag = rp.next_mag
-	rp.next_mag = rp.prior_mag
+	rp.next_mag = tmpmag
 	rp.transform = flipped_transform
 	rp.set_internal_updating(false)
 
@@ -48,10 +48,11 @@ func simple_flip_roadpoint(rp: RoadPoint) -> void:
 ## Checkes that two RoadPoints pointing in the same direction produces good lanes
 func test_lanes_next_to_prior():
 	var container:RoadContainer = add_child_autofree(RoadContainer.new())
-	container.generate_ai_lanes = true
-	container.draw_lanes_editor = true
 	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
 	# No flipping, already in a next-to-prior config
+	
+	container.generate_ai_lanes = true
+	container.draw_lanes_editor = true
 	ensure_roadlanes_exist(container)
 	road_util.save_testscene_to_file(container)# "test_lanes_next_to_prior")
 
@@ -59,13 +60,14 @@ func test_lanes_next_to_prior():
 ## Checkes that two RoadPoints pointing away from each other produces good lanes
 func test_lanes_prior_to_prior():
 	var container:RoadContainer = add_child_autofree(RoadContainer.new())
-	container.generate_ai_lanes = true
-	container.draw_lanes_editor = true
 	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
 	# Flip first two roadpoints
 	for idx in [0, 1]:
 		var rp:RoadPoint = points[idx]
 		simple_flip_roadpoint(rp)
+
+	container.generate_ai_lanes = true
+	container.draw_lanes_editor = true
 	container.rebuild_segments(true)
 	ensure_roadlanes_exist(container)
 	road_util.save_testscene_to_file(container)# "test_lanes_prior_to_prior")
@@ -74,12 +76,13 @@ func test_lanes_prior_to_prior():
 ## Checkes that two RoadPoints pointing towards each other produces good lanes
 func test_lanes_next_to_next():
 	var container:RoadContainer = add_child_autofree(RoadContainer.new())
-	container.generate_ai_lanes = true
-	container.draw_lanes_editor = true
 	var points: Array[RoadPoint] = road_util.create_rp_line(container, 4, true, true)
 	for idx in [2, 3]:
 		var rp:RoadPoint = points[idx]
 		simple_flip_roadpoint(rp)
+
+	container.generate_ai_lanes = true
+	container.draw_lanes_editor = true
 	container.rebuild_segments(true)
 	ensure_roadlanes_exist(container)
 	road_util.save_testscene_to_file(container)

--- a/test/unit/test_segment_lanes.gd.uid
+++ b/test/unit/test_segment_lanes.gd.uid
@@ -1,0 +1,1 @@
+uid://dalgpoq1ansf6


### PR DESCRIPTION
Before this change, anytime there were two RoadPoints connected where they were both each other's "prior" point, it results in one or the other having two RoadSegments children. However, while the segment are named uniquely based on runtime ID, RoadLanes have preset names to be stable in the interface. This however results in one segment's RoadLanes being overwritten by another, resulting in a gap of lanes for one segmetn.

This PR:
- Fixes this issue, by renaming one set of RoadLanes when there are prior-to-prior connections, and is the primary solve here.
 - This fixes #406 which itself is a reproduction of one of the bullet points in #171
- Creates a more robust unit test to cover this scenario
- Creates some nice reusable test utilities for inspecting procedurally generated scenes during testing, which helps a lot to ensure the generated code is actually what we want.


## Important note:

This only solves the issue of the lanes not appear. However, the normalizing aspects of #171 are still valid until the decorations branch is merged. This means a prior-prior connection ends up with the sam artifacts of a next-to-next, where the lanes get a bit twisted around:

<img width="313" height="149" alt="Screenshot 2026-09-05 at 1 58 26 PM" src="https://github.com/user-attachments/assets/e601551c-d66f-4933-a840-b188d5281fe8" />
